### PR TITLE
Add per type scores in seqeval metric

### DIFF
--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -145,8 +145,12 @@ class Seqeval(nlp.Metric):
             reference_urls=["https://github.com/chakki-works/seqeval"]
         )
 
-    def _compute(self, predictions, references, **metrics_kwargs):
-        suffix = metrics_kwargs.pop("suffix", False)
+    def _compute(self, predictions, references, suffix=False):
+        """
+         Args:
+           suffix: True if the types are not in IOBs format False otherwise.
+             default: False
+        """
         true_entities = set(get_entities(references, suffix))
         pred_entities = set(get_entities(predictions, suffix))
         d1 = defaultdict(set)

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -46,6 +46,7 @@ from a source against one or more references.
 Args:
     predictions: List of List of predicted labels (Estimated targets as returned by a tagger)
     references: List of List of reference labels (Ground truth (correct) target values)
+    suffix: True if the types are not in IOBs format False otherwise. default: False
 Returns:
     Overall:
         'accuracy': accuracy,
@@ -146,11 +147,6 @@ class Seqeval(nlp.Metric):
         )
 
     def _compute(self, predictions, references, suffix=False):
-        """
-         Args:
-           suffix: True if the types are not in IOBs format False otherwise.
-             default: False
-        """
         true_entities = set(get_entities(references, suffix))
         pred_entities = set(get_entities(predictions, suffix))
         d1 = defaultdict(set)

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """ seqeval metric. """
 
+from collections import defaultdict
+
 import nlp
 from seqeval.metrics import accuracy_score, precision_score, recall_score, f1_score
 
@@ -38,18 +40,109 @@ See the [README.md] file at https://github.com/chakki-works/seqeval for more inf
 """
 
 _KWARGS_DESCRIPTION = """
-Produces BLEU scores along with its sufficient statistics
+Produces labelling scores along with its sufficient statistics
 from a source against one or more references.
 
 Args:
     predictions: List of List of predicted labels (Estimated targets as returned by a tagger)
     references: List of List of reference labels (Ground truth (correct) target values)
 Returns:
-    'accuracy': accuracy,
-    'precision': precision,
-    'recall': recall,
-    'f1': F1 score, also known as balanced F-score or F-measure,
+    Overall:
+        'accuracy': accuracy,
+        'precision': precision,
+        'recall': recall,
+        'f1': F1 score, also known as balanced F-score or F-measure,
+    Per type:
+        'precision': precision,
+        'recall': recall,
+        'f1': F1 score, also known as balanced F-score or F-measure,
 """
+
+def end_of_chunk(prev_tag, tag, prev_type, type_):
+    """Checks if a chunk ended between the previous and current word.
+    Args:
+        prev_tag: previous chunk tag.
+        tag: current chunk tag.
+        prev_type: previous type.
+        type_: current type.
+    Returns:
+        chunk_end: boolean.
+    """
+    chunk_end = False
+
+    if prev_tag == 'E': chunk_end = True
+    if prev_tag == 'S': chunk_end = True
+
+    if prev_tag == 'B' and tag == 'B': chunk_end = True
+    if prev_tag == 'B' and tag == 'S': chunk_end = True
+    if prev_tag == 'B' and tag == 'O': chunk_end = True
+    if prev_tag == 'I' and tag == 'B': chunk_end = True
+    if prev_tag == 'I' and tag == 'S': chunk_end = True
+    if prev_tag == 'I' and tag == 'O': chunk_end = True
+
+    if prev_tag != 'O' and prev_tag != '.' and prev_type != type_:
+        chunk_end = True
+
+    return chunk_end
+
+
+def start_of_chunk(prev_tag, tag, prev_type, type_):
+    """Checks if a chunk started between the previous and current word.
+    Args:
+        prev_tag: previous chunk tag.
+        tag: current chunk tag.
+        prev_type: previous type.
+        type_: current type.
+    Returns:
+        chunk_start: boolean.
+    """
+    chunk_start = False
+
+    if tag == 'B': chunk_start = True
+    if tag == 'S': chunk_start = True
+
+    if prev_tag == 'E' and tag == 'E': chunk_start = True
+    if prev_tag == 'E' and tag == 'I': chunk_start = True
+    if prev_tag == 'S' and tag == 'E': chunk_start = True
+    if prev_tag == 'S' and tag == 'I': chunk_start = True
+    if prev_tag == 'O' and tag == 'E': chunk_start = True
+    if prev_tag == 'O' and tag == 'I': chunk_start = True
+
+    if tag != 'O' and tag != '.' and prev_type != type_:
+        chunk_start = True
+
+    return chunk_start
+
+def get_entities(seq, suffix=False):
+    """Gets entities from sequence.
+    Args:
+        seq (list): sequence of labels.
+    Returns:
+        list: list of (chunk_type, chunk_start, chunk_end).
+    """
+    if any(isinstance(s, list) for s in seq):
+        seq = [item for sublist in seq for item in sublist + ['O']]
+
+    prev_tag = 'O'
+    prev_type = ''
+    begin_offset = 0
+    chunks = []
+    for i, chunk in enumerate(seq + ['O']):
+        if suffix:
+            tag = chunk[-1]
+            type_ = chunk.split('-')[0]
+        else:
+            tag = chunk[0]
+            type_ = chunk.split('-')[-1]
+
+        if end_of_chunk(prev_tag, tag, prev_type, type_):
+            chunks.append((prev_type, begin_offset, i-1))
+        if start_of_chunk(prev_tag, tag, prev_type, type_):
+            begin_offset = i
+        prev_tag = tag
+        prev_type = type_
+
+    return chunks
 
 class Seqeval(nlp.Metric):
     def _info(self):
@@ -66,12 +159,39 @@ class Seqeval(nlp.Metric):
             reference_urls=["https://github.com/chakki-works/seqeval"]
         )
 
-    def _compute(self, predictions, references):
-        scores = {
-            'accuracy': accuracy_score(y_true=references, y_pred=predictions),
-            'precision': precision_score(y_true=references, y_pred=predictions),
-            'recall': recall_score(y_true=references, y_pred=predictions),
-            'f1': f1_score(y_true=references, y_pred=predictions),
-        }
+    def _compute(self, predictions, references, **metrics_kwargs):
+        suffix = metrics_kwargs.pop("suffix", False)
+        true_entities = set(get_entities(references, suffix))
+        pred_entities = set(get_entities(predictions, suffix))
+        d1 = defaultdict(set)
+        d2 = defaultdict(set)
+        scores = {}
+
+        for e in true_entities:
+            d1[e[0]].add((e[1], e[2]))
+
+        for e in pred_entities:
+            d2[e[0]].add((e[1], e[2]))
+        
+        for type_name, true_entities in d1.items():
+            scores[type_name] = {}
+            pred_entities = d2[type_name]
+            nb_correct = len(true_entities & pred_entities)
+            nb_pred = len(pred_entities)
+            nb_true = len(true_entities)
+
+            p = nb_correct / nb_pred if nb_pred > 0 else 0
+            r = nb_correct / nb_true if nb_true > 0 else 0
+            f1 = 2 * p * r / (p + r) if p + r > 0 else 0
+
+            scores[type_name]["precision"] = p
+            scores[type_name]["recall"] = r
+            scores[type_name]["f1"] = f1
+            scores[type_name]["number"] = nb_true
+
+        scores["overall_precision"] = precision_score(y_true=references, y_pred=predictions, suffix=suffix)
+        scores["overall_recall"] = recall_score(y_true=references, y_pred=predictions, suffix=suffix)
+        scores["overall_f1"] = f1_score(y_true=references, y_pred=predictions, suffix=suffix)
+        scores["overall_accuracy"] = accuracy_score(y_true=references, y_pred=predictions)
 
         return scores

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -70,17 +70,10 @@ def end_of_chunk(prev_tag, tag, prev_type, type_):
     """
     chunk_end = False
 
-    if prev_tag == 'E': chunk_end = True
-    if prev_tag == 'S': chunk_end = True
+    if (prev_tag in ["B", "I"] and tag in ["B", "S", "O"]) or prev_tag in ["E", "S"]:
+        chunk_end = True
 
-    if prev_tag == 'B' and tag == 'B': chunk_end = True
-    if prev_tag == 'B' and tag == 'S': chunk_end = True
-    if prev_tag == 'B' and tag == 'O': chunk_end = True
-    if prev_tag == 'I' and tag == 'B': chunk_end = True
-    if prev_tag == 'I' and tag == 'S': chunk_end = True
-    if prev_tag == 'I' and tag == 'O': chunk_end = True
-
-    if prev_tag != 'O' and prev_tag != '.' and prev_type != type_:
+    if prev_tag not in ['O', '.'] and prev_type != type_:
         chunk_end = True
 
     return chunk_end
@@ -98,17 +91,10 @@ def start_of_chunk(prev_tag, tag, prev_type, type_):
     """
     chunk_start = False
 
-    if tag == 'B': chunk_start = True
-    if tag == 'S': chunk_start = True
+    if (prev_tag in ["E", "S", "O"] and tag in ["E", "I"]) or tag in ["B", "S"]:
+        chunk_start = True
 
-    if prev_tag == 'E' and tag == 'E': chunk_start = True
-    if prev_tag == 'E' and tag == 'I': chunk_start = True
-    if prev_tag == 'S' and tag == 'E': chunk_start = True
-    if prev_tag == 'S' and tag == 'I': chunk_start = True
-    if prev_tag == 'O' and tag == 'E': chunk_start = True
-    if prev_tag == 'O' and tag == 'I': chunk_start = True
-
-    if tag != 'O' and tag != '.' and prev_type != type_:
+    if tag not in ['O', '.'] and prev_type != type_:
         chunk_start = True
 
     return chunk_start


### PR DESCRIPTION
This PR add a bit more detail in the seqeval metric. Now the usage and output are:

```python
import nlp
met = nlp.load_metric('metrics/seqeval')
references = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
predictions =  [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
met.compute(predictions, references)

#Output: {'PER': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'MISC': {'precision': 0.0, 'recall': 0.0, 'f1': 0, 'number': 1}, 'overall_precision': 0.5, 'overall_recall': 0.5, 'overall_f1': 0.5, 'overall_accuracy': 0.8}
```

It is also possible to compute scores for non IOB notations, POS tagging for example hasn't this kind of notation. Add `suffix` parameter:

```python
import nlp
met = nlp.load_metric('metrics/seqeval')
references = [['O', 'O', 'O', 'MISC', 'MISC', 'MISC', 'O'], ['PER', 'PER', 'O']]
predictions =  [['O', 'O', 'MISC', 'MISC', 'MISC', 'MISC', 'O'], ['PER', 'PER', 'O']]
met.compute(predictions, references, metrics_kwargs={"suffix": True})

#Output: {'PER': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'MISC': {'precision': 0.0, 'recall': 0.0, 'f1': 0, 'number': 1}, 'overall_precision': 0.5, 'overall_recall': 0.5, 'overall_f1': 0.5, 'overall_accuracy': 0.9}
```