### PR TITLE
add writer_batch_size to GeneratorBasedBuilder

### DIFF
--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -40,7 +40,7 @@ class ArrowWriter(object):
         schema: Optional[pa.Schema] = None,
         path: Optional[str] = None,
         stream: Optional[pa.NativeFile] = None,
-        writer_batch_size: int = DEFAULT_MAX_BATCH_SIZE,
+        writer_batch_size: Optional[int] = None,
         disable_nullable: bool = True,
     ):
         if path is None and stream is None:
@@ -66,7 +66,7 @@ class ArrowWriter(object):
         else:
             self.stream = stream
 
-        self.writer_batch_size = writer_batch_size
+        self.writer_batch_size = writer_batch_size or DEFAULT_MAX_BATCH_SIZE
 
         self._num_examples = 0
         self._num_bytes = 0

--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -556,6 +556,10 @@ class GeneratorBasedBuilder(DatasetBuilder):
     (`_split_generators`). See the method docstrings for details.
     """
 
+    def __init__(self, *args, **kwargs):
+        super(GeneratorBasedBuilder, self).__init__(*args, **kwargs)
+        self._writer_batch_size = kwargs.get("writer_batch_size")
+
     @abc.abstractmethod
     def _generate_examples(self, **kwargs):
         """Default function generating examples for each `SplitGenerator`.
@@ -592,7 +596,7 @@ class GeneratorBasedBuilder(DatasetBuilder):
         fname = "{}-{}.arrow".format(self.name, split_generator.name)
         fpath = os.path.join(self._cache_dir, fname)
         examples_type = self.info.features.type
-        writer = ArrowWriter(data_type=examples_type, path=fpath)
+        writer = ArrowWriter(data_type=examples_type, path=fpath, writer_batch_size=self._writer_batch_size)
 
         generator = self._generate_examples(**split_generator.gen_kwargs)
         for key, record in utils.tqdm(generator, unit=" examples", total=split_info.num_examples, leave=False):


### PR DESCRIPTION
You can now specify `writer_batch_size` in the builder arguments or directly in `load_dataset`