### PR TITLE
[Tests] Local => aws

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -123,7 +123,7 @@ def get_dataset_names():
     else:
         # fetch all dataset names
         api = hf_api.HfApi()
-        datasets = [x.datasetId for x in api.dataset_list()]
+        datasets = [x.id for x in api.dataset_list()]
 
     dataset_names_parametrized = [{"testcase_name": x, "dataset_name": x} for x in datasets]
     return dataset_names_parametrized

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,8 +23,8 @@ def parse_flag_from_env(key, default=False):
 
 
 _run_slow_tests = parse_flag_from_env("RUN_SLOW", default=False)
-_run_local_tests = parse_flag_from_env("RUN_LOCAL", default=True)
-_run_aws_tests = parse_flag_from_env("RUN_AWS", default=False)
+_run_local_tests = parse_flag_from_env("RUN_LOCAL", default=False)
+_run_aws_tests = parse_flag_from_env("RUN_AWS", default=True)
 
 
 def slow(test_case):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,7 @@ def local(test_case):
     Decorator marking a test as local
 
     Local tests are run by default. Set the RUN_LOCAL environment variable
-    to a falsy value to not run them.
+    to a truthy value to run them.
     """
     if not _run_local_tests:
         test_case = unittest.skip("test is local")(test_case)
@@ -61,7 +61,7 @@ def aws(test_case):
     Decorator marking a test as one that relies on AWS.
 
     AWS tests are skipped by default. Set the RUN_AWS environment variable
-    to a truthy value to run them.
+    to a falsy value to not run them.
     """
     if not _run_aws_tests:
         test_case = unittest.skip("test requires aws")(test_case)


### PR DESCRIPTION
## Change default Test from local => aws

As a default we set` aws=True`, `Local=False`, `slow=False`

### 1. RUN_AWS=1 (default)
This runs 4 tests per dataset script.

a) Does the dataset script have a valid etag / Can it be reached on AWS? 
b) Can we load its `builder_class`?
c) Can we load **all** dataset configs?
d) _Most importantly_: Can we load the dataset? 

Important - we currently only test the first config of each dataset to reduce test time. Total test time is around 1min20s.

### 2. RUN_LOCAL=1 RUN_AWS=0

***This should be done when debugging dataset scripts of the ./datasets folder***

This only runs 1 test per dataset test, which is equivalent to aws d) - Can we load the dataset from the local `datasets` directory?

### 3. RUN_SLOW=1

We should set up to run these tests maybe 1 time per week ? @thomwolf 

The `slow` tests include two more important tests. 

e) Can we load the dataset with all possible configs? This test will probably fail at the moment because a lot of dummy data is missing. We should add the dummy data step by step to be sure that all configs work.

f) Test that the actual dataset can be loaded. This will take quite some time to run, but is important to make sure that the "real" data can be loaded. It will also test whether the dataset script has the correct checksums file which is currently not tested with `aws=True`. @lhoestq - is there an easy way to check cheaply whether the `dataset_info.json` is correct for each dataset script? 