### PR TITLE
[AWS tests] AWS test should not run for canonical datasets

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -140,6 +140,10 @@ class DatasetTest(parameterized.TestCase):
 
     @aws
     def test_dataset_has_valid_etag(self, dataset_name):
+        if "/" not in dataset_name:
+            logging.info("Skip {} because it is a canonical dataset")
+            return
+
         py_script_path = list(filter(lambda x: x, dataset_name.split("/")))[-1] + ".py"
         dataset_url = hf_bucket_url(dataset_name, filename=py_script_path, dataset=True)
         etag = None
@@ -155,6 +159,10 @@ class DatasetTest(parameterized.TestCase):
 
     @aws
     def test_builder_class(self, dataset_name):
+        if "/" not in dataset_name:
+            logging.info("Skip {} because it is a canonical dataset")
+            return
+
         builder_cls = self.dataset_tester.load_builder_class(dataset_name)
         builder = builder_cls()
         self.assertTrue(isinstance(builder, DatasetBuilder))

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -170,11 +170,16 @@ class DatasetTest(parameterized.TestCase):
     @aws
     def test_load_dataset(self, dataset_name):
         # test only first config
+        if "/" not in dataset_name:
+            logging.info("Skip {} because it is a canonical dataset")
+            return
+
         configs = self.dataset_tester.load_all_configs(dataset_name)[:1]
         self.dataset_tester.check_load_dataset(dataset_name, configs)
 
     @local
     def test_load_dataset_local(self, dataset_name):
+        # test only first config
         if "/" in dataset_name:
             logging.info("Skip {} because it is not a canonical dataset")
             return
@@ -185,6 +190,10 @@ class DatasetTest(parameterized.TestCase):
     @slow
     @aws
     def test_load_dataset_all_configs(self, dataset_name):
+        if "/" not in dataset_name:
+            logging.info("Skip {} because it is a canonical dataset")
+            return
+
         configs = self.dataset_tester.load_all_configs(dataset_name)
         self.dataset_tester.check_load_dataset(dataset_name, configs)
 
@@ -201,6 +210,10 @@ class DatasetTest(parameterized.TestCase):
     @slow
     @aws
     def test_load_real_dataset(self, dataset_name):
+        if "/" not in dataset_name:
+            logging.info("Skip {} because it is a canonical dataset")
+            return
+
         with tempfile.TemporaryDirectory() as temp_data_dir:
             download_config = DownloadConfig()
             download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD
@@ -215,6 +228,10 @@ class DatasetTest(parameterized.TestCase):
     @slow
     @local
     def test_load_real_dataset_local(self, dataset_name):
+        if "/" in dataset_name:
+            logging.info("Skip {} because it is not a canonical dataset")
+            return
+
         with tempfile.TemporaryDirectory() as temp_data_dir:
             download_config = DownloadConfig()
             download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD


### PR DESCRIPTION
AWS tests should in general not run for canonical datasets. Only local tests will run in this case. This way a PR is able to pass when adding a new dataset.

This PR changes to logic to the following: 

1) All datasets that are present in `nlp/datasets` are tested only locally. This way when one adds a canonical dataset, the PR includes his dataset in the tests.

2) All datasets that are only present on AWS, such as `webis/tl_dr` atm are tested only on AWS. 

I think the testing structure might need a bigger refactoring and better documentation very soon. 

Merging for now to unblock new PRs @thomwolf @mariamabarham .