### PR TITLE
fix prev files hash in map

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -369,7 +369,7 @@ class Dataset(object):
         if not self._data_files or "filename" not in self._data_files[0]:
             return None
         previous_files_string = "-".join(
-            "-".join(str(k) + "-" + str(v) for k, v in cache_kwargs.items()) for f in self._data_files
+            "-".join(str(k) + "-" + str(v) for k, v in f.items()) for f in self._data_files
         )
         cache_kwargs_string = "-".join(str(k) + "-" + str(v) for k, v in cache_kwargs.items())
         function_bytes = dumps(function)


### PR DESCRIPTION
Fix the `.map` issue in #160.
This makes sure it takes the previous files when computing the hash.