### PR TITLE
[Tests] refactor tests

### DIFF
--- a/datasets/json/json.py
+++ b/datasets/json/json.py
@@ -11,6 +11,7 @@ import nlp
 @dataclass
 class JsonConfig(nlp.BuilderConfig):
     """BuilderConfig for JSON."""
+
     read_options: paj.ReadOptions = paj.ReadOptions()
     parse_options: paj.ParseOptions = paj.ParseOptions()
 
@@ -36,26 +37,19 @@ class Json(nlp.ArrowBasedBuilder):
             files = self.config.data_files
             if isinstance(files, str):
                 files = [files]
-            return [nlp.SplitGenerator(
-                        name=nlp.Split.TRAIN,
-                        gen_kwargs={"files": files})]
+            return [nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"files": files})]
         splits = []
         for split_name in [nlp.Split.TRAIN, nlp.Split.VALIDATION, nlp.Split.TEST]:
             if split_name in self.config.data_files:
                 files = self.config.data_files[split_name]
                 if isinstance(files, str):
                     files = [files]
-                splits.append(
-                    nlp.SplitGenerator(
-                            name=split_name,
-                            gen_kwargs={"files": files}))
+                splits.append(nlp.SplitGenerator(name=split_name, gen_kwargs={"files": files}))
         return splits
 
     def _generate_tables(self, files):
         for i, file in enumerate(files):
             pa_table = paj.read_json(
-                file,
-                read_options=self.config.pa_read_options,
-                parse_options=self.config.pa_parse_options,
+                file, read_options=self.config.pa_read_options, parse_options=self.config.pa_parse_options,
             )
             yield i, pa_table

--- a/datasets/ubuntu_dialogs_corpus/ubuntu_dialogs_corpus.py
+++ b/datasets/ubuntu_dialogs_corpus/ubuntu_dialogs_corpus.py
@@ -1,12 +1,12 @@
 """TODO(ubuntu_dialogs_corpus): Add a description here."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import nlp
 import csv
 import os
+
+import nlp
+
 
 # TODO(ubuntu_dialogs_corpus): BibTeX citation
 _CITATION = """\
@@ -34,111 +34,96 @@ _DESCRIPTION = """\
 Ubuntu Dialogue Corpus, a dataset containing almost 1 million multi-turn dialogues, with a total of over 7 million utterances and 100 million words. This provides a unique resource for research into building dialogue managers based on neural language models that can make use of large amounts of unlabeled data. The dataset has both the multi-turn property of conversations in the Dialog State Tracking Challenge datasets, and the unstructured nature of interactions from microblog services such as Twitter.
 """
 
-class UbuntuDialogsCorpusConfig(nlp.BuilderConfig):
-  """BuilderConfig for UbuntuDialogsCorpus."""
 
-  def __init__(self, features,  **kwargs):
-    """BuilderConfig for UbuntuDialogsCorpus.
+class UbuntuDialogsCorpusConfig(nlp.BuilderConfig):
+    """BuilderConfig for UbuntuDialogsCorpus."""
+
+    def __init__(self, features, **kwargs):
+        """BuilderConfig for UbuntuDialogsCorpus.
 
     Args:
 
       **kwargs: keyword arguments forwarded to super.
     """
 
-    super(UbuntuDialogsCorpusConfig, self).__init__(
-        version=nlp.Version("2.0.0"), **kwargs)
-    self.features = features
+        super(UbuntuDialogsCorpusConfig, self).__init__(version=nlp.Version("2.0.0"), **kwargs)
+        self.features = features
 
 
 class UbuntuDialogsCorpus(nlp.GeneratorBasedBuilder):
-  """TODO(ubuntu_dialogs_corpus): Short description of my dataset."""
+    """TODO(ubuntu_dialogs_corpus): Short description of my dataset."""
 
-  # TODO(ubuntu_dialogs_corpus): Set up version.
-  VERSION = nlp.Version('2.0.0')
-  BUILDER_CONFIGS = [
-      UbuntuDialogsCorpusConfig(
-          name='train',
-          features= ['Context','Utterance', 'Label'],
-          description='training features'
-      ),
-      UbuntuDialogsCorpusConfig(
-          name='dev_test',
-          features=['Context', 'Ground Truth Utterance']+['Distractor_'+str(i) for i in range(9)],
-          description='test and dev features'
-      )
-  ]
-  MANUAL_DOWNLOAD_INSTRUCTIONS = """\
+    # TODO(ubuntu_dialogs_corpus): Set up version.
+    VERSION = nlp.Version("2.0.0")
+    BUILDER_CONFIGS = [
+        UbuntuDialogsCorpusConfig(
+            name="train", features=["Context", "Utterance", "Label"], description="training features"
+        ),
+        UbuntuDialogsCorpusConfig(
+            name="dev_test",
+            features=["Context", "Ground Truth Utterance"] + ["Distractor_" + str(i) for i in range(9)],
+            description="test and dev features",
+        ),
+    ]
+    MANUAL_DOWNLOAD_INSTRUCTIONS = """\
   Please download the Ubuntu Dialog Corpus from https://github.com/rkadlec/ubuntu-ranking-dataset-creator. Run ./generate.sh -t -s -l to download the
    data. Others arguments are left to their default values here. Please save train.csv, test.csv and valid.csv in the same path"""
 
-  def _info(self):
-    # TODO(ubuntu_dialogs_corpus): Specifies the nlp.DatasetInfo object
-    features = {
-        feature: nlp.Value('string') for feature in self.config.features
-    }
-    if self.config.name == 'train':
-        features['Label'] = nlp.Value('int32')
-    return nlp.DatasetInfo(
-        # This is the description that will appear on the datasets page.
-        description=_DESCRIPTION,
-        # nlp.features.FeatureConnectors
-        features=nlp.Features(
-            # These are the features of your dataset like images, labels ...
-            features
-        ),
-        # If there's a common (input, target) tuple from the features,
-        # specify them here. They'll be used if as_supervised=True in
-        # builder.as_dataset.
-        supervised_keys=None,
-        # Homepage of the dataset for documentation
-        homepage='https://github.com/rkadlec/ubuntu-ranking-dataset-creator',
-        citation=_CITATION,
-    )
-
-  def _split_generators(self, dl_manager):
-    """Returns SplitGenerators."""
-    # TODO(ubuntu_dialogs_corpus): Downloads the data and defines the splits
-    # dl_manager is a nlp.download.DownloadManager that can be used to
-    # download and extract URLs
-    manual_dir = os.path.abspath(os.path.expanduser(dl_manager.manual_dir))
-        
-    if self.config.name == 'train':
-        return [
-            nlp.SplitGenerator(
-                name=nlp.Split.TRAIN,
-                # These kwargs will be passed to _generate_examples
-                gen_kwargs={
-
-                    'filepath': os.path.join(manual_dir, 'train.csv')
-
-                },
+    def _info(self):
+        # TODO(ubuntu_dialogs_corpus): Specifies the nlp.DatasetInfo object
+        features = {feature: nlp.Value("string") for feature in self.config.features}
+        if self.config.name == "train":
+            features["Label"] = nlp.Value("int32")
+        return nlp.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            # nlp.features.FeatureConnectors
+            features=nlp.Features(
+                # These are the features of your dataset like images, labels ...
+                features
             ),
-        ]
-    else:
-        return [
-            nlp.SplitGenerator(
-                name=nlp.Split.TEST,
-                # These kwargs will be passed to _generate_examples
-                gen_kwargs={
-                        'filepath': os.path.join(manual_dir, 'test.csv')
+            # If there's a common (input, target) tuple from the features,
+            # specify them here. They'll be used if as_supervised=True in
+            # builder.as_dataset.
+            supervised_keys=None,
+            # Homepage of the dataset for documentation
+            homepage="https://github.com/rkadlec/ubuntu-ranking-dataset-creator",
+            citation=_CITATION,
+        )
 
-       },
-            ),
-            nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION,
-                # These kwargs will be passed to _generate_examples
-                gen_kwargs={
-                    'filepath': os.path.join(manual_dir, 'valid.csv')
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        # TODO(ubuntu_dialogs_corpus): Downloads the data and defines the splits
+        # dl_manager is a nlp.download.DownloadManager that can be used to
+        # download and extract URLs
+        manual_dir = os.path.abspath(os.path.expanduser(dl_manager.manual_dir))
 
-                },
-            ),
-        ]
+        if self.config.name == "train":
+            return [
+                nlp.SplitGenerator(
+                    name=nlp.Split.TRAIN,
+                    # These kwargs will be passed to _generate_examples
+                    gen_kwargs={"filepath": os.path.join(manual_dir, "train.csv")},
+                ),
+            ]
+        else:
+            return [
+                nlp.SplitGenerator(
+                    name=nlp.Split.TEST,
+                    # These kwargs will be passed to _generate_examples
+                    gen_kwargs={"filepath": os.path.join(manual_dir, "test.csv")},
+                ),
+                nlp.SplitGenerator(
+                    name=nlp.Split.VALIDATION,
+                    # These kwargs will be passed to _generate_examples
+                    gen_kwargs={"filepath": os.path.join(manual_dir, "valid.csv")},
+                ),
+            ]
 
-  def _generate_examples(self, filepath):
-    """Yields examples."""
-    # TODO(ubuntu_dialogs_corpus): Yields (key, example) tuples from the dataset
-    with open(filepath) as f:
-        data = csv.DictReader(f)
-        for id_, row in enumerate(data):
-            yield id_, row
-
+    def _generate_examples(self, filepath):
+        """Yields examples."""
+        # TODO(ubuntu_dialogs_corpus): Yields (key, example) tuples from the dataset
+        with open(filepath) as f:
+            data = csv.DictReader(f)
+            for id_, row in enumerate(data):
+                yield id_, row

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -143,7 +143,8 @@ class LocalDatasetTest(parameterized.TestCase):
         self.dataset_tester.check_load_dataset(dataset_name, configs, is_local=True)
 
     def test_builder_class(self, dataset_name):
-        builder = self.dataset_tester.load_builder_class(dataset_name, is_local=True)
+        builder_cls = self.dataset_tester.load_builder_class(dataset_name, is_local=True)
+        builder = builder_cls()
         self.assertTrue(isinstance(builder, DatasetBuilder))
 
     def test_builder_configs(self, dataset_name):
@@ -204,7 +205,8 @@ class AWSDatasetTest(parameterized.TestCase):
         self.assertIsNotNone(etag)
 
     def test_builder_class(self, dataset_name):
-        builder = self.dataset_tester.load_builder_class(dataset_name)
+        builder_cls = self.dataset_tester.load_builder_class(dataset_name)
+        builder = builder_cls()
         self.assertTrue(isinstance(builder, DatasetBuilder))
 
     def test_builder_configs(self, dataset_name):

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -142,6 +142,17 @@ class LocalDatasetTest(parameterized.TestCase):
         configs = self.dataset_tester.load_all_configs(dataset_name, is_local=True)[:1]
         self.dataset_tester.check_load_dataset(dataset_name, configs, is_local=True)
 
+    def test_builder_class(self, dataset_name):
+        builder = self.dataset_tester.load_builder_class(dataset_name, is_local=True)
+        self.assertTrue(isinstance(builder, DatasetBuilder))
+
+    def test_builder_configs(self, dataset_name):
+        builder_configs = self.dataset_tester.load_all_configs(dataset_name, is_local=True)
+        self.assertTrue(len(builder_configs) > 0)
+
+        if builder_configs[0] is not None:
+            all(self.assertTrue(isinstance(config, BuilderConfig)) for config in builder_configs)
+
     @slow
     def test_load_dataset_all_configs(self, dataset_name):
         configs = self.dataset_tester.load_all_configs(dataset_name, is_local=True)
@@ -193,7 +204,7 @@ class AWSDatasetTest(parameterized.TestCase):
         self.assertIsNotNone(etag)
 
     def test_builder_class(self, dataset_name):
-        builder = self.dataset_tester.load_builder_cls(dataset_name)
+        builder = self.dataset_tester.load_builder_class(dataset_name)
         self.assertTrue(isinstance(builder, DatasetBuilder))
 
     def test_builder_configs(self, dataset_name):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,9 +22,9 @@ def parse_flag_from_env(key, default=False):
     return _value
 
 
-_run_slow_tests = parse_flag_from_env("RUN_SLOW", default=False)
+_run_slow_tests = parse_flag_from_env("RUN_SLOW", default=True)
 _run_local_tests = parse_flag_from_env("RUN_LOCAL", default=True)
-_run_aws_tests = parse_flag_from_env("RUN_AWS", default=True)
+_run_aws_tests = parse_flag_from_env("RUN_AWS", default=False)
 
 
 def slow(test_case):
@@ -35,7 +35,7 @@ def slow(test_case):
     to a truthy value to run them.
 
     """
-    if not _run_slow_tests:
+    if not _run_slow_tests or _run_slow_tests == 0:
         test_case = unittest.skip("test is slow")(test_case)
     return test_case
 
@@ -47,7 +47,7 @@ def local(test_case):
     Local tests are run by default. Set the RUN_LOCAL environment variable
     to a falsy value to not run them.
     """
-    if not _run_local_tests:
+    if not _run_local_tests or _run_local_tests == 0:
         test_case = unittest.skip("test is local")(test_case)
     return test_case
 
@@ -67,7 +67,7 @@ def aws(test_case):
     AWS tests are skipped by default. Set the RUN_AWS environment variable
     to a falsy value to not run them.
     """
-    if not _run_aws_tests:
+    if not _run_aws_tests or _run_aws_tests == 0:
         test_case = unittest.skip("test requires aws")(test_case)
     return test_case
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,9 +22,9 @@ def parse_flag_from_env(key, default=False):
     return _value
 
 
-_run_slow_tests = parse_flag_from_env("RUN_SLOW", default=True)
+_run_slow_tests = parse_flag_from_env("RUN_SLOW", default=False)
+_run_aws_tests = parse_flag_from_env("RUN_AWS", default=True)
 _run_local_tests = parse_flag_from_env("RUN_LOCAL", default=True)
-_run_aws_tests = parse_flag_from_env("RUN_AWS", default=False)
 
 
 def slow(test_case):
@@ -50,14 +50,6 @@ def local(test_case):
     if not _run_local_tests or _run_local_tests == 0:
         test_case = unittest.skip("test is local")(test_case)
     return test_case
-
-
-def is_local_mode():
-    return _run_local_tests
-
-
-def is_aws_mode():
-    return _run_aws_tests
 
 
 def aws(test_case):


### PR DESCRIPTION
This PR separates AWS and Local tests to remove these ugly statements in the script:
```python
        if "/" not in dataset_name:
            logging.info("Skip {} because it is a canonical dataset")
            return
```

To run a `aws` test, one should now run the following command: 

```python 
pytest -s tests/test_dataset_common.py::AWSDatasetTest::test_builder_class_wmt14
```

The same `local` test, can be run with:
```python 
pytest -s tests/test_dataset_common.py::LocalDatasetTest::test_builder_class_wmt14
```