### PR TITLE
[Manual data] improve error message for manual data in general

### DIFF
--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -136,7 +136,7 @@ class DatasetBuilder:
 
     @property
     def does_require_manual_download(self):
-        return hasattr(self, "MANUAL_DOWNLOAD_INSTRUCTIONS")
+        return hasattr(self, "MANUAL_DOWNLOAD_INSTRUCTIONS") and (self.MANUAL_DOWNLOAD_INSTRUCTIONS is not None)
 
     @classmethod
     def get_all_exported_dataset_infos(cls) -> dict:
@@ -339,6 +339,13 @@ class DatasetBuilder:
 
             dl_manager = DownloadManager(
                 dataset_name=self.name, download_config=download_config, data_dir=self.config.data_dir
+            )
+
+        if self.does_require_manual_download:
+            assert (
+                dl_manager.manual_dir is not None
+            ), "The dataset {} with config {} requires manual data. \n Please follow the manual download instructions: {}. \n Manual data can be loaded with `nlp.load({}, data_dir='<path/to/manual/data>')".format(
+                self.name, self.config.name, self.MANUAL_DOWNLOAD_INSTRUCTIONS, self.name
             )
 
         @contextlib.contextmanager


### PR DESCRIPTION
`nlp.load("xsum")` now leads to the following error message:

![Screenshot from 2020-05-20 20-05-28](https://user-images.githubusercontent.com/23423619/82481825-3587ea00-9ad6-11ea-9ca2-5794252c6ac7.png)

I guess the manual download instructions for `xsum` can also be improved.