### PR TITLE
Check invalid config name

### DIFF
--- a/datasets/xsum/xsum.py
+++ b/datasets/xsum/xsum.py
@@ -107,7 +107,7 @@ class Xsum(nlp.GeneratorBasedBuilder):
                 "{} does not exist. Make sure you indicate the data_dir as  `nlp.load('xsum', data_dir=...), which points to your downloded dataset'. Manual download instructions: {})".format(
                     downloaded_path, self.MANUAL_DOWNLOAD_INSTRUCTIONS
                 )
-            ) 
+            )
         return [
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN, gen_kwargs={"split_ids": split_ids["train"], "path": downloaded_path,},

--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -70,9 +70,11 @@ class BuilderConfig:
         for invalid_char in invalid_windows_characters:
             if invalid_char in self.name:
                 raise InvalidConfigName(
-                    "Bad characters for directories on Windows '{}' found in '{}'".format(
-                        invalid_windows_characters, self.name
-                    )
+                    (
+                        "Bad characters from black list '{}' found in '{}'. "
+                        "They could create issues when creating a directory "
+                        "for this config on Windows filesystem."
+                    ).format(invalid_windows_characters, self.name)
                 )
 
 

--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -66,7 +66,7 @@ class BuilderConfig:
 
     def __post_init__(self):
         # The config name is used to name the cache directory.
-        invalid_windows_characters = "<>:/\|?*"
+        invalid_windows_characters = r"<>:/\|?*"
         for invalid_char in invalid_windows_characters:
             if invalid_char in self.name:
                 raise InvalidConfigName(

--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -46,6 +46,10 @@ REUSE_CACHE_IF_EXISTS = GenerateMode.REUSE_CACHE_IF_EXISTS
 REUSE_DATASET_IF_EXISTS = GenerateMode.REUSE_DATASET_IF_EXISTS
 
 
+class InvalidConfigName(ValueError):
+    pass
+
+
 @dataclass
 class BuilderConfig:
     """Base class for `DatasetBuilder` data configuration.
@@ -59,6 +63,17 @@ class BuilderConfig:
     data_dir: str = None
     data_files: Union[Dict, List] = None
     description: str = None
+
+    def __post_init__(self):
+        # The config name is used to name the cache directory.
+        invalid_windows_characters = "<>:/\|?*"
+        for invalid_char in invalid_windows_characters:
+            if invalid_char in self.name:
+                raise InvalidConfigName(
+                    "Bad characters for directories on Windows '{}' found in '{}'".format(
+                        invalid_windows_characters, self.name
+                    )
+                )
 
 
 class DatasetBuilder:


### PR DESCRIPTION
As said in #194, we should raise an error if the config name has bad characters.
Bad characters are those that are not allowed for directory names on windows.