### PR TITLE
[ArrowWriter] Set schema at first write example

### DIFF
--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -147,6 +147,8 @@ class ArrowWriter(object):
         Args:
             example: the Example to add.
         """
+        if self.pa_writer is None:
+            self._build_writer(pa_table=pa.Table.from_pydict(batch_examples))
         pa_table: pa.Table = pa.Table.from_pydict(batch_examples, schema=self._schema)
         if writer_batch_size is None:
             writer_batch_size = self.writer_batch_size

--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -136,6 +136,8 @@ class ArrowWriter(object):
         self._num_examples += 1
         if writer_batch_size is None:
             writer_batch_size = self.writer_batch_size
+        if self.pa_writer is None:
+            self._build_writer(pa_table=pa.Table.from_pydict(example))
         if writer_batch_size is not None and len(self.current_rows) >= writer_batch_size:
             self.write_on_file()
 


### PR DESCRIPTION
Right now if the schema was not specified when instantiating `ArrowWriter`, then it could be set with the first `write_table` for example (it calls `self._build_writer()` to do so).

I noticed that it was not done if the first example is added via `.write`, so I added it for coherence.