### PR TITLE
Raise an error if no config name for datasets like glue

### DIFF
--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -173,7 +173,14 @@ class DatasetBuilder:
             config_kwargs override the defaults kwargs in config
         """
         builder_config = None
-        if name is None and self.BUILDER_CONFIGS:
+        if name is None and self.BUILDER_CONFIGS and not config_kwargs:
+            if len(self.BUILDER_CONFIGS) > 1:
+                example_of_usage = "load_dataset('{}', '{}')".format(self.name, self.BUILDER_CONFIGS[0].name)
+                raise ValueError(
+                    "Config name is missing."
+                    "\nPlease pick one among the available configs: %s" % list(self.builder_configs.keys())
+                    + "\nExample of usage:\n\t`{}`".format(example_of_usage)
+                )
             builder_config = self.BUILDER_CONFIGS[0]
             logger.info("No config specified, defaulting to first: %s/%s", self.name, builder_config.name)
         if isinstance(name, str):

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -72,7 +72,8 @@ class DatasetTester(object):
 
                 # create config and dataset
                 dataset_builder_cls = self.load_builder_class(dataset_name, is_local=is_local)
-                dataset_builder = dataset_builder_cls(config=config, cache_dir=processed_temp_dir)
+                name = config.name if config is not None else None
+                dataset_builder = dataset_builder_cls(name=name, cache_dir=processed_temp_dir)
 
                 # TODO: skip Beam datasets for now
                 if isinstance(dataset_builder, BeamBasedBuilder):
@@ -145,8 +146,10 @@ class LocalDatasetTest(parameterized.TestCase):
 
     def test_builder_class(self, dataset_name):
         builder_cls = self.dataset_tester.load_builder_class(dataset_name, is_local=True)
-        builder = builder_cls()
-        self.assertTrue(isinstance(builder, DatasetBuilder))
+        name = builder_cls.BUILDER_CONFIGS[0].name if builder_cls.BUILDER_CONFIGS else None
+        with tempfile.TemporaryDirectory() as tmp_cache_dir:
+            builder = builder_cls(name=name, cache_dir=tmp_cache_dir)
+            self.assertTrue(isinstance(builder, DatasetBuilder))
 
     def test_builder_configs(self, dataset_name):
         builder_configs = self.dataset_tester.load_all_configs(dataset_name, is_local=True)
@@ -207,8 +210,10 @@ class AWSDatasetTest(parameterized.TestCase):
 
     def test_builder_class(self, dataset_name):
         builder_cls = self.dataset_tester.load_builder_class(dataset_name)
-        builder = builder_cls()
-        self.assertTrue(isinstance(builder, DatasetBuilder))
+        name = builder_cls.BUILDER_CONFIGS[0].name if builder_cls.BUILDER_CONFIGS else None
+        with tempfile.TemporaryDirectory() as tmp_cache_dir:
+            builder = builder_cls(name=name, cache_dir=tmp_cache_dir)
+            self.assertTrue(isinstance(builder, DatasetBuilder))
 
     def test_builder_configs(self, dataset_name):
         builder_configs = self.dataset_tester.load_all_configs(dataset_name)


### PR DESCRIPTION
Some datasets like glue (see #130) and scientific_papers (see #197) have many configs.
For example for glue there are cola, sst2, mrpc etc.

Currently if a user does `load_dataset('glue')`, then Cola is loaded by default and it can be confusing. Instead, we should raise an error to let the user know that he has to pick one of the available configs (as proposed in #152). For example for glue, the message looks like:
```
ValueError: Config name is missing.
Please pick one among the available configs: ['cola', 'sst2', 'mrpc', 'qqp', 'stsb', 'mnli', 'mnli_mismatched', 'mnli_matched', 'qnli', 'rte', 'wnli', 'ax']
Example of usage:
	`load_dataset('glue', 'cola')`
```

The error is raised if the config name is missing and if there are >=2 possible configs.