### PR TITLE
Better arrow dataset iter

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -162,8 +162,16 @@ class Dataset(object):
         return self._data.num_rows
 
     def __iter__(self):
+        format_type = self._format_type
+        format_columns = self._format_columns
+        output_all_columns = self._output_all_columns
         for index in range(self._data.num_rows):
-            yield self._unnest(self._data.slice(index, 1).to_pydict())
+            yield self._getitem(
+                index,
+                format_type=format_type,
+                format_columns=format_columns,
+                output_all_columns=output_all_columns,
+            )
 
     def __repr__(self):
         schema_str = dict((a, str(b)) for a, b in zip(self._data.schema.names, self._data.schema.types))

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -167,10 +167,7 @@ class Dataset(object):
         output_all_columns = self._output_all_columns
         for index in range(self._data.num_rows):
             yield self._getitem(
-                index,
-                format_type=format_type,
-                format_columns=format_columns,
-                output_all_columns=output_all_columns,
+                index, format_type=format_type, format_columns=format_columns, output_all_columns=output_all_columns,
             )
 
     def __repr__(self):


### PR DESCRIPTION
I tried to play around with `tf.data.Dataset.from_generator` and I found out that the `__iter__` that we have for `nlp.arrow_dataset.Dataset` ignores the format that has been set (torch or tensorflow).
With these changes I should be able to come up with a `tf.data.Dataset` that uses lazy loading, as asked in #193.