### PR TITLE
[Dummy data] insert config name instead of config 

### DIFF
--- a/src/nlp/commands/dummy_data.py
+++ b/src/nlp/commands/dummy_data.py
@@ -67,7 +67,7 @@ class DummyDataCommand(BaseTransformersCLICommand):
 
             for split in generator_splits:
                 logger.info(f"Collecting dummy data file paths to create for {split.name}")
-                split_names.add(split.name)
+                split_names.append(split.name)
                 gen_kwargs = split.gen_kwargs
                 generator = dataset_builder._generate_examples(**gen_kwargs)
 

--- a/src/nlp/commands/dummy_data.py
+++ b/src/nlp/commands/dummy_data.py
@@ -61,13 +61,13 @@ class DummyDataCommand(BaseTransformersCLICommand):
                     f"Dataset {self._dataset_name} with config {config} seems to already open files in the method `_split_generators(...)`. You might consider to instead only open files in the method `_generate_examples(...)` instead. If this is not possible the dummy data has to be created with less guidance. Make sure you create the file {e.filename}."
                 )
 
-            files_to_create = []
+            files_to_create = set()
             split_names = []
             dummy_file_name = mock_dl_manager.dummy_file_name
 
             for split in generator_splits:
                 logger.info(f"Collecting dummy data file paths to create for {split.name}")
-                split_names.append(split.name)
+                split_names.add(split.name)
                 gen_kwargs = split.gen_kwargs
                 generator = dataset_builder._generate_examples(**gen_kwargs)
 
@@ -92,8 +92,8 @@ class DummyDataCommand(BaseTransformersCLICommand):
             split_names = ", ".join(split_names)
             if len(files_to_create) > 0:
                 # no glob.glob(...) in `_generate_examples(...)`
-                if len(files_to_create) == 1 and files_to_create[0] == dummy_file_name:
-                    dummy_data_guidance_print += f"- Please create a single dummy data file called '{files_to_create[0]}' from the folder '{dummy_data_folder}'. Make sure that the dummy data file provides at least one example for the split '{split_names}' \n\n"
+                if len(files_to_create) == 1 and next(iter(files_to_create)) == dummy_file_name:
+                    dummy_data_guidance_print += f"- Please create a single dummy data file called '{next(iter(files_to_create))}' from the folder '{dummy_data_folder}'. Make sure that the dummy data file provides at least one example for the split(s) '{split_names}' \n\n"
                     files_string = dummy_file_name
                 else:
                     files_string = ", ".join(files_to_create)
@@ -103,7 +103,7 @@ class DummyDataCommand(BaseTransformersCLICommand):
 
                 dummy_data_guidance_print += f"- If the method `_generate_examples(...)` includes multiple `open()` statements, you might have to create other files in addition to '{files_string}'. In this case please refer to the `_generate_examples(...)` method \n\n"
 
-            if len(files_to_create) == 1 and files_to_create[0] == dummy_file_name:
+            if len(files_to_create) == 1 and next(iter(files_to_create)) == dummy_file_name:
                 dummy_data_guidance_print += f"-After the dummy data file is created, it should be zipped to '{dummy_file_name}.zip' with the command `zip {dummy_file_name}.zip {dummy_file_name}` \n\n"
 
                 dummy_data_guidance_print += (

--- a/src/nlp/commands/dummy_data.py
+++ b/src/nlp/commands/dummy_data.py
@@ -87,7 +87,7 @@ class DummyDataCommand(BaseTransformersCLICommand):
                     dummy_data_guidance_print += f"- It appears that the function `_generate_examples(...)` expects one or more files in the folder {dummy_file_name} using the function `glob.glob(...)`. In this case, please refer to the `_generate_examples(...)` method to see under which filename the dummy data files should be created. \n\n"
 
                 except FileNotFoundError as e:
-                    files_to_create.append(e.filename)
+                    files_to_create.add(e.filename)
 
             split_names = ", ".join(split_names)
             if len(files_to_create) > 0:

--- a/src/nlp/commands/run_beam.py
+++ b/src/nlp/commands/run_beam.py
@@ -7,8 +7,8 @@ import apache_beam as beam
 
 from nlp.builder import FORCE_REDOWNLOAD, HF_DATASETS_CACHE, REUSE_CACHE_IF_EXISTS, DatasetBuilder, DownloadConfig
 from nlp.commands import BaseTransformersCLICommand
-from nlp.load import import_main_class, prepare_module
 from nlp.info import DATASET_INFOS_DICT_FILE_NAME
+from nlp.load import import_main_class, prepare_module
 
 
 def run_beam_command_factory(args):

--- a/src/nlp/commands/run_beam.py
+++ b/src/nlp/commands/run_beam.py
@@ -8,7 +8,7 @@ import apache_beam as beam
 from nlp.builder import FORCE_REDOWNLOAD, HF_DATASETS_CACHE, REUSE_CACHE_IF_EXISTS, DatasetBuilder, DownloadConfig
 from nlp.commands import BaseTransformersCLICommand
 from nlp.load import import_main_class, prepare_module
-from nlp.utils.info_utils import DATASET_INFOS_DICT_FILE_NAME
+from nlp.info import DATASET_INFOS_DICT_FILE_NAME
 
 
 def run_beam_command_factory(args):


### PR DESCRIPTION
Thanks @yjernite for letting me know. in the dummy data command the config name shuold be passed to the dataset builder and not the config itself. 

Also, @lhoestq fixed small import bug introduced by beam command I think.