### PR TITLE
force mwparserfromhell as third party

### DIFF
--- a/datasets/wikipedia/wikipedia.py
+++ b/datasets/wikipedia/wikipedia.py
@@ -25,9 +25,9 @@ import re
 import xml.etree.cElementTree as etree
 
 import apache_beam as beam
+import mwparserfromhell
 import six
 
-import mwparserfromhell
 import nlp
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ known_third_party =
     git
     h5py
     MeCab
+    mwparserfromhell
     nlp
     nltk
     numpy


### PR DESCRIPTION
This should fix your env because you had `mwparserfromhell ` as a first party for `isort` @patrickvonplaten 