### PR TITLE
Fix tests/test_dataset_common.py

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -170,9 +170,7 @@ class LocalDatasetTest(parameterized.TestCase):
             download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD
 
             dataset = load_dataset(
-                "./datasets/" + dataset_name,
-                data_dir=temp_data_dir,
-                download_config=download_config,
+                "./datasets/" + dataset_name, data_dir=temp_data_dir, download_config=download_config
             )
             for split in dataset.keys():
                 self.assertTrue(len(dataset[split]) > 0)
@@ -236,8 +234,6 @@ class AWSDatasetTest(parameterized.TestCase):
             download_config = DownloadConfig()
             download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD
 
-            dataset = load_dataset(
-                dataset_name, data_dir=temp_data_dir, download_config=download_config
-            )
+            dataset = load_dataset(dataset_name, data_dir=temp_data_dir, download_config=download_config)
             for split in dataset.keys():
                 self.assertTrue(len(dataset[split]) > 0)

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -167,13 +167,12 @@ class LocalDatasetTest(parameterized.TestCase):
     def test_load_real_dataset(self, dataset_name):
         with tempfile.TemporaryDirectory() as temp_data_dir:
             download_config = DownloadConfig()
-            download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD
-            download_and_prepare_kwargs = {"download_config": download_config}
+            download_config.download_mode = GenerateMode.FORCE_REDOWNLOA
 
             dataset = load_dataset(
                 "./datasets/" + dataset_name,
                 data_dir=temp_data_dir,
-                download_and_prepare_kwargs=download_and_prepare_kwargs,
+                download_config=download_config,
             )
             for split in dataset.keys():
                 self.assertTrue(len(dataset[split]) > 0)
@@ -236,10 +235,9 @@ class AWSDatasetTest(parameterized.TestCase):
         with tempfile.TemporaryDirectory() as temp_data_dir:
             download_config = DownloadConfig()
             download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD
-            download_and_prepare_kwargs = {"download_config": download_config}
 
             dataset = load_dataset(
-                dataset_name, data_dir=temp_data_dir, download_and_prepare_kwargs=download_and_prepare_kwargs
+                dataset_name, data_dir=temp_data_dir, download_config=download_config
             )
             for split in dataset.keys():
                 self.assertTrue(len(dataset[split]) > 0)

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -167,7 +167,7 @@ class LocalDatasetTest(parameterized.TestCase):
     def test_load_real_dataset(self, dataset_name):
         with tempfile.TemporaryDirectory() as temp_data_dir:
             download_config = DownloadConfig()
-            download_config.download_mode = GenerateMode.FORCE_REDOWNLOA
+            download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD
 
             dataset = load_dataset(
                 "./datasets/" + dataset_name,


### PR DESCRIPTION
When I run the command `RUN_SLOW=1 pytest tests/test_dataset_common.py::LocalDatasetTest::test_load_real_dataset_arcd` while working on #220. I get the error ` unexpected keyword argument "'download_and_prepare_kwargs'"` at the level of  `load_dataset`. Indeed, this [function](https://github.com/huggingface/nlp/blob/master/src/nlp/load.py#L441) no longer has the argument `download_and_prepare_kwargs` but rather `download_config`. So here I change the tests accordingly. 