### PR TITLE
Don't force to install apache beam for wikipedia dataset

### DIFF
--- a/datasets/wiki40b/wiki40b.py
+++ b/datasets/wiki40b/wiki40b.py
@@ -20,9 +20,6 @@ from __future__ import absolute_import, division, print_function
 import logging
 import os
 
-import apache_beam as beam
-import tensorflow as tf
-
 import nlp
 
 
@@ -125,7 +122,7 @@ class Wiki40b(nlp.BeamBasedBuilder):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
             features=nlp.Features(
-                {"wikidata_id": nlp.Value("string"), "text": nlp.Value("string"), "version_id": nlp.Value("string"),}
+                {"wikidata_id": nlp.Value("string"), "text": nlp.Value("string"), "version_id": nlp.Value("string")}
             ),
             supervised_keys=None,
             homepage=_URL,
@@ -154,6 +151,9 @@ class Wiki40b(nlp.BeamBasedBuilder):
 
     def _build_pcollection(self, pipeline, filepaths):
         """Build PCollection of examples."""
+        import apache_beam as beam
+        import tensorflow as tf
+
         logging.info("generating examples from = %s", filepaths)
 
         def _extract_content(example):

--- a/datasets/wikipedia/wikipedia.py
+++ b/datasets/wikipedia/wikipedia.py
@@ -24,8 +24,6 @@ import logging
 import re
 import xml.etree.cElementTree as etree
 
-import apache_beam as beam
-import mwparserfromhell
 import six
 
 import nlp
@@ -452,6 +450,8 @@ class Wikipedia(nlp.BeamBasedBuilder):
 
     def _build_pcollection(self, pipeline, filepaths, language):
         """Build PCollection of examples in the raw (text) form."""
+        import apache_beam as beam
+        import mwparserfromhell
 
         def _extract_content(filepath):
             """Extracts article content from a single WikiMedia XML file."""
@@ -497,7 +497,7 @@ class Wikipedia(nlp.BeamBasedBuilder):
             """Cleans raw wikicode to extract text."""
             id_, title, raw_content = inputs
             try:
-                text = _parse_and_clean_wikicode(raw_content)
+                text = _parse_and_clean_wikicode(raw_content, parser=mwparserfromhell)
             except (mwparserfromhell.parser.ParserError) as e:
                 beam.metrics.Metrics.counter(language, "parser-error").inc()
                 logging.error("mwparserfromhell ParseError: %s", e)
@@ -520,9 +520,9 @@ class Wikipedia(nlp.BeamBasedBuilder):
         )
 
 
-def _parse_and_clean_wikicode(raw_content):
+def _parse_and_clean_wikicode(raw_content, parser):
     """Strips formatting and unwanted sections from raw page content."""
-    wikicode = mwparserfromhell.parse(raw_content)
+    wikicode = parser.parse(raw_content)
 
     # Filters for references, tables, and file/image links.
     re_rm_wikilink = re.compile("^(?:File|Image|Media):", flags=re.IGNORECASE | re.UNICODE)


### PR DESCRIPTION
As pointed out in #227, we shouldn't force users to install apache beam if the processed dataset can be downloaded. I moved the imports of some datasets to avoid this problem