### PR TITLE
Add .download to MockDownloadManager

### DIFF
--- a/src/nlp/utils/mock_download_manager.py
+++ b/src/nlp/utils/mock_download_manager.py
@@ -104,6 +104,10 @@ class MockDownloadManager(object):
         return dummy_file
 
     # this function has to be in the manager under this name so that testing works
+    def download(self, data_url, *args):
+        return self.download_and_extract(data_url)
+
+    # this function has to be in the manager under this name so that testing works
     def download_custom(self, data_url, custom_download):
         return self.download_and_extract(data_url)
 


### PR DESCRIPTION
One method from the DownloadManager was missing and some users couldn't run the tests because of that.
@yjernite 