### PR TITLE
Fix empty cache dir

### DIFF
--- a/src/nlp/utils/py_utils.py
+++ b/src/nlp/utils/py_utils.py
@@ -90,8 +90,10 @@ def temporary_assignment(obj, attr, value):
     """Temporarily assign obj.attr to value."""
     original = getattr(obj, attr, None)
     setattr(obj, attr, value)
-    yield
-    setattr(obj, attr, original)
+    try:
+        yield
+    finally:
+        setattr(obj, attr, original)
 
 
 def zip_dict(*dicts):


### PR DESCRIPTION
If the cache dir of a dataset is empty, the dataset fails to load and throws a FileNotFounfError. We could end up with empty cache dir because there was a line in the code that created the cache dir without using a temp dir. Using a temp dir is useful as it gets renamed to the real cache dir only if the full process is successful.

So I removed this bad line, and I also reordered things a bit to make sure that we always use a temp dir. I also added warning if we still end up with empty cache dirs in the future.

This should fix #239
