### PR TITLE
Specify utf-8 encoding for GLUE

### DIFF
--- a/datasets/glue/glue.py
+++ b/datasets/glue/glue.py
@@ -522,7 +522,7 @@ class Glue(nlp.GeneratorBasedBuilder):
             # header.
             is_cola_non_test = self.config.name == "cola" and split != "test"
 
-            with open(data_file) as f:
+            with open(data_file, encoding='utf8') as f:
                 reader = csv.DictReader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
                 if is_cola_non_test:
                     reader = csv.reader(f, delimiter="\t", quoting=csv.QUOTE_NONE)


### PR DESCRIPTION
#242 
This makes the GLUE-MNLI dataset readable on my machine, not sure if it's a Windows-only bug.