### PR TITLE
Make all dataset downloads deterministic by applying `sorted` to glob and os.listdir

### DIFF
--- a/datasets/aeslc/aeslc.py
+++ b/datasets/aeslc/aeslc.py
@@ -81,7 +81,7 @@ class Aeslc(nlp.GeneratorBasedBuilder):
 
     def _generate_examples(self, pattern=None):
         """Yields examples."""
-        for filename in glob.glob(pattern):
+        for filename in sorted(glob.glob(pattern)):
             email_body, subject_line = _parse_email_file(filename)
             key = os.path.basename(filename).rstrip(".subject")
             yield key, {_DOCUMENT: email_body, _SUMMARY: subject_line}

--- a/datasets/blended_skill_talk/blended_skill_talk.py
+++ b/datasets/blended_skill_talk/blended_skill_talk.py
@@ -1,12 +1,11 @@
 """TODO(blended_skill_talk): Add a description here."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import json
+import os
 
 import nlp
-import os
-import json
 
 
 # TODO(blended_skill_talk): BibTeX citation
@@ -25,127 +24,103 @@ _CITATION = """\
 _DESCRIPTION = """\
 A dataset of 7k conversations explicitly designed to exhibit multiple conversation modes: displaying personality, having empathy, and demonstrating knowledge.
 """
-_URL = 'http://parl.ai/downloads/blended_skill_talk/blended_skill_talk.tar.gz'
+_URL = "http://parl.ai/downloads/blended_skill_talk/blended_skill_talk.tar.gz"
 
-_TASK = ['convai2', 'empathetic_dialogues', 'wizard_of_wikipedia']
+_TASK = ["convai2", "empathetic_dialogues", "wizard_of_wikipedia"]
 
 
 class BlendedSkillTalk(nlp.GeneratorBasedBuilder):
-  """TODO(blended_skill_talk): Short description of my dataset."""
+    """TODO(blended_skill_talk): Short description of my dataset."""
 
-  # TODO(blended_skill_talk): Set up version.
-  VERSION = nlp.Version('1.0.0')
+    # TODO(blended_skill_talk): Set up version.
+    VERSION = nlp.Version("1.0.0")
 
-  def _info(self):
-    # TODO(blended_skill_talk): Specifies the nlp.DatasetInfo object
-    return nlp.DatasetInfo(
-        # This is the description that will appear on the datasets page.
-        description=_DESCRIPTION,
-        # nlp.features.FeatureConnectors
-        features=nlp.Features({
-            'personas': nlp.features.Sequence({
-                'persona': nlp.Value('string'),
-            }),
-            'additional_context': nlp.Value('string'),
-            'previous_utterance': nlp.features.Sequence({
-                'previous_utterance': nlp.Value('string'),
-            }),
-            'context': nlp.Value('string'),
-            'free_messages': nlp.features.Sequence({
-                'free_message': nlp.Value('string'),
-            }),
-            'guided_messgaes': nlp.features.Sequence({
-                'guided_messgae': nlp.Value('string'),
-            }),
-            'suggestions': nlp.features.Sequence({
-                task: nlp.Value('string') for task in _TASK
-
-            })
-            # These are the features of your dataset like images, labels ...
-        }),
-        # If there's a common (input, target) tuple from the features,
-        # specify them here. They'll be used if as_supervised=True in
-        # builder.as_dataset.
-        supervised_keys=None,
-        # Homepage of the dataset for documentation
-        homepage='https://parl.ai/projects/bst/',
-        citation=_CITATION,
-    )
-
-  def _split_generators(self, dl_manager):
-    """Returns SplitGenerators."""
-    # TODO(blended_skill_talk): Downloads the data and defines the splits
-    # dl_manager is a nlp.download.DownloadManager that can be used to
-    # download and extract URLs
-    data_dir = dl_manager.download_and_extract(_URL)
-    return [
-        nlp.SplitGenerator(
-            name=nlp.Split.TRAIN,
-            # These kwargs will be passed to _generate_examples
-            gen_kwargs={
-                'filepath': os.path.join(data_dir, 'train.json')
-            },
-        ),
-        nlp.SplitGenerator(
-            name=nlp.Split.VALIDATION,
-            # These kwargs will be passed to _generate_examples
-            gen_kwargs={
-                'filepath': os.path.join(data_dir, 'valid.json')
-            },
-        ),
-        nlp.SplitGenerator(
-            name=nlp.Split.TEST,
-            # These kwargs will be passed to _generate_examples
-            gen_kwargs={
-                'filepath': os.path.join(data_dir, 'test.json')
-            },
-        ),
-    ]
-
-  def _generate_examples(self, filepath):
-    """Yields examples."""
-    # TODO(blended_skill_talk): Yields (key, example) tuples from the dataset
-    with open(filepath) as f:
-        data = json.load(f)
-        for id_, row in enumerate(data):
-            personas = [row['personas'][1][0], row['personas'][1][1]]
-            dialogs = [dialog[1] for dialog in row['dialog']]
-            free_messages = []
-            guided_messages = []
-
-            for i in range(len(dialogs)//2):
-                free_messages.append(dialogs[2*i])
-                guided_messages.append(dialogs[2*i+1])
-            context = row['context_dataset']
-            add_context = row['additional_context'] if context == 'wizard_of_wikipedia' else ''
-            previous_utterance = [row['free_turker_utterance'], row['guided_turker_utterance']]
-            suggestions = row['suggestions']
-            convai_suggestions = []
-            empathetic_suggestions = []
-            wow_suggestions = []
-            for i in range(len(suggestions)//2):
-                convai_suggestions.append(suggestions[2 * i + 1]['convai2'])
-                empathetic_suggestions.append(suggestions[2*i + 1]['empathetic_dialogues'])
-                wow_suggestions.append(suggestions[2*i + 1]['wizard_of_wikipedia'])
-            yield id_, {
-                'personas': {
-                    'persona': personas,
-                },
-                'additional_context': add_context,
-                'previous_utterance': {
-                    'previous_utterance': previous_utterance,
-                },
-                'context': context,
-                'free_messages': {
-                    'free_message': free_messages,
-                },
-                'guided_messgaes': {
-                    'guided_messgae': guided_messages,
-                },
-                'suggestions': {
-                    'convai2': convai_suggestions,
-                    'empathetic_dialogues': empathetic_suggestions,
-                    'wizard_of_wikipedia': wow_suggestions
+    def _info(self):
+        # TODO(blended_skill_talk): Specifies the nlp.DatasetInfo object
+        return nlp.DatasetInfo(
+            # This is the description that will appear on the datasets page.
+            description=_DESCRIPTION,
+            # nlp.features.FeatureConnectors
+            features=nlp.Features(
+                {
+                    "personas": nlp.features.Sequence({"persona": nlp.Value("string"),}),
+                    "additional_context": nlp.Value("string"),
+                    "previous_utterance": nlp.features.Sequence({"previous_utterance": nlp.Value("string"),}),
+                    "context": nlp.Value("string"),
+                    "free_messages": nlp.features.Sequence({"free_message": nlp.Value("string"),}),
+                    "guided_messgaes": nlp.features.Sequence({"guided_messgae": nlp.Value("string"),}),
+                    "suggestions": nlp.features.Sequence({task: nlp.Value("string") for task in _TASK})
+                    # These are the features of your dataset like images, labels ...
                 }
-            }
+            ),
+            # If there's a common (input, target) tuple from the features,
+            # specify them here. They'll be used if as_supervised=True in
+            # builder.as_dataset.
+            supervised_keys=None,
+            # Homepage of the dataset for documentation
+            homepage="https://parl.ai/projects/bst/",
+            citation=_CITATION,
+        )
 
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        # TODO(blended_skill_talk): Downloads the data and defines the splits
+        # dl_manager is a nlp.download.DownloadManager that can be used to
+        # download and extract URLs
+        data_dir = dl_manager.download_and_extract(_URL)
+        return [
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={"filepath": os.path.join(data_dir, "train.json")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={"filepath": os.path.join(data_dir, "valid.json")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                # These kwargs will be passed to _generate_examples
+                gen_kwargs={"filepath": os.path.join(data_dir, "test.json")},
+            ),
+        ]
+
+    def _generate_examples(self, filepath):
+        """Yields examples."""
+        # TODO(blended_skill_talk): Yields (key, example) tuples from the dataset
+        with open(filepath) as f:
+            data = json.load(f)
+            for id_, row in enumerate(data):
+                personas = [row["personas"][1][0], row["personas"][1][1]]
+                dialogs = [dialog[1] for dialog in row["dialog"]]
+                free_messages = []
+                guided_messages = []
+
+                for i in range(len(dialogs) // 2):
+                    free_messages.append(dialogs[2 * i])
+                    guided_messages.append(dialogs[2 * i + 1])
+                context = row["context_dataset"]
+                add_context = row["additional_context"] if context == "wizard_of_wikipedia" else ""
+                previous_utterance = [row["free_turker_utterance"], row["guided_turker_utterance"]]
+                suggestions = row["suggestions"]
+                convai_suggestions = []
+                empathetic_suggestions = []
+                wow_suggestions = []
+                for i in range(len(suggestions) // 2):
+                    convai_suggestions.append(suggestions[2 * i + 1]["convai2"])
+                    empathetic_suggestions.append(suggestions[2 * i + 1]["empathetic_dialogues"])
+                    wow_suggestions.append(suggestions[2 * i + 1]["wizard_of_wikipedia"])
+                yield id_, {
+                    "personas": {"persona": personas,},
+                    "additional_context": add_context,
+                    "previous_utterance": {"previous_utterance": previous_utterance,},
+                    "context": context,
+                    "free_messages": {"free_message": free_messages,},
+                    "guided_messgaes": {"guided_messgae": guided_messages,},
+                    "suggestions": {
+                        "convai2": convai_suggestions,
+                        "empathetic_dialogues": empathetic_suggestions,
+                        "wizard_of_wikipedia": wow_suggestions,
+                    },
+                }

--- a/datasets/blog_authorship_corpus/blog_authorship_corpus.py
+++ b/datasets/blog_authorship_corpus/blog_authorship_corpus.py
@@ -96,7 +96,7 @@ class BlogAuthorshipCorpus(nlp.GeneratorBasedBuilder):
         if self.config.name == "blog-authorship-corpus":
             data = dl_manager.download_and_extract(self.config.data_url)
             data_dir = os.path.join(data, "blogs")
-            files = glob.glob(os.path.join(data_dir, "*.xml"))
+            files = sorted(glob.glob(os.path.join(data_dir, "*.xml")))
             train_files = []
             validation_files = []
 

--- a/datasets/c4/c4_utils.py
+++ b/datasets/c4/c4_utils.py
@@ -26,11 +26,12 @@ import re
 import threading
 
 import apache_beam as beam
-import langdetect
 import nltk
 import tensorflow.compat.v2 as tf
-import tldextract
 from absl import logging
+
+import langdetect
+import tldextract
 
 
 # WET file constants

--- a/datasets/cnn_dailymail/cnn_dailymail.py
+++ b/datasets/cnn_dailymail/cnn_dailymail.py
@@ -125,7 +125,7 @@ def _find_files(dl_paths, publisher, url_dict):
         top_dir = os.path.join(dl_paths["dm_stories"], "dailymail", "stories")
     else:
         logging.fatal("Unsupported publisher: %s", publisher)
-    files = os.listdir(top_dir)
+    files = sorted(os.listdir(top_dir))
 
     ret_files = []
     for p in files:
@@ -228,7 +228,7 @@ class CnnDailymail(nlp.GeneratorBasedBuilder):
         # Should return a nlp.DatasetInfo object
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({_ARTICLE: nlp.Value("string"), _HIGHLIGHTS: nlp.Value("string"),}),
+            features=nlp.Features({_ARTICLE: nlp.Value("string"), _HIGHLIGHTS: nlp.Value("string")}),
             supervised_keys=None,
             homepage="https://github.com/abisee/cnn-dailymail",
             citation=_CITATION,

--- a/datasets/hansards/hansards.py
+++ b/datasets/hansards/hansards.py
@@ -28,7 +28,7 @@ Caveats
 1. This release contains only sentence pairs. Even though the order of the sentences is the same
 as in the original, there may be gaps resulting from many-to-one, many-to-many, or one-to-many
 alignments that were filtered out. Therefore, this release may not be suitable for
-discourse-related research. 
+discourse-related research.
 2. Neither the sentence splitting nor the alignments are perfect. In particular, watch out for
 pairs that differ considerably in length. You may want to filter these out before you do
 any statistical training.
@@ -128,8 +128,8 @@ class Hansards(nlp.GeneratorBasedBuilder):
                 name, split_name + "ing"
             )
             data_dir = os.path.join(downloaded_files[split_name], archive_dir)
-            split_compress_files = list(glob.glob(os.path.join(data_dir, "*.gz")))
-            split_compress_files += list(glob.glob(os.path.join(data_dir, "**/*.gz")))
+            split_compress_files = list(sorted(glob.glob(os.path.join(data_dir, "*.gz"))))
+            split_compress_files += list(sorted(glob.glob(os.path.join(data_dir, "**/*.gz"))))
             fr_split_compress_files = sorted([f for f in split_compress_files if f.endswith(".f.gz")])
             en_split_compress_files = sorted([f for f in split_compress_files if f.endswith(".e.gz")])
             fr_files[split_name] = dl_manager.extract(fr_split_compress_files)

--- a/datasets/imdb/imdb.py
+++ b/datasets/imdb/imdb.py
@@ -18,9 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import glob
 import os
-import re
 
 import nlp
 
@@ -73,7 +71,7 @@ class Imdb(nlp.GeneratorBasedBuilder):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
             features=nlp.Features(
-                {"text": nlp.Value("string"), "label": nlp.features.ClassLabel(names=["neg", "pos"]),}
+                {"text": nlp.Value("string"), "label": nlp.features.ClassLabel(names=["neg", "pos"])}
             ),
             supervised_keys=None,
             homepage="http://ai.stanford.edu/~amaas/data/sentiment/",
@@ -101,8 +99,8 @@ class Imdb(nlp.GeneratorBasedBuilder):
         # For labeled examples, extract the label from the path.
         if labeled:
             files = {
-                "pos": os.listdir(os.path.join(directory, "pos")),
-                "neg": os.listdir(os.path.join(directory, "neg")),
+                "pos": sorted(os.listdir(os.path.join(directory, "pos"))),
+                "neg": sorted(os.listdir(os.path.join(directory, "neg"))),
             }
             for key in files:
                 for id_, file in enumerate(files[key]):
@@ -110,7 +108,7 @@ class Imdb(nlp.GeneratorBasedBuilder):
                     with open(filepath) as f:
                         yield key + "_" + str(id_), {"text": f.read(), "label": key}
         else:
-            unsup_files = os.listdir(os.path.join(directory, "unsup"))
+            unsup_files = sorted(os.listdir(os.path.join(directory, "unsup")))
             for id_, file in enumerate(unsup_files):
                 filepath = os.path.join(directory, "unsup", file)
                 with open(filepath) as f:

--- a/datasets/lm1b/lm1b.py
+++ b/datasets/lm1b/lm1b.py
@@ -73,11 +73,11 @@ class Lm1bConfig(nlp.BuilderConfig):
 
 
 def _train_data_filenames(tmp_dir):
-    return glob.glob(os.path.join(tmp_dir, _TRAIN_FILE_FORMAT))
+    return sorted(glob.glob(os.path.join(tmp_dir, _TRAIN_FILE_FORMAT)))
 
 
 def _test_data_filenames(tmp_dir):
-    return glob.glob(os.path.join(tmp_dir, _HELDOUT_FILE_FORMAT))
+    return sorted(glob.glob(os.path.join(tmp_dir, _HELDOUT_FILE_FORMAT)))
 
 
 class Lm1b(nlp.GeneratorBasedBuilder):
@@ -90,7 +90,7 @@ class Lm1b(nlp.GeneratorBasedBuilder):
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({"text": nlp.Value("string"),}),
+            features=nlp.Features({"text": nlp.Value("string")}),
             supervised_keys=("text", "text"),
             homepage="http://www.statmt.org/lm-benchmark/",
             citation=_CITATION,

--- a/datasets/opinosis/opinosis.py
+++ b/datasets/opinosis/opinosis.py
@@ -71,7 +71,7 @@ class Opinosis(nlp.GeneratorBasedBuilder):
     def _generate_examples(self, path=None):
         """Yields examples."""
         topics_path = os.path.join(path, "topics")
-        filenames = os.listdir(topics_path)
+        filenames = sorted(os.listdir(topics_path))
         for filename in filenames:
             file_path = os.path.join(topics_path, filename)
             topic_name = filename.split(".txt")[0]
@@ -79,7 +79,7 @@ class Opinosis(nlp.GeneratorBasedBuilder):
                 input_data = src_f.read().decode("latin-1")
             summaries_path = os.path.join(path, "summaries-gold", topic_name)
             summary_lst = []
-            for summ_filename in os.listdir(summaries_path):
+            for summ_filename in sorted(os.listdir(summaries_path)):
                 file_path = os.path.join(summaries_path, summ_filename)
                 with open(file_path, "rb") as tgt_f:
                     data = tgt_f.read().strip().decode("latin-1")

--- a/datasets/race/race.py
+++ b/datasets/race/race.py
@@ -13,7 +13,7 @@ _CITATION = """\
 @article{lai2017large,
     title={RACE: Large-scale ReAding Comprehension Dataset From Examinations},
     author={Lai, Guokun and Xie, Qizhe and Liu, Hanxiao and Yang, Yiming and Hovy, Eduard},
-    journal={arXiv preprint arXiv:1704.04683},  
+    journal={arXiv preprint arXiv:1704.04683},
     year={2017}
 }
 """
@@ -70,7 +70,7 @@ class Race(nlp.GeneratorBasedBuilder):
                 name=nlp.Split.TEST,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "files": os.listdir(os.path.join(dl_dir, "RACE/test/high")),
+                    "files": sorted(os.listdir(os.path.join(dl_dir, "RACE/test/high"))),
                     "filespath": os.path.join(dl_dir, "RACE/test/high"),
                 },
             ),
@@ -78,7 +78,7 @@ class Race(nlp.GeneratorBasedBuilder):
                 name=nlp.Split.TRAIN,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "files": os.listdir(os.path.join(dl_dir, "RACE/train/high")),
+                    "files": sorted(os.listdir(os.path.join(dl_dir, "RACE/train/high"))),
                     "filespath": os.path.join(dl_dir, "RACE/train/high"),
                 },
             ),
@@ -86,7 +86,7 @@ class Race(nlp.GeneratorBasedBuilder):
                 name=nlp.Split.VALIDATION,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "files": os.listdir(os.path.join(dl_dir, "RACE/dev/high")),
+                    "files": sorted(os.listdir(os.path.join(dl_dir, "RACE/dev/high"))),
                     "filespath": os.path.join(dl_dir, "RACE/dev/high"),
                 },
             ),

--- a/datasets/trivia_qa/trivia_qa.py
+++ b/datasets/trivia_qa/trivia_qa.py
@@ -71,11 +71,11 @@ _CONTEXT_ADDENDUM = "Includes context from Wikipedia and search results."
 
 
 def _web_evidence_dir(tmp_dir):
-    return glob.glob(os.path.join(tmp_dir, _WEB_EVIDENCE_DIR))
+    return sorted(glob.glob(os.path.join(tmp_dir, _WEB_EVIDENCE_DIR)))
 
 
 def _wiki_evidence_dir(tmp_dir):
-    return glob.glob(os.path.join(tmp_dir, _WIKI_EVIDENCE_DIR))
+    return sorted(glob.glob(os.path.join(tmp_dir, _WIKI_EVIDENCE_DIR)))
 
 
 class TriviaQaConfig(nlp.BuilderConfig):
@@ -177,9 +177,9 @@ class TriviaQa(nlp.GeneratorBasedBuilder):
             if cfg.unfiltered
             else os.path.join(file_paths["rc"], "qa")
         )
-        train_files = glob.glob(os.path.join(qa_dir, _TRAIN_FILE_FORMAT))
-        valid_files = glob.glob(os.path.join(qa_dir, _VALIDATION_FILE_FORMAT))
-        test_files = glob.glob(os.path.join(qa_dir, _TEST_FILE_FORMAT))
+        train_files = sorted(glob.glob(os.path.join(qa_dir, _TRAIN_FILE_FORMAT)))
+        valid_files = sorted(glob.glob(os.path.join(qa_dir, _VALIDATION_FILE_FORMAT)))
+        test_files = sorted(glob.glob(os.path.join(qa_dir, _TEST_FILE_FORMAT)))
 
         if cfg.exclude_context:
             web_evidence_dir = None

--- a/datasets/wmt14/wmt_utils.py
+++ b/datasets/wmt14/wmt_utils.py
@@ -886,8 +886,8 @@ def _parse_parallel_sentences(f1, f2):
 
     # Some datasets (e.g., CWMT) contain multiple parallel files specified with
     # a wildcard. We sort both sets to align them and parse them one by one.
-    f1_files = glob.glob(f1)
-    f2_files = glob.glob(f2)
+    f1_files = sorted(glob.glob(f1))
+    f2_files = sorted(glob.glob(f2))
 
     assert f1_files and f2_files, "No matching files found: %s, %s." % (f1, f2)
     assert len(f1_files) == len(f2_files), "Number of files do not match: %d vs %d for %s vs %s." % (
@@ -993,7 +993,7 @@ def _parse_czeng(*paths, **kwargs):
         logging.info("Loaded %d bad blocks to filter from CzEng v1.6 to make v1.7.", len(bad_blocks))
 
     for path in paths:
-        for gz_path in glob.glob(path):
+        for gz_path in sorted(glob.glob(path)):
             with open(gz_path, "rb") as g, gzip.GzipFile(fileobj=g) as f:
                 filename = os.path.basename(gz_path)
                 for line_id, line in enumerate(f):

--- a/datasets/wmt15/wmt_utils.py
+++ b/datasets/wmt15/wmt_utils.py
@@ -886,8 +886,8 @@ def _parse_parallel_sentences(f1, f2):
 
     # Some datasets (e.g., CWMT) contain multiple parallel files specified with
     # a wildcard. We sort both sets to align them and parse them one by one.
-    f1_files = glob.glob(f1)
-    f2_files = glob.glob(f2)
+    f1_files = sorted(glob.glob(f1))
+    f2_files = sorted(glob.glob(f2))
 
     assert f1_files and f2_files, "No matching files found: %s, %s." % (f1, f2)
     assert len(f1_files) == len(f2_files), "Number of files do not match: %d vs %d for %s vs %s." % (
@@ -993,7 +993,7 @@ def _parse_czeng(*paths, **kwargs):
         logging.info("Loaded %d bad blocks to filter from CzEng v1.6 to make v1.7.", len(bad_blocks))
 
     for path in paths:
-        for gz_path in glob.glob(path):
+        for gz_path in sorted(glob.glob(path)):
             with open(gz_path, "rb") as g, gzip.GzipFile(fileobj=g) as f:
                 filename = os.path.basename(gz_path)
                 for line_id, line in enumerate(f):

--- a/datasets/wmt16/wmt_utils.py
+++ b/datasets/wmt16/wmt_utils.py
@@ -886,8 +886,8 @@ def _parse_parallel_sentences(f1, f2):
 
     # Some datasets (e.g., CWMT) contain multiple parallel files specified with
     # a wildcard. We sort both sets to align them and parse them one by one.
-    f1_files = glob.glob(f1)
-    f2_files = glob.glob(f2)
+    f1_files = sorted(glob.glob(f1))
+    f2_files = sorted(glob.glob(f2))
 
     assert f1_files and f2_files, "No matching files found: %s, %s." % (f1, f2)
     assert len(f1_files) == len(f2_files), "Number of files do not match: %d vs %d for %s vs %s." % (
@@ -993,7 +993,7 @@ def _parse_czeng(*paths, **kwargs):
         logging.info("Loaded %d bad blocks to filter from CzEng v1.6 to make v1.7.", len(bad_blocks))
 
     for path in paths:
-        for gz_path in glob.glob(path):
+        for gz_path in sorted(glob.glob(path)):
             with open(gz_path, "rb") as g, gzip.GzipFile(fileobj=g) as f:
                 filename = os.path.basename(gz_path)
                 for line_id, line in enumerate(f):

--- a/datasets/wmt17/wmt_utils.py
+++ b/datasets/wmt17/wmt_utils.py
@@ -886,8 +886,8 @@ def _parse_parallel_sentences(f1, f2):
 
     # Some datasets (e.g., CWMT) contain multiple parallel files specified with
     # a wildcard. We sort both sets to align them and parse them one by one.
-    f1_files = glob.glob(f1)
-    f2_files = glob.glob(f2)
+    f1_files = sorted(glob.glob(f1))
+    f2_files = sorted(glob.glob(f2))
 
     assert f1_files and f2_files, "No matching files found: %s, %s." % (f1, f2)
     assert len(f1_files) == len(f2_files), "Number of files do not match: %d vs %d for %s vs %s." % (
@@ -993,7 +993,7 @@ def _parse_czeng(*paths, **kwargs):
         logging.info("Loaded %d bad blocks to filter from CzEng v1.6 to make v1.7.", len(bad_blocks))
 
     for path in paths:
-        for gz_path in glob.glob(path):
+        for gz_path in sorted(glob.glob(path)):
             with open(gz_path, "rb") as g, gzip.GzipFile(fileobj=g) as f:
                 filename = os.path.basename(gz_path)
                 for line_id, line in enumerate(f):

--- a/datasets/wmt18/wmt_utils.py
+++ b/datasets/wmt18/wmt_utils.py
@@ -886,8 +886,8 @@ def _parse_parallel_sentences(f1, f2):
 
     # Some datasets (e.g., CWMT) contain multiple parallel files specified with
     # a wildcard. We sort both sets to align them and parse them one by one.
-    f1_files = glob.glob(f1)
-    f2_files = glob.glob(f2)
+    f1_files = sorted(glob.glob(f1))
+    f2_files = sorted(glob.glob(f2))
 
     assert f1_files and f2_files, "No matching files found: %s, %s." % (f1, f2)
     assert len(f1_files) == len(f2_files), "Number of files do not match: %d vs %d for %s vs %s." % (
@@ -993,7 +993,7 @@ def _parse_czeng(*paths, **kwargs):
         logging.info("Loaded %d bad blocks to filter from CzEng v1.6 to make v1.7.", len(bad_blocks))
 
     for path in paths:
-        for gz_path in glob.glob(path):
+        for gz_path in sorted(glob.glob(path)):
             with open(gz_path, "rb") as g, gzip.GzipFile(fileobj=g) as f:
                 filename = os.path.basename(gz_path)
                 for line_id, line in enumerate(f):

--- a/datasets/wmt19/wmt_utils.py
+++ b/datasets/wmt19/wmt_utils.py
@@ -886,8 +886,8 @@ def _parse_parallel_sentences(f1, f2):
 
     # Some datasets (e.g., CWMT) contain multiple parallel files specified with
     # a wildcard. We sort both sets to align them and parse them one by one.
-    f1_files = glob.glob(f1)
-    f2_files = glob.glob(f2)
+    f1_files = sorted(glob.glob(f1))
+    f2_files = sorted(glob.glob(f2))
 
     assert f1_files and f2_files, "No matching files found: %s, %s." % (f1, f2)
     assert len(f1_files) == len(f2_files), "Number of files do not match: %d vs %d for %s vs %s." % (
@@ -993,7 +993,7 @@ def _parse_czeng(*paths, **kwargs):
         logging.info("Loaded %d bad blocks to filter from CzEng v1.6 to make v1.7.", len(bad_blocks))
 
     for path in paths:
-        for gz_path in glob.glob(path):
+        for gz_path in sorted(glob.glob(path)):
             with open(gz_path, "rb") as g, gzip.GzipFile(fileobj=g) as f:
                 filename = os.path.basename(gz_path)
                 for line_id, line in enumerate(f):

--- a/datasets/wmt_t2t/wmt_utils.py
+++ b/datasets/wmt_t2t/wmt_utils.py
@@ -656,6 +656,14 @@ class WmtConfig(nlp.BuilderConfig):
         self.language_pair = language_pair
         self.subsets = subsets
 
+        # TODO(PVP): remove when manual dir works
+        # +++++++++++++++++++++
+        if language_pair[1] in ["cs", "hi", "ru"]:
+            assert NotImplementedError(
+                "The dataset for {}-en is currently not fully supported.".format(language_pair[1])
+            )
+        # +++++++++++++++++++++
+
 
 class Wmt(ABC, nlp.GeneratorBasedBuilder):
     """WMT translation dataset."""
@@ -878,8 +886,8 @@ def _parse_parallel_sentences(f1, f2):
 
     # Some datasets (e.g., CWMT) contain multiple parallel files specified with
     # a wildcard. We sort both sets to align them and parse them one by one.
-    f1_files = glob.glob(f1)
-    f2_files = glob.glob(f2)
+    f1_files = sorted(glob.glob(f1))
+    f2_files = sorted(glob.glob(f2))
 
     assert f1_files and f2_files, "No matching files found: %s, %s." % (f1, f2)
     assert len(f1_files) == len(f2_files), "Number of files do not match: %d vs %d for %s vs %s." % (
@@ -985,7 +993,7 @@ def _parse_czeng(*paths, **kwargs):
         logging.info("Loaded %d bad blocks to filter from CzEng v1.6 to make v1.7.", len(bad_blocks))
 
     for path in paths:
-        for gz_path in glob.glob(path):
+        for gz_path in sorted(glob.glob(path)):
             with open(gz_path, "rb") as g, gzip.GzipFile(fileobj=g) as f:
                 filename = os.path.basename(gz_path)
                 for line_id, line in enumerate(f):

--- a/datasets/xtreme/xtreme.py
+++ b/datasets/xtreme/xtreme.py
@@ -2,13 +2,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-import collections
 import csv
 import glob
 import json
 import os
 import textwrap
-from pathlib import Path
 
 import six
 
@@ -30,12 +28,12 @@ _CITATION = """\
 
 # TODO(xtrem):
 _DESCRIPTION = """\
-The Cross-lingual TRansfer Evaluation of Multilingual Encoders (XTREME) benchmark is a benchmark for the evaluation of 
-the cross-lingual generalization ability of pre-trained multilingual models. It covers 40 typologically diverse languages 
-(spanning 12 language families) and includes nine tasks that collectively require reasoning about different levels of 
-syntax and semantics. The languages in XTREME are selected to maximize language diversity, coverage in existing tasks, 
-and availability of training data. Among these are many under-studied languages, such as the Dravidian languages Tamil 
-(spoken in southern India, Sri Lanka, and Singapore), Telugu and Malayalam (spoken mainly in southern India), and the 
+The Cross-lingual TRansfer Evaluation of Multilingual Encoders (XTREME) benchmark is a benchmark for the evaluation of
+the cross-lingual generalization ability of pre-trained multilingual models. It covers 40 typologically diverse languages
+(spanning 12 language families) and includes nine tasks that collectively require reasoning about different levels of
+syntax and semantics. The languages in XTREME are selected to maximize language diversity, coverage in existing tasks,
+and availability of training data. Among these are many under-studied languages, such as the Dravidian languages Tamil
+(spoken in southern India, Sri Lanka, and Singapore), Telugu and Malayalam (spoken mainly in southern India), and the
 Niger-Congo languages Swahili and Yoruba, spoken in Africa.
 """
 _MLQA_LANG = ["ar", "de", "vi", "zh", "en", "es", "hi"]
@@ -177,11 +175,11 @@ for lang in _UD_POS_LANG:
 
 _DESCRIPTIONS = {
     "tydiqa": textwrap.dedent(
-        """\Gold passage task (GoldP): Given a passage that is guaranteed to contain the 
-             answer, predict the single contiguous span of characters that answers the question. This is more similar to 
-             existing reading comprehension datasets (as opposed to the information-seeking task outlined above). 
-             This task is constructed with two goals in mind: (1) more directly comparing with prior work and (2) providing 
-             a simplified way for researchers to use TyDi QA by providing compatibility with existing code for SQuAD 1.1, 
+        """Gold passage task (GoldP): Given a passage that is guaranteed to contain the
+             answer, predict the single contiguous span of characters that answers the question. This is more similar to
+             existing reading comprehension datasets (as opposed to the information-seeking task outlined above).
+             This task is constructed with two goals in mind: (1) more directly comparing with prior work and (2) providing
+             a simplified way for researchers to use TyDi QA by providing compatibility with existing code for SQuAD 1.1,
              XQuAD, and MLQA. Toward these goals, the gold passage task differs from the primary task in several ways:
              only the gold answer passage is provided rather than the entire Wikipedia article;
              unanswerable questions have been discarded, similar to MLQA and XQuAD;
@@ -191,57 +189,57 @@ _DESCRIPTIONS = {
     ),
     "XNLI": textwrap.dedent(
         """
-          The Cross-lingual Natural Language Inference (XNLI) corpus is a crowd-sourced collection of 5,000 test and 
-          2,500 dev pairs for the MultiNLI corpus. The pairs are annotated with textual entailment and translated into 
-          14 languages: French, Spanish, German, Greek, Bulgarian, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, 
-          Hindi, Swahili and Urdu. This results in 112.5k annotated pairs. Each premise can be associated with the 
-          corresponding hypothesis in the 15 languages, summing up to more than 1.5M combinations. The corpus is made to 
-          evaluate how to perform inference in any language (including low-resources ones like Swahili or Urdu) when only 
-          English NLI data is available at training time. One solution is cross-lingual sentence encoding, for which XNLI 
+          The Cross-lingual Natural Language Inference (XNLI) corpus is a crowd-sourced collection of 5,000 test and
+          2,500 dev pairs for the MultiNLI corpus. The pairs are annotated with textual entailment and translated into
+          14 languages: French, Spanish, German, Greek, Bulgarian, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese,
+          Hindi, Swahili and Urdu. This results in 112.5k annotated pairs. Each premise can be associated with the
+          corresponding hypothesis in the 15 languages, summing up to more than 1.5M combinations. The corpus is made to
+          evaluate how to perform inference in any language (including low-resources ones like Swahili or Urdu) when only
+          English NLI data is available at training time. One solution is cross-lingual sentence encoding, for which XNLI
           is an evaluation benchmark."""
     ),
     "PAWS-X": textwrap.dedent(
         """
-          This dataset contains 23,659 human translated PAWS evaluation pairs and 296,406 machine translated training 
-          pairs in six typologically distinct languages: French, Spanish, German, Chinese, Japanese, and Korean. All 
+          This dataset contains 23,659 human translated PAWS evaluation pairs and 296,406 machine translated training
+          pairs in six typologically distinct languages: French, Spanish, German, Chinese, Japanese, and Korean. All
           translated pairs are sourced from examples in PAWS-Wiki."""
     ),
     "XQuAD": textwrap.dedent(
         """\
-          XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question 
-          answering performance. The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from 
-          the development set of SQuAD v1.1 (Rajpurkar et al., 2016) together with their professional translations into 
-          ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi. Consequently, 
+          XQuAD (Cross-lingual Question Answering Dataset) is a benchmark dataset for evaluating cross-lingual question
+          answering performance. The dataset consists of a subset of 240 paragraphs and 1190 question-answer pairs from
+          the development set of SQuAD v1.1 (Rajpurkar et al., 2016) together with their professional translations into
+          ten languages: Spanish, German, Greek, Russian, Turkish, Arabic, Vietnamese, Thai, Chinese, and Hindi. Consequently,
           the dataset is entirely parallel across 11 languages."""
     ),
     "MLQA": textwrap.dedent(
         """\
           MLQA (MultiLingual Question Answering) is a benchmark dataset for evaluating cross-lingual question answering performance.
     MLQA consists of over 5K extractive QA instances (12K in English) in SQuAD format in seven languages - English, Arabic,
-    German, Spanish, Hindi, Vietnamese and Simplified Chinese. MLQA is highly parallel, with QA instances parallel between 
+    German, Spanish, Hindi, Vietnamese and Simplified Chinese. MLQA is highly parallel, with QA instances parallel between
     4 different languages on average."""
     ),
     "tatoeba": textwrap.dedent(
         """\
           his data is extracted from the Tatoeba corpus, dated Saturday 2018/11/17.
 
-          For each languages, we have selected 1000 English sentences and their translations, if available. Please check 
+          For each languages, we have selected 1000 English sentences and their translations, if available. Please check
           this paper for a description of the languages, their families and scripts as well as baseline results.
-        
-          Please note that the English sentences are not identical for all language pairs. This means that the results are 
-          not directly comparable across languages. In particular, the sentences tend to have less variety for several 
+
+          Please note that the English sentences are not identical for all language pairs. This means that the results are
+          not directly comparable across languages. In particular, the sentences tend to have less variety for several
           low-resource languages, e.g. "Tom needed water", "Tom needs water", "Tom is getting water", ...
                     """
     ),
     "bucc18": textwrap.dedent(
-        """\Building and Using Comparable Corpora
+        """Building and Using Comparable Corpora
           """
     ),
     "udpos": textwrap.dedent(
         """\
-    Universal Dependencies (UD) is a framework for consistent annotation of grammar (parts of speech, morphological 
-    features, and syntactic dependencies) across different human languages. UD is an open community effort with over 200 
-    contributors producing more than 100 treebanks in over 70 languages. If you’re new to UD, you should start by reading 
+    Universal Dependencies (UD) is a framework for consistent annotation of grammar (parts of speech, morphological
+    features, and syntactic dependencies) across different human languages. UD is an open community effort with over 200
+    contributors producing more than 100 treebanks in over 70 languages. If you’re new to UD, you should start by reading
     the first part of the Short Introduction and then browsing the annotation guidelines.
     """
     ),
@@ -254,8 +252,8 @@ _DESCRIPTIONS = {
     ),
     "PAN-X": textwrap.dedent(
         """\
-    The WikiANN dataset (Pan et al. 2017) is a dataset with NER annotations for PER, ORG and LOC. It has been 
-    constructed using the linked entities in Wikipedia pages for 282 different languages including Danish. The dataset 
+    The WikiANN dataset (Pan et al. 2017) is a dataset with NER annotations for PER, ORG and LOC. It has been
+    constructed using the linked entities in Wikipedia pages for 282 different languages including Danish. The dataset
     can be loaded with the DaNLP package:"""
     ),
 }
@@ -282,7 +280,7 @@ _CITATIONS = {
                          and Schwenk, Holger
                          and Stoyanov, Veselin",
           title = "XNLI: Evaluating Cross-lingual Sentence Representations",
-          booktitle = "Proceedings of the 2018 Conference on Empirical Methods 
+          booktitle = "Proceedings of the 2018 Conference on Empirical Methods
                        in Natural Language Processing",
           year = "2018",
           publisher = "Association for Computational Linguistics",
@@ -356,7 +354,7 @@ _CITATIONS = {
 }
 
 _TEXT_FEATURES = {
-    "XNLI": {"language": "language", "sentence1": "sentence1", "sentence2": "sentence2",},
+    "XNLI": {"language": "language", "sentence1": "sentence1", "sentence2": "sentence2"},
     "tydiqa": {"id": "id", "title": "title", "context": "context", "question": "question", "answers": "answers"},
     "XQuAD": {"id": "id", "context": "context", "question": "question", "answers": "answers"},
     "MLQA": {"id": "id", "title": "title", "context": "context", "question": "question", "answers": "answers"},
@@ -423,8 +421,8 @@ class Xtreme(nlp.GeneratorBasedBuilder):
     VERSION = nlp.Version("0.1.0")
     MANUAL_DOWNLOAD_INSTRUCTIONS = """\
      You need to manually download the AmazonPhotos.zip file on Amazon Cloud Drive
-     (https://www.amazon.com/clouddrive/share/d3KGCRCIYwhKJF0H3eWA26hjg2ZCRhjpEQtDL70FSBN) and save the file under <path/to/folder>AmazonPhotos.zip 
-    
+     (https://www.amazon.com/clouddrive/share/d3KGCRCIYwhKJF0H3eWA26hjg2ZCRhjpEQtDL70FSBN) and save the file under <path/to/folder>AmazonPhotos.zip
+
     """
     BUILDER_CONFIGS = [
         XtremeConfig(
@@ -611,7 +609,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
 
             lang = self.config.name.split(".")[1]
             data_dir = os.path.join(data_dir, "*_" + lang + "*")
-            folders = glob.glob(data_dir)
+            folders = sorted(glob.glob(data_dir))
 
             if lang == "Kazakh":
                 return [
@@ -622,7 +620,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                             "filepath": [
                                 os.path.join(folder, file)
                                 for folder in folders
-                                for file in os.listdir(folder)
+                                for file in sorted(os.listdir(folder))
                                 if "test" in file and file.endswith(".conllu")
                             ]
                         },
@@ -634,7 +632,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                             "filepath": [
                                 os.path.join(folder, file)
                                 for folder in folders
-                                for file in os.listdir(folder)
+                                for file in sorted(os.listdir(folder))
                                 if "train" in file and file.endswith(".conllu")
                             ]
                         },
@@ -649,7 +647,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                             "filepath": [
                                 os.path.join(folder, file)
                                 for folder in folders
-                                for file in os.listdir(folder)
+                                for file in sorted(os.listdir(folder))
                                 if "test" in file and file.endswith(".conllu")
                             ]
                         },
@@ -664,7 +662,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                             "filepath": [
                                 os.path.join(folder, file)
                                 for folder in folders
-                                for file in os.listdir(folder)
+                                for file in sorted(os.listdir(folder))
                                 if "NYUAD" not in folder and "dev" in file and file.endswith(".conllu")
                             ]
                             # we exclude Arabic NYUAD which deos not contains any word, only _
@@ -677,7 +675,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                             "filepath": [
                                 os.path.join(folder, file)
                                 for folder in folders
-                                for file in os.listdir(folder)
+                                for file in sorted(os.listdir(folder))
                                 if "NYUAD" not in folder and "test" in file and file.endswith(".conllu")
                             ]
                         },
@@ -689,7 +687,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                             "filepath": [
                                 os.path.join(folder, file)
                                 for folder in folders
-                                for file in os.listdir(folder)
+                                for file in sorted(os.listdir(folder))
                                 if "NYUAD" not in folder and "train" in file and file.endswith(".conllu")
                             ]
                         },
@@ -769,7 +767,7 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                                 "context": context,
                                 "question": question,
                                 "id": id_,
-                                "answers": {"answer_start": answer_starts, "text": answers,},
+                                "answers": {"answer_start": answer_starts, "text": answers},
                             }
         if self.config.name == "XNLI":
             with open(filepath) as f:
@@ -806,10 +804,10 @@ class Xtreme(nlp.GeneratorBasedBuilder):
                                 "context": context,
                                 "question": question,
                                 "id": id_,
-                                "answers": {"answer_start": answer_starts, "text": answers,},
+                                "answers": {"answer_start": answer_starts, "text": answers},
                             }
         if self.config.name.startswith("bucc18"):
-            files = os.listdir(filepath)
+            files = sorted(os.listdir(filepath))
             target_file = "/"
             source_file = "/"
             source_target_file = "/"


### PR DESCRIPTION
This PR makes all datasets loading deterministic by applying `sorted()` to all `glob.glob` and `os.listdir` statements.

Are there other "non-deterministic" functions apart from `glob.glob()` and `os.listdir()` that you can think of @thomwolf @lhoestq @mariamabarham @jplu ?

**Important** 
It does break backward compatibility for these datasets because
1. When loading the complete dataset the order in which the examples are saved is different now
2. When loading only part of a split, the examples themselves might be different.

@patrickvonplaten - the nlp / longformer notebook has to be updated since the examples might now be different