### PR TITLE
Remove checksum download in c4

### DIFF
--- a/datasets/c4/c4.py
+++ b/datasets/c4/c4.py
@@ -172,7 +172,6 @@ class C4(nlp.BeamBasedBuilder):
         )
 
     def _split_generators(self, dl_manager, pipeline):
-        dl_manager.download_checksums(_CHECKSUMS_URL)
 
         # We will automatically down the default CC version(s), but others need to
         # be manually downloaded.


### PR DESCRIPTION
There was a line from the original tfds script that was still there and causing issues when loading the c4 script. This one should fix #233 and allow anyone to load the c4 script to generate the dataset