### PR TITLE
Better access to all dataset information

### DIFF
--- a/datasets/c4/c4_utils.py
+++ b/datasets/c4/c4_utils.py
@@ -26,12 +26,11 @@ import re
 import threading
 
 import apache_beam as beam
+import langdetect
 import nltk
 import tensorflow.compat.v2 as tf
-from absl import logging
-
-import langdetect
 import tldextract
+from absl import logging
 
 
 # WET file constants

--- a/datasets/glue/glue.py
+++ b/datasets/glue/glue.py
@@ -522,7 +522,7 @@ class Glue(nlp.GeneratorBasedBuilder):
             # header.
             is_cola_non_test = self.config.name == "cola" and split != "test"
 
-            with open(data_file, encoding='utf8') as f:
+            with open(data_file, encoding="utf8") as f:
                 reader = csv.DictReader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
                 if is_cola_non_test:
                     reader = csv.reader(f, delimiter="\t", quoting=csv.QUOTE_NONE)

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -38,8 +38,9 @@ logger = logging.getLogger(__name__)
 
 class DatasetInfoMixin(object):
     """ This base class exposes some attributes of DatasetInfo
-        at the base level of the Dataset for easy access. 
+        at the base level of the Dataset for easy access.
     """
+
     def __init__(self, info, split):
         self._info = info
         self._split = split

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -36,7 +36,73 @@ from .utils import convert_tuples_in_lists, map_nested
 logger = logging.getLogger(__name__)
 
 
-class Dataset(object):
+class DatasetInfoMixin(object):
+    def __init__(self, info, split):
+        self._info = info
+        self._split = split
+
+    @property
+    def info(self):
+        return self._info
+
+    @property
+    def split(self):
+        return self._split
+
+    @property
+    def builder_name(self) -> str:
+        return self._info.builder_name
+
+    @property
+    def citation(self) -> str:
+        return self._info.citation
+
+    @property
+    def config_name(self) -> str:
+        return self._info.config_name
+
+    @property
+    def dataset_size(self) -> Optional[int]:
+        return self._info.dataset_size
+
+    @property
+    def description(self) -> str:
+        return self._info.description
+
+    @property
+    def download_checksums(self) -> Optional[dict]:
+        return self._info.download_checksums
+
+    @property
+    def download_size(self) -> Optional[int]:
+        return self._info.download_size
+
+    @property
+    def features(self):
+        return self._info.features
+
+    @property
+    def homepage(self) -> Optional[str]:
+        return self._info.homepage
+
+    @property
+    def license(self) -> Optional[str]:
+        return self._info.license
+
+    @property
+    def size_in_bytes(self) -> Optional[int]:
+        return self._info.size_in_bytes
+
+    @property
+    def supervised_keys(self):
+        return self._info.supervised_keys
+
+    @property
+    def version(self):
+        return self._info.version
+
+
+class Dataset(DatasetInfoMixin):
     """ A Dataset backed by an Arrow table or Record Batch.
     """
 
@@ -45,8 +111,9 @@ class Dataset(object):
         arrow_table: Union[pa.Table, pa.RecordBatch],
         data_files: Optional[List[dict]] = None,
         info: Optional[Any] = None,
+        split: Optional[Any] = None,
     ):
-        self._info = info
+        super().__init__(info=info, split=split)
         self._data: pa.Table = arrow_table
         self._data_files: List[dict] = data_files if data_files is not None else []
         self._format_type = None
@@ -68,10 +135,6 @@ class Dataset(object):
         f = pa.ipc.open_stream(mmap)
         pa_table = f.read_all()
         return cls(pa_table)
-
-    @property
-    def info(self):
-        return self._info
 
     @property
     def data(self):

--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -121,6 +121,8 @@ class ClassLabel:
     names_file: str = None
     id: Optional[str] = None
     # Automatically constructed
+    dtype: ClassVar[str] = "int64"
+    pa_type: ClassVar[Any] = pa.int64()
     _str2int: ClassVar[Dict[str, int]] = None
     _int2str: ClassVar[Dict[int, int]] = None
     _type: str = "ClassLabel"
@@ -162,7 +164,7 @@ class ClassLabel:
             )
 
     def __call__(self):
-        return pa.int64()
+        return self.pa_type
 
     def str2int(self, str_value):
         """Conversion class name string => integer."""
@@ -264,6 +266,8 @@ class Translation:
     languages: List[str]
     id: Optional[str] = None
     # Automatically constructed
+    dtype: ClassVar[str] = "dict"
+    pa_type: ClassVar[Any] = None
     _type: str = "Translation"
 
     def __call__(self):
@@ -316,6 +320,8 @@ class TranslationVariableLanguages:
     num_languages: int = None
     id: Optional[str] = None
     # Automatically constructed
+    dtype: ClassVar[str] = "dict"
+    pa_type: ClassVar[Any] = None
     _type: str = "TranslationVariableLanguages"
 
     def __post_init__(self):
@@ -359,6 +365,8 @@ class Sequence:
     length: int = -1
     id: Optional[str] = None
     # Automatically constructed
+    dtype: ClassVar[str] = "list"
+    pa_type: ClassVar[Any] = None
     _type: str = "Sequence"
 
 

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -451,7 +451,7 @@ def load_dataset(
     ignore_verifications: bool = False,
     save_infos: bool = False,
     **config_kwargs,
-) -> Dataset:
+) -> Union[Dict[Split, Dataset], Dataset]:
     r"""Load a dataset
 
         This method does the following under the hood:

--- a/src/nlp/metric.py
+++ b/src/nlp/metric.py
@@ -36,10 +36,10 @@ class Metric(object):
     def __init__(
         self,
         name: str = None,
+        experiment_id: Optional[str] = None,
         process_id: int = 0,
         num_process: int = 1,
         data_dir: Optional[str] = None,
-        experiment_id: Optional[str] = None,
         in_memory: bool = False,
         **kwargs,
     ):


### PR DESCRIPTION
Moves all the dataset info down one level from `dataset.info.XXX` to `dataset.XXX`
This way it's easier to access `dataset.feature['label']` for instance

Also, add the original split instructions used to create the dataset in `dataset.split`
Ex:
```
from nlp import load_dataset
stsb = load_dataset('glue', name='stsb', split='train')
stsb.split
>>> NamedSplit('train')
```