### PR TITLE
Add sort, shuffle, test_train_split and select methods

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -689,7 +689,8 @@ class Dataset(DatasetInfoMixin):
         # return map function
         return self.map(map_function, batched=True, with_indices=with_indices, arrow_schema=arrow_schema, **kwargs)
 
-    def sort(self,
+    def sort(
+        self,
         column: Optional[str] = None,
         indices: Optional[List[int]] = None,
         kind: str = None,
@@ -722,16 +723,18 @@ class Dataset(DatasetInfoMixin):
         if len(self) == 0:
             return self
 
-        assert (column is not None and isinstance(column, str)) or \
-            (indices is not None and isinstance(column, list)), "You must provide a column name or a list of indices"
-        assert column is None or indices is None, "You must provide either a column name or a list of indices but not both."
+        assert (column is not None and isinstance(column, str)) or (
+            indices is not None and isinstance(column, list)
+        ), "You must provide a column name or a list of indices"
+        assert (
+            column is None or indices is None
+        ), "You must provide either a column name or a list of indices but not both."
 
         # Check the column name
         if column is not None and column not in self._data.column_names:
             raise ValueError(
                 "Column name {} not in the dataset. Current columns in the dataset: {}".format(
-                    column,
-                    self._data.column_names,
+                    column, self._data.column_names,
                 )
             )
 
@@ -762,21 +765,12 @@ class Dataset(DatasetInfoMixin):
             writer = ArrowWriter(schema=self.schema, path=cache_file_name, writer_batch_size=writer_batch_size)
 
         if indices is None:
-            indices = self._getitem(
-                column,
-                format_type='numpy',
-                format_columns=None,
-                output_all_columns=False,
-            )
+            indices = self._getitem(column, format_type="numpy", format_columns=None, output_all_columns=False,)
             indices = np.argsort(indices, kind=kind)
 
         # Loop over single examples or batches and write to buffer/file if examples are to be updated
         for i in tqdm(indices):
-            example = self._getitem(
-                key=i,
-                format_type=None,
-                format_columns=None,
-            )
+            example = self._getitem(key=i.item(), format_type=None, format_columns=None,)
             writer.write(example)
 
         writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -382,7 +382,9 @@ class Dataset(DatasetInfoMixin):
                     if format_type == "pandas":
                         outputs = self._data[key].to_pandas(zero_copy_only=False)
                     elif format_type == "numpy":
-                        outputs = np.concatenate([arr.to_numpy(zero_copy_only=False) for arr in self._data[key].chunks])
+                        outputs = np.concatenate(
+                            [arr.to_numpy(zero_copy_only=False) for arr in self._data[key].chunks]
+                        )
                     else:
                         outputs = self._convert_outputs(self._data[key].to_pylist(), format_type=format_type)
                 else:
@@ -1033,8 +1035,10 @@ class Dataset(DatasetInfoMixin):
                     test_cache_file_name = self._get_cache_file_path(self.train_test_split, test_kwargs)
             if os.path.exists(train_cache_file_name) and os.path.exists(test_cache_file_name) and load_from_cache_file:
                 logger.info("Loading cached split dataset at %s and %s", train_cache_file_name, test_cache_file_name)
-                return {'train': Dataset.from_file(train_cache_file_name, info=self.info, split=self.split),
-                        'test': Dataset.from_file(test_cache_file_name, info=self.info, split=self.split)}
+                return {
+                    "train": Dataset.from_file(train_cache_file_name, info=self.info, split=self.split),
+                    "test": Dataset.from_file(test_cache_file_name, info=self.info, split=self.split),
+                }
 
         if not shuffle:
             train_indices = np.arange(n_train)

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -919,7 +919,7 @@ class Dataset(DatasetInfoMixin):
                     If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the test split.
                     If int, represents the absolute number of test samples.
                     If None, the value is set to the complement of the train size.
-                    If train_size is also None, raise an error.
+                    If train_size is also None, it will be set to 0.25.
                 `train_size` (Optional `np.random.Generator`): Size of the train split
                     If float, should be between 0.0 and 1.0 and represent the proportion of the dataset to include in the train split.
                     If int, represents the absolute number of train samples.
@@ -945,7 +945,7 @@ class Dataset(DatasetInfoMixin):
             return self
 
         if test_size is None and train_size is None:
-            raise ValueError("At least one of test_size and train_size must be provided.")
+            test_size = 0.25
 
         # Safety checks similar to scikit-learn's ones.
         # (adapted from https://github.com/scikit-learn/scikit-learn/blob/fd237278e895b42abe8d8d09105cbb82dc2cbba7/sklearn/model_selection/_split.py#L1750)

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -152,11 +152,16 @@ class BaseDatasetTest(TestCase):
             self.assertEqual(len(dset), 10)
             self.assertEqual(dset[0]["filename"], "my_name-train_8")
             self.assertEqual(dset[1]["filename"], "my_name-train_9")
-
+            # Sort
             tmp_file = os.path.join(tmp_dir, "test_3.arrow")
             dset_sorted = dset.sort("filename", cache_file_name=tmp_file)
             for i, row in enumerate(dset_sorted):
                 self.assertEqual(int(row["filename"][-1]), i)
+            # Sort reversed
+            tmp_file = os.path.join(tmp_dir, "test_4.arrow")
+            dset_sorted = dset.sort("filename", cache_file_name=tmp_file, reverse=True)
+            for i, row in enumerate(dset_sorted):
+                self.assertEqual(int(row["filename"][-1]), len(dset_sorted) - 1 - i)
 
     def test_train_test_split(self):
         dset = self._create_dummy_dataset()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -123,7 +123,7 @@ class BaseDatasetTest(TestCase):
             dset_select_even = dset.select(indices, cache_file_name=tmp_file)
             self.assertEqual(len(dset_select_even), 15)
             for row in dset_select_even:
-                self.assertEqual(int(row['filename'][-1]) % 2, 0)
+                self.assertEqual(int(row["filename"][-1]) % 2, 0)
 
     def test_shuffle(self):
         dset = self._create_dummy_dataset()
@@ -132,13 +132,13 @@ class BaseDatasetTest(TestCase):
             tmp_file = os.path.join(tmp_dir, "test.arrow")
             dset_shuffled = dset.shuffle(seed=1234, cache_file_name=tmp_file)
             self.assertEqual(len(dset_shuffled), 30)
-            self.assertEqual(dset_shuffled[0]['filename'], 'my_name-train_28')
-            self.assertEqual(dset_shuffled[2]['filename'], 'my_name-train_10')
+            self.assertEqual(dset_shuffled[0]["filename"], "my_name-train_28")
+            self.assertEqual(dset_shuffled[2]["filename"], "my_name-train_10")
 
             # Reproductibility
             tmp_file = os.path.join(tmp_dir, "test_2.arrow")
             dset_shuffled_2 = dset.shuffle(seed=1234, cache_file_name=tmp_file)
-            self.assertListEqual(dset_shuffled['filename'], dset_shuffled_2['filename'])
+            self.assertListEqual(dset_shuffled["filename"], dset_shuffled_2["filename"])
 
     def test_sort(self):
         dset = self._create_dummy_dataset()
@@ -150,13 +150,13 @@ class BaseDatasetTest(TestCase):
             tmp_file = os.path.join(tmp_dir, "test_2.arrow")
             dset = dset.shuffle(seed=1234, cache_file_name=tmp_file)
             self.assertEqual(len(dset), 10)
-            self.assertEqual(dset[0]['filename'], 'my_name-train_8')
-            self.assertEqual(dset[1]['filename'], 'my_name-train_9')
+            self.assertEqual(dset[0]["filename"], "my_name-train_8")
+            self.assertEqual(dset[1]["filename"], "my_name-train_9")
 
             tmp_file = os.path.join(tmp_dir, "test_3.arrow")
-            dset_sorted = dset.sort('filename', cache_file_name=tmp_file)
+            dset_sorted = dset.sort("filename", cache_file_name=tmp_file)
             for i, row in enumerate(dset_sorted):
-                self.assertEqual(int(row['filename'][-1]), i)
+                self.assertEqual(int(row["filename"][-1]), i)
 
     def test_train_test_split(self):
         dset = self._create_dummy_dataset()
@@ -164,28 +164,64 @@ class BaseDatasetTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_file = os.path.join(tmp_dir, "test.arrow")
             tmp_file_2 = os.path.join(tmp_dir, "test_2.arrow")
-            dset_dict = dset.train_test_split(test_size=10, shuffle=False, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2)
-            self.assertListEqual(list(dset_dict.keys()), ['train', 'test'])
-            dset_train = dset_dict['train']
-            dset_test = dset_dict['test']
+            dset_dict = dset.train_test_split(
+                test_size=10, shuffle=False, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2
+            )
+            self.assertListEqual(list(dset_dict.keys()), ["train", "test"])
+            dset_train = dset_dict["train"]
+            dset_test = dset_dict["test"]
 
             self.assertEqual(len(dset_train), 20)
             self.assertEqual(len(dset_test), 10)
-            self.assertEqual(dset_train[0]['filename'], 'my_name-train_0')
-            self.assertEqual(dset_train[-1]['filename'], 'my_name-train_19')
-            self.assertEqual(dset_test[0]['filename'], 'my_name-train_20')
-            self.assertEqual(dset_test[-1]['filename'], 'my_name-train_29')
+            self.assertEqual(dset_train[0]["filename"], "my_name-train_0")
+            self.assertEqual(dset_train[-1]["filename"], "my_name-train_19")
+            self.assertEqual(dset_test[0]["filename"], "my_name-train_20")
+            self.assertEqual(dset_test[-1]["filename"], "my_name-train_29")
 
             tmp_file = os.path.join(tmp_dir, "test_3.arrow")
             tmp_file_2 = os.path.join(tmp_dir, "test_4.arrow")
-            dset_dict = dset.train_test_split(test_size=0.5, shuffle=False, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2)
-            self.assertListEqual(list(dset_dict.keys()), ['train', 'test'])
-            dset_train = dset_dict['train']
-            dset_test = dset_dict['test']
+            dset_dict = dset.train_test_split(
+                test_size=0.5, shuffle=False, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2
+            )
+            self.assertListEqual(list(dset_dict.keys()), ["train", "test"])
+            dset_train = dset_dict["train"]
+            dset_test = dset_dict["test"]
 
             self.assertEqual(len(dset_train), 15)
             self.assertEqual(len(dset_test), 15)
-            self.assertEqual(dset_train[0]['filename'], 'my_name-train_0')
-            self.assertEqual(dset_train[-1]['filename'], 'my_name-train_14')
-            self.assertEqual(dset_test[0]['filename'], 'my_name-train_15')
-            self.assertEqual(dset_test[-1]['filename'], 'my_name-train_29')
+            self.assertEqual(dset_train[0]["filename"], "my_name-train_0")
+            self.assertEqual(dset_train[-1]["filename"], "my_name-train_14")
+            self.assertEqual(dset_test[0]["filename"], "my_name-train_15")
+            self.assertEqual(dset_test[-1]["filename"], "my_name-train_29")
+
+            tmp_file = os.path.join(tmp_dir, "test_5.arrow")
+            tmp_file_2 = os.path.join(tmp_dir, "test_6.arrow")
+            dset_dict = dset.train_test_split(
+                train_size=10, shuffle=False, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2
+            )
+            self.assertListEqual(list(dset_dict.keys()), ["train", "test"])
+            dset_train = dset_dict["train"]
+            dset_test = dset_dict["test"]
+
+            self.assertEqual(len(dset_train), 10)
+            self.assertEqual(len(dset_test), 20)
+            self.assertEqual(dset_train[0]["filename"], "my_name-train_0")
+            self.assertEqual(dset_train[-1]["filename"], "my_name-train_9")
+            self.assertEqual(dset_test[0]["filename"], "my_name-train_10")
+            self.assertEqual(dset_test[-1]["filename"], "my_name-train_29")
+
+            tmp_file = os.path.join(tmp_dir, "test_7.arrow")
+            tmp_file_2 = os.path.join(tmp_dir, "test_8.arrow")
+            dset_dict = dset.train_test_split(
+                train_size=10, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2
+            )
+            self.assertListEqual(list(dset_dict.keys()), ["train", "test"])
+            dset_train = dset_dict["train"]
+            dset_test = dset_dict["test"]
+
+            self.assertEqual(len(dset_train), 10)
+            self.assertEqual(len(dset_test), 20)
+            self.assertNotEqual(dset_train[0]["filename"], "my_name-train_0")
+            self.assertNotEqual(dset_train[-1]["filename"], "my_name-train_9")
+            self.assertNotEqual(dset_test[0]["filename"], "my_name-train_10")
+            self.assertNotEqual(dset_test[-1]["filename"], "my_name-train_29")

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -112,3 +112,80 @@ class BaseDatasetTest(TestCase):
             tmp_file = os.path.join(tmp_dir, "test.arrow")
             dset_filter_even_num = dset.filter(lambda x: (int(x["filename"][-1]) % 2 == 0), cache_file_name=tmp_file)
             self.assertEqual(len(dset_filter_even_num), 15)
+
+    def test_select(self):
+        dset = self._create_dummy_dataset()
+        # select every two example
+        indices = list(range(0, len(dset), 2))
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            dset_select_even = dset.select(indices, cache_file_name=tmp_file)
+            self.assertEqual(len(dset_select_even), 15)
+            for row in dset_select_even:
+                self.assertEqual(int(row['filename'][-1]) % 2, 0)
+
+    def test_shuffle(self):
+        dset = self._create_dummy_dataset()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            dset_shuffled = dset.shuffle(seed=1234, cache_file_name=tmp_file)
+            self.assertEqual(len(dset_shuffled), 30)
+            self.assertEqual(dset_shuffled[0]['filename'], 'my_name-train_28')
+            self.assertEqual(dset_shuffled[2]['filename'], 'my_name-train_10')
+
+            # Reproductibility
+            tmp_file = os.path.join(tmp_dir, "test_2.arrow")
+            dset_shuffled_2 = dset.shuffle(seed=1234, cache_file_name=tmp_file)
+            self.assertListEqual(dset_shuffled['filename'], dset_shuffled_2['filename'])
+
+    def test_sort(self):
+        dset = self._create_dummy_dataset()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Keep only 10 examples
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            dset = dset.select(range(10), cache_file_name=tmp_file)
+            tmp_file = os.path.join(tmp_dir, "test_2.arrow")
+            dset = dset.shuffle(seed=1234, cache_file_name=tmp_file)
+            self.assertEqual(len(dset), 10)
+            self.assertEqual(dset[0]['filename'], 'my_name-train_8')
+            self.assertEqual(dset[1]['filename'], 'my_name-train_9')
+
+            tmp_file = os.path.join(tmp_dir, "test_3.arrow")
+            dset_sorted = dset.sort('filename', cache_file_name=tmp_file)
+            for i, row in enumerate(dset_sorted):
+                self.assertEqual(int(row['filename'][-1]), i)
+
+    def test_train_test_split(self):
+        dset = self._create_dummy_dataset()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            tmp_file_2 = os.path.join(tmp_dir, "test_2.arrow")
+            dset_dict = dset.train_test_split(test_size=10, shuffle=False, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2)
+            self.assertListEqual(list(dset_dict.keys()), ['train', 'test'])
+            dset_train = dset_dict['train']
+            dset_test = dset_dict['test']
+
+            self.assertEqual(len(dset_train), 20)
+            self.assertEqual(len(dset_test), 10)
+            self.assertEqual(dset_train[0]['filename'], 'my_name-train_0')
+            self.assertEqual(dset_train[-1]['filename'], 'my_name-train_19')
+            self.assertEqual(dset_test[0]['filename'], 'my_name-train_20')
+            self.assertEqual(dset_test[-1]['filename'], 'my_name-train_29')
+
+            tmp_file = os.path.join(tmp_dir, "test_3.arrow")
+            tmp_file_2 = os.path.join(tmp_dir, "test_4.arrow")
+            dset_dict = dset.train_test_split(test_size=0.5, shuffle=False, train_cache_file_name=tmp_file, test_cache_file_name=tmp_file_2)
+            self.assertListEqual(list(dset_dict.keys()), ['train', 'test'])
+            dset_train = dset_dict['train']
+            dset_test = dset_dict['test']
+
+            self.assertEqual(len(dset_train), 15)
+            self.assertEqual(len(dset_test), 15)
+            self.assertEqual(dset_train[0]['filename'], 'my_name-train_0')
+            self.assertEqual(dset_train[-1]['filename'], 'my_name-train_14')
+            self.assertEqual(dset_test[0]['filename'], 'my_name-train_15')
+            self.assertEqual(dset_test[-1]['filename'], 'my_name-train_29')


### PR DESCRIPTION
Add a bunch of methods to reorder/split/select rows in a dataset:
- `dataset.select(indices)`: Create a new dataset with rows selected following the list/array of indices (which can have a different size than the dataset and contain duplicated indices, the only constrain is that all the integers in the list must be smaller than the dataset size, otherwise we're indexing outside the dataset...)
- `dataset.sort(column_name)`: sort a dataset according to a column (has to be a column with a numpy compatible type)
- `dataset.shuffle(seed)`: shuffle a dataset rows
- `dataset.train_test_split(test_size, train_size)`: Return a dictionary with two random train and test subsets (`train` and `test` ``Dataset`` splits)

All these methods are **not** in-place which means they return new ``Dataset``.
This is the default behavior in the library.

Fix #147 #166 #259 