### PR TITLE
Fix metric compute (original_instructions missing)

### DIFF
--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -22,7 +22,7 @@ import math
 import os
 import re
 from dataclasses import dataclass
-from typing import List, Optional, Any
+from typing import List, Optional
 
 import pyarrow as pa
 import pyarrow.parquet

--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -22,7 +22,7 @@ import math
 import os
 import re
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Any
 
 import pyarrow as pa
 import pyarrow.parquet
@@ -192,7 +192,7 @@ class BaseReader:
         return py_utils.map_nested(_read_instruction_to_ds, instructions)
 
     def read_files(
-        self, files, original_instructions,
+        self, files, original_instructions=None,
     ):
         """Returns single Dataset instance for the set of file instructions.
 


### PR DESCRIPTION
When loading arrow data we added in cc8d250 a way to specify the instructions that were used to store them with the loaded dataset.
However metrics load data the same way but don't need instructions (we use one single file).

In this PR I just make `original_instructions` optional when reading files to load a `Dataset` object.

This should fix #269 