### PR TITLE
Update dataset_info from gcs

### DIFF
--- a/datasets/cos_e/cos_e.py
+++ b/datasets/cos_e/cos_e.py
@@ -51,19 +51,19 @@ _CQA_V1_11_URL_DEV = "https://s3.amazonaws.com/commensenseqa/dev_rand_split.json
 _CQA_V1_11_URL_TEST = "https://s3.amazonaws.com/commensenseqa/test_rand_split_no_answers.jsonl"
 
 _CQA_V1_0_URL_TRAIN = os.path.join(_COS_E_URL, "v1.0/train_rand_split.jsonl")
-_CQA_V1_0_URL_DEV = os.path.join(_COS_E_URL,"v1.0/dev_rand_split.jsonl")
+_CQA_V1_0_URL_DEV = os.path.join(_COS_E_URL, "v1.0/dev_rand_split.jsonl")
 _CQA_V1_0_URL_TEST = os.path.join(_COS_E_URL, "v1.0/test_rand_split_no_answers.jsonl")
-
 
 
 def _download_and_index_cqa(dl_manager, name):
     """Downloads CQA and returns it, indexed by id, for joining with Cos-E."""
 
     downloaded_files = dl_manager.download_and_extract(
-        {"cqa_train": _CQA_V1_11_URL_TRAIN if name == 'v1.11' else _CQA_V1_0_URL_TRAIN,
-          "cqa_dev": _CQA_V1_11_URL_DEV if name == 'v1.11' else _CQA_V1_0_URL_DEV,
-          "cqa_test": _CQA_V1_11_URL_TEST if name == 'v1.11' else _CQA_V1_0_URL_TEST
-         }
+        {
+            "cqa_train": _CQA_V1_11_URL_TRAIN if name == "v1.11" else _CQA_V1_0_URL_TRAIN,
+            "cqa_dev": _CQA_V1_11_URL_DEV if name == "v1.11" else _CQA_V1_0_URL_DEV,
+            "cqa_test": _CQA_V1_11_URL_TEST if name == "v1.11" else _CQA_V1_0_URL_TEST,
+        }
     )
 
     # NB: "cqa_test" is included in the files, but not in any of the CoS-E splits.
@@ -112,12 +112,14 @@ class CosE(nlp.GeneratorBasedBuilder):
 
     BUILDER_CONFIGS = [
         CosEConfig(
-            name="v1.0", description="cos-e version 1.0",
-            version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)")
+            name="v1.0",
+            description="cos-e version 1.0",
+            version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"),
         ),
         CosEConfig(
-            name="v1.11", description="cos-e version 1.11",
-            version=nlp.Version("1.11.0", "New split API (https://tensorflow.org/datasets/splits)")
+            name="v1.11",
+            description="cos-e version 1.11",
+            version=nlp.Version("1.11.0", "New split API (https://tensorflow.org/datasets/splits)"),
         ),
     ]
 
@@ -145,14 +147,14 @@ class CosE(nlp.GeneratorBasedBuilder):
         # NB: The CQA Dataset should be read only once, and only by callers who
         # want to _create_ the Cos-E dataset from scratch.
         cqa_indexed = _download_and_index_cqa(dl_manager, self.config.name)
-        if self.config.name == 'v1.11':
+        if self.config.name == "v1.11":
             files = dl_manager.download_and_extract(
                 {
                     "dev": [os.path.join(_COS_E_URL, "v1.11/cose_dev_v1.11_processed.jsonl")],
                     "train": [os.path.join(_COS_E_URL, "v1.11/cose_train_v1.11_processed.jsonl")],
                 }
             )
-        elif self.config.name == 'v1.0':
+        elif self.config.name == "v1.0":
             files = dl_manager.download_and_extract(
                 {
                     "dev": [os.path.join(_COS_E_URL, "v1.0/cose_dev_v1.0_processed.jsonl")],
@@ -160,7 +162,7 @@ class CosE(nlp.GeneratorBasedBuilder):
                 }
             )
         else:
-            raise ValueError('Unknown config name')
+            raise ValueError("Unknown config name")
 
         # We use the CoS-E/CQA dev set as our validation set.
         return [
@@ -170,7 +172,6 @@ class CosE(nlp.GeneratorBasedBuilder):
             nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION, gen_kwargs={"files": files["dev"], "cqa_indexed": cqa_indexed},
             ),
-
         ]
 
     def _generate_examples(self, files, **kwargs):

--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -22,7 +22,7 @@ import math
 import os
 import re
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import pyarrow as pa
 import pyarrow.parquet
@@ -30,6 +30,10 @@ import pyarrow.parquet
 from .arrow_dataset import Dataset
 from .naming import filename_for_dataset_split
 from .utils import cached_path, py_utils
+
+
+if TYPE_CHECKING:
+    from .info import DatasetInfo
 
 
 logger = logging.getLogger(__name__)
@@ -123,16 +127,16 @@ class BaseReader:
     Build a Dataset object out of Instruction instance(s).
     """
 
-    def __init__(self, path, info):
+    def __init__(self, path: str, info: Optional["DatasetInfo"]):
         """Initializes ArrowReader.
 
         Args:
             path (str): path where tfrecords are stored.
             info (DatasetInfo): info about the dataset.
         """
-        self._path = path
-        self._info = info
-        self._filetype_suffix = None
+        self._path: str = path
+        self._info: Optional["DatasetInfo"] = info
+        self._filetype_suffix: Optional[str] = None
 
     def _get_dataset_from_filename(self, filename_skip_take):
         """Returns a Dataset instance from given (filename, skip, take)."""
@@ -227,6 +231,8 @@ class BaseReader:
             remote_dataset_info = os.path.join(remote_cache_dir, "dataset_info.json")
             downloaded_dataset_info = cached_path(remote_dataset_info)
             os.rename(downloaded_dataset_info, os.path.join(cache_dir, "dataset_info.json"))
+            if self._info is not None:
+                self._info.update(self._info.from_directory(cache_dir))
         except ConnectionError:
             raise DatasetNotOnHfGcs()
         for split in self._info.splits:
@@ -245,7 +251,7 @@ class ArrowReader(BaseReader):
     This Reader uses memory mapping on arrow files.
     """
 
-    def __init__(self, path, info):
+    def __init__(self, path: str, info: Optional["DatasetInfo"]):
         """Initializes ArrowReader.
 
         Args:
@@ -276,7 +282,7 @@ class ParquetReader(BaseReader):
     This Reader uses memory mapping on parquet files.
     """
 
-    def __init__(self, path, info):
+    def __init__(self, path: str, info: Optional["DatasetInfo"]):
         """Initializes ParquetReader.
 
         Args:

--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -33,7 +33,7 @@ from .utils import cached_path, py_utils
 
 
 if TYPE_CHECKING:
-    from .info import DatasetInfo
+    from .info import DatasetInfo  # noqa: F401
 
 
 logger = logging.getLogger(__name__)

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -353,7 +353,11 @@ def prepare_module(
             else:
                 logger.info("Couldn't find dataset infos file at %s", dataset_infos)
         else:
-            logger.info("Found dataset infos file from %s to %s", dataset_infos, dataset_infos_path)
+            if local_dataset_infos_path is not None:
+                logger.info("Updating dataset infos file from %s to %s", dataset_infos, dataset_infos_path)
+                shutil.copyfile(local_dataset_infos_path, dataset_infos_path)
+            else:
+                logger.info("Found dataset infos file from %s to %s", dataset_infos, dataset_infos_path)
 
         # Record metadata associating original dataset path with local unique folder
         meta_path = local_file_path.split(".py")[0] + ".json"


### PR DESCRIPTION
Some datasets are hosted on gcs (wikipedia for example). In this PR I make sure that, when a user loads such datasets, the file_instructions are built using the dataset_info.json from gcs and not from the info extracted from the local `dataset_infos.json` (the one that contain the info for each config). Indeed local files may end up outdated.

Furthermore, to avoid outdated dataset_infos.json, I now make sure that each time you run `load_dataset` it also tries to update the file locally.
