### PR TITLE
Fix bertscore references

### DIFF
--- a/datasets/anli/anli.py
+++ b/datasets/anli/anli.py
@@ -18,8 +18,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os
 import json
+import os
 
 import nlp
 
@@ -47,10 +47,11 @@ It contains three rounds. Each round has train/dev/test splits.
 """
 
 stdnli_label = {
-    'e': "entailment",
-    'n': "neutral",
-    'c': "contradiction",
+    "e": "entailment",
+    "n": "neutral",
+    "c": "contradiction",
 }
+
 
 class ANLIConfig(nlp.BuilderConfig):
     """BuilderConfig for ANLI."""
@@ -83,7 +84,7 @@ class ANLI(nlp.GeneratorBasedBuilder):
                     "premise": nlp.Value("string"),
                     "hypothesis": nlp.Value("string"),
                     "label": nlp.features.ClassLabel(names=["entailment", "neutral", "contradiction"]),
-                    "reason": nlp.Value("string")
+                    "reason": nlp.Value("string"),
                 }
             ),
             # No default supervised_keys (as we have to pass both premise
@@ -99,9 +100,7 @@ class ANLI(nlp.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
 
-        downloaded_dir = dl_manager.download_and_extract(
-            "https://dl.fbaipublicfiles.com/anli/anli_v0.1.zip"
-        )
+        downloaded_dir = dl_manager.download_and_extract("https://dl.fbaipublicfiles.com/anli/anli_v0.1.zip")
 
         anli_path = os.path.join(downloaded_dir, "anli_v0.1")
 
@@ -113,19 +112,17 @@ class ANLI(nlp.GeneratorBasedBuilder):
 
         return [
             # Round 1
-            nlp.SplitGenerator(name='train_r1', gen_kwargs={"filepath": path_dict["R1"]["train"]}),
-            nlp.SplitGenerator(name='dev_r1', gen_kwargs={"filepath": path_dict["R1"]["dev"]}),
-            nlp.SplitGenerator(name='test_r1', gen_kwargs={"filepath": path_dict["R1"]["test"]}),
-
+            nlp.SplitGenerator(name="train_r1", gen_kwargs={"filepath": path_dict["R1"]["train"]}),
+            nlp.SplitGenerator(name="dev_r1", gen_kwargs={"filepath": path_dict["R1"]["dev"]}),
+            nlp.SplitGenerator(name="test_r1", gen_kwargs={"filepath": path_dict["R1"]["test"]}),
             # Round 2
-            nlp.SplitGenerator(name='train_r2', gen_kwargs={"filepath": path_dict["R2"]["train"]}),
-            nlp.SplitGenerator(name='dev_r2', gen_kwargs={"filepath": path_dict["R2"]["dev"]}),
-            nlp.SplitGenerator(name='test_r2', gen_kwargs={"filepath": path_dict["R2"]["test"]}),
-
+            nlp.SplitGenerator(name="train_r2", gen_kwargs={"filepath": path_dict["R2"]["train"]}),
+            nlp.SplitGenerator(name="dev_r2", gen_kwargs={"filepath": path_dict["R2"]["dev"]}),
+            nlp.SplitGenerator(name="test_r2", gen_kwargs={"filepath": path_dict["R2"]["test"]}),
             # Round 3
-            nlp.SplitGenerator(name='train_r3', gen_kwargs={"filepath": path_dict["R3"]["train"]}),
-            nlp.SplitGenerator(name='dev_r3', gen_kwargs={"filepath": path_dict["R3"]["dev"]}),
-            nlp.SplitGenerator(name='test_r3', gen_kwargs={"filepath": path_dict["R3"]["test"]}),
+            nlp.SplitGenerator(name="train_r3", gen_kwargs={"filepath": path_dict["R3"]["train"]}),
+            nlp.SplitGenerator(name="dev_r3", gen_kwargs={"filepath": path_dict["R3"]["dev"]}),
+            nlp.SplitGenerator(name="test_r3", gen_kwargs={"filepath": path_dict["R3"]["test"]}),
         ]
 
     def _generate_examples(self, filepath):
@@ -142,14 +139,14 @@ class ANLI(nlp.GeneratorBasedBuilder):
                 line = line.strip().decode("utf-8")
                 item = json.loads(line)
 
-                reason_text = ''
-                if 'reason' in item:
-                    reason_text = item['reason']
+                reason_text = ""
+                if "reason" in item:
+                    reason_text = item["reason"]
 
-                yield item['uid'], {
-                    "uid": item['uid'],
-                    "premise": item['context'],
-                    "hypothesis": item['hypothesis'],
-                    "label": stdnli_label[item['label']],
+                yield item["uid"], {
+                    "uid": item["uid"],
+                    "premise": item["context"],
+                    "hypothesis": item["hypothesis"],
+                    "label": stdnli_label[item["label"]],
                     "reason": reason_text,
                 }

--- a/datasets/c4/c4_utils.py
+++ b/datasets/c4/c4_utils.py
@@ -26,12 +26,11 @@ import re
 import threading
 
 import apache_beam as beam
+import langdetect
 import nltk
 import tensorflow.compat.v2 as tf
-from absl import logging
-
-import langdetect
 import tldextract
+from absl import logging
 
 
 # WET file constants

--- a/datasets/cos_e/cos_e.py
+++ b/datasets/cos_e/cos_e.py
@@ -51,18 +51,19 @@ _CQA_V1_11_URL_DEV = "https://s3.amazonaws.com/commensenseqa/dev_rand_split.json
 _CQA_V1_11_URL_TEST = "https://s3.amazonaws.com/commensenseqa/test_rand_split_no_answers.jsonl"
 
 _CQA_V1_0_URL_TRAIN = os.path.join(_COS_E_URL, "v1.0/train_rand_split.jsonl")
-_CQA_V1_0_URL_DEV = os.path.join(_COS_E_URL,"v1.0/dev_rand_split.jsonl")
+_CQA_V1_0_URL_DEV = os.path.join(_COS_E_URL, "v1.0/dev_rand_split.jsonl")
 _CQA_V1_0_URL_TEST = os.path.join(_COS_E_URL, "v1.0/test_rand_split_no_answers.jsonl")
+
 
 def _download_and_index_cqa(dl_manager, name):
     """Downloads CQA and returns it, indexed by id, for joining with Cos-E."""
 
     downloaded_files = dl_manager.download_and_extract(
-
-        {"cqa_train": _CQA_V1_11_URL_TRAIN if name == 'v1.11' else _CQA_V1_0_URL_TRAIN,
-          "cqa_dev": _CQA_V1_11_URL_DEV if name == 'v1.11' else _CQA_V1_0_URL_DEV,
-          "cqa_test": _CQA_V1_11_URL_TEST if name == 'v1.11' else _CQA_V1_0_URL_TEST
-         }
+        {
+            "cqa_train": _CQA_V1_11_URL_TRAIN if name == "v1.11" else _CQA_V1_0_URL_TRAIN,
+            "cqa_dev": _CQA_V1_11_URL_DEV if name == "v1.11" else _CQA_V1_0_URL_DEV,
+            "cqa_test": _CQA_V1_11_URL_TEST if name == "v1.11" else _CQA_V1_0_URL_TEST,
+        }
     )
 
     # NB: "cqa_test" is included in the files, but not in any of the CoS-E splits.
@@ -172,7 +173,6 @@ class CosE(nlp.GeneratorBasedBuilder):
             nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION, gen_kwargs={"files": files["dev"], "cqa_indexed": cqa_indexed},
             ),
-
         ]
 
     def _generate_examples(self, files, **kwargs):

--- a/datasets/xsum/xsum.py
+++ b/datasets/xsum/xsum.py
@@ -45,12 +45,10 @@ There are two features:
 """
 
 
-_URL = 'https://s3.amazonaws.com/datasets.huggingface.co/summarization/xsum.tar.gz'
+_URL = "https://s3.amazonaws.com/datasets.huggingface.co/summarization/xsum.tar.gz"
 
 _DOCUMENT = "document"
 _SUMMARY = "summary"
-
-
 
 
 class Xsum(nlp.GeneratorBasedBuilder):
@@ -71,19 +69,31 @@ class Xsum(nlp.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
-        
+
         dl_path = dl_manager.download_and_extract(_URL)
 
-        dl_path = os.path.join(dl_path, 'xsum')
+        dl_path = os.path.join(dl_path, "xsum")
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={"source": os.path.join(dl_path, 'train.source'), "target": os.path.join(dl_path, 'train.target')},
+                name=nlp.Split.TRAIN,
+                gen_kwargs={
+                    "source": os.path.join(dl_path, "train.source"),
+                    "target": os.path.join(dl_path, "train.target"),
+                },
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={"source": os.path.join(dl_path, 'val.source'), "target": os.path.join(dl_path, 'val.target')},
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={
+                    "source": os.path.join(dl_path, "val.source"),
+                    "target": os.path.join(dl_path, "val.target"),
+                },
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.TEST, gen_kwargs={"source": os.path.join(dl_path, 'test.source'), "target": os.path.join(dl_path, 'test.target')},
+                name=nlp.Split.TEST,
+                gen_kwargs={
+                    "source": os.path.join(dl_path, "test.source"),
+                    "target": os.path.join(dl_path, "test.target"),
+                },
             ),
         ]
 
@@ -93,7 +103,6 @@ class Xsum(nlp.GeneratorBasedBuilder):
             source = f1.readlines()
         with open(target) as f2:
             target = f2.readlines()
-        assert (len(source) == len(target))
-        for i in range(len(target)):    
+        assert len(source) == len(target)
+        for i in range(len(target)):
             yield i, {_DOCUMENT: source[i], _SUMMARY: target[i]}
-           

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -95,7 +95,6 @@ class BERTScore(nlp.Metric):
         all_layers=False,
         rescale_with_baseline=False,
     ):
-        print(">>>", predictions, references)
         if model_type is None:
             assert lang is not None, "either lang or model_type should be specified"
             model_type = bert_score.utils.lang2model[lang.lower()]

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -63,6 +63,7 @@ Returns:
     'hashcode': Hashcode of the library,
 """
 
+
 class BERTScore(nlp.Metric):
     def _info(self):
         return nlp.MetricInfo(
@@ -94,6 +95,7 @@ class BERTScore(nlp.Metric):
         all_layers=False,
         rescale_with_baseline=False,
     ):
+        print(">>>", predictions, references)
         if model_type is None:
             assert lang is not None, "either lang or model_type should be specified"
             model_type = bert_score.utils.lang2model[lang.lower()]
@@ -125,3 +127,21 @@ class BERTScore(nlp.Metric):
             'hashcode': hashcode,
         }
         return output_dict
+
+    def add_batch(self, predictions=None, references=None, **kwargs):
+        """ Add a batch of predictions and references for the metric's stack.
+        """
+        # Refefences can be strings or lists of strings
+        # Let's change strings to lists of strings with one element
+        if references is not None:
+            references = [[ref] if isinstance(ref, str) else ref for ref in references]
+        super().add_batch(predictions=predictions, references=references, **kwargs)
+
+    def add(self, prediction=None, reference=None, **kwargs):
+        """ Add one prediction and reference for the metric's stack.
+        """
+        # Refefences can be strings or lists of strings
+        # Let's change strings to lists of strings with one element
+        if isinstance(reference, str):
+            reference = [reference]
+        super().add(prediction=prediction, reference=reference, **kwargs)

--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -421,6 +421,8 @@ def encode_nested_example(schema, obj):
                     list_dict[k] = [encode_nested_example(sub_schema, o) for o in sub_objs]
                 return list_dict
         # schema.feature is not a dict
+        if isinstance(obj, str):  # don't interpret a string as a list
+            raise ValueError("Got a string but expected a list instead: '{}'".format(obj))
         return [encode_nested_example(schema.feature, o) for o in obj]
 
     # Object with special encoding:

--- a/src/nlp/metric.py
+++ b/src/nlp/metric.py
@@ -212,6 +212,7 @@ class Metric(object):
         """ Add one prediction and reference for the metric's stack.
         """
         example = {"predictions": prediction, "references": reference}
+        example = self.info.features.encode_example(example)
         if self.writer is None:
             self._init_writer()
         self.writer.write(example)


### PR DESCRIPTION
I added some type checking for metrics. There was an issue where a metric could interpret a string a a list. A `ValueError` is raised if a string is given instead of a list.

Moreover I added support for both strings and lists of strings for `references` in `bertscore`, as it is the case in the original code.

Both ways work:
```
import nlp

scorer = nlp.load_metric("bertscore")
with open("pred.txt") as p, open("ref.txt") as g:
    for lp, lg in zip(p, g):
        scorer.add(lp, [lg])
score = scorer.compute(lang="en")
```

```
import nlp

scorer = nlp.load_metric("bertscore")
with open("pred.txt") as p, open("ref.txt") as g:
    for lp, lg in zip(p, g):
        scorer.add(lp, lg)
score = scorer.compute(lang="en")
```

This should fix #295 and #238 