### PR TITLE
allow to move files across file systems

### DIFF
--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -21,6 +21,7 @@ import logging
 import math
 import os
 import re
+import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
@@ -230,7 +231,7 @@ class BaseReader:
         try:
             remote_dataset_info = os.path.join(remote_cache_dir, "dataset_info.json")
             downloaded_dataset_info = cached_path(remote_dataset_info)
-            os.rename(downloaded_dataset_info, os.path.join(cache_dir, "dataset_info.json"))
+            shutil.move(downloaded_dataset_info, os.path.join(cache_dir, "dataset_info.json"))
             if self._info is not None:
                 self._info.update(self._info.from_directory(cache_dir))
         except ConnectionError:
@@ -242,7 +243,7 @@ class BaseReader:
             for file_instruction in file_instructions:
                 remote_prepared_filename = os.path.join(remote_cache_dir, file_instruction["filename"])
                 downloaded_prepared_filename = cached_path(remote_prepared_filename)
-                os.rename(downloaded_prepared_filename, os.path.join(cache_dir, file_instruction["filename"]))
+                shutil.move(downloaded_prepared_filename, os.path.join(cache_dir, file_instruction["filename"]))
 
 
 class ArrowReader(BaseReader):

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -389,7 +389,7 @@ def get_from_cache(
             http_get(url, temp_file, proxies=proxies, resume_size=resume_size, user_agent=user_agent, cookies=cookies)
 
         logger.info("storing %s in cache at %s", url, cache_path)
-        os.rename(temp_file.name, cache_path)
+        shutil.move(temp_file.name, cache_path)
 
         logger.info("creating metadata file for %s", cache_path)
         meta = {"url": url, "etag": etag}


### PR DESCRIPTION
Users are allowed to use the `cache_dir` that they want.
Therefore it can happen that we try to move files across filesystems.
We were using `os.rename` that doesn't allow that, so I changed some of them to `shutil.move`.

This should fix #301