### PR TITLE
Specify utf-8 encoding for MRPC files

### DIFF
--- a/datasets/glue/glue.py
+++ b/datasets/glue/glue.py
@@ -556,7 +556,7 @@ class Glue(nlp.GeneratorBasedBuilder):
 
     def _generate_example_mrpc_files(self, mrpc_files, split):
         if split == "test":
-            with open(mrpc_files["test"]) as f:
+            with open(mrpc_files["test"], encoding="utf8") as f:
                 reader = csv.DictReader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
                 for n, row in enumerate(reader):
                     yield {
@@ -566,10 +566,10 @@ class Glue(nlp.GeneratorBasedBuilder):
                         "idx": n,
                     }
         else:
-            with open(mrpc_files["dev_ids"]) as f:
+            with open(mrpc_files["dev_ids"], encoding="utf8") as f:
                 reader = csv.reader(f, delimiter="\t", quoting=csv.QUOTE_NONE)
                 dev_ids = [[row[0], row[1]] for row in reader]
-            with open(mrpc_files["train"]) as f:
+            with open(mrpc_files["train"], encoding="utf8") as f:
                 # The first 3 bytes are the utf-8 BOM \xef\xbb\xbf, which messes with
                 # the Quality key.
                 f.seek(3)


### PR DESCRIPTION
Fixes #307, again probably a Windows-related issue.