### PR TITLE
Fixed singlular very minor spelling error

### DIFF
--- a/notebooks/Overview.ipynb
+++ b/notebooks/Overview.ipynb
@@ -3514,7 +3514,7 @@
       "source": [
         "## Modifying the dataset with `dataset.map`\n",
         "\n",
-        "There is a powerful method `.map()` which is inspired by `tf.data` map method and that you can use to apply a function to each examples, independantly or in batch."
+        "There is a powerful method `.map()` which is inspired by `tf.data` map method and that you can use to apply a function to each examples, independently or in batch."
       ]
     },
     {


### PR DESCRIPTION
An instance of "independantly" was changed to "independently". That's all.