### PR TITLE
output nested dict in get_nearest_examples

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -460,8 +460,15 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     outputs = self._data[key].to_pandas(split_blocks=True).to_list()
             else:
                 outputs = self._data[key].to_pandas(split_blocks=True).to_list()
+        elif isinstance(key, list):
+            data_subset = pa.concat_tables(self._data.slice(i, 1) for i in key)
+            if format_type is not None and format_type == "pandas":
+                outputs = data_subset.to_pandas(split_blocks=True)
+            else:
+                outputs = data_subset.to_pandas(split_blocks=True).to_dict("list")
+
         else:
-            raise ValueError("Can only get row(s) (int or slice) or columns (string).")
+            raise ValueError("Can only get row(s) (int or slice or list[int]) or columns (string).")
 
         if (
             (format_type is not None or format_columns is not None)

--- a/src/nlp/search.py
+++ b/src/nlp/search.py
@@ -41,9 +41,9 @@ BatchedSearchResults = NamedTuple(
     "BatchedSearchResults", [("total_scores", List[List[float]]), ("total_indices", List[List[int]])]
 )
 
-NearestExamplesResults = NamedTuple("NearestExamplesResults", [("scores", List[float]), ("examples", List[dict])])
+NearestExamplesResults = NamedTuple("NearestExamplesResults", [("scores", List[float]), ("examples", dict)])
 BatchedNearestExamplesResults = NamedTuple(
-    "BatchedNearestExamplesResults", [("total_scores", List[List[float]]), ("total_examples", List[List[dict]])]
+    "BatchedNearestExamplesResults", [("total_scores", List[List[float]]), ("total_examples", List[dict])]
 )
 
 
@@ -530,12 +530,12 @@ class IndexableMixin:
                 `k` (`int`): The number of examples to retrieve.
 
             Ouput:
-                `scores` (`List[List[float]`): The retrieval scores of the retrieved examples.
-                `examples` (`List[List[dict]]`): The retrieved examples.
+                `scores` (`List[float]`): The retrieval scores of the retrieved examples.
+                `examples` (`dict`): The retrieved examples.
         """
         self._check_index_is_initialized(index_name)
         scores, indices = self.search(index_name, query, k)
-        return NearestExamplesResults(scores, [self[int(i)] for i in indices])
+        return NearestExamplesResults(scores, self[list(indices)])
 
     def get_nearest_examples_batch(
         self, index_name: str, queries: Union[List[str], np.array], k: int = 10
@@ -549,10 +549,8 @@ class IndexableMixin:
 
             Ouput:
                 `total_scores` (`List[List[float]`): The retrieval scores of the retrieved examples per query.
-                `total_examples` (`List[List[dict]]`): The retrieved examples per query.
+                `total_examples` (`List[dict]`): The retrieved examples per query.
         """
         self._check_index_is_initialized(index_name)
         total_scores, total_indices = self.search_batch(index_name, queries, k)
-        return BatchedNearestExamplesResults(
-            total_scores, [[self[int(i)] for i in indices] for indices in total_indices]
-        )
+        return BatchedNearestExamplesResults(total_scores, [self[list(indices)] for indices in total_indices])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -55,7 +55,7 @@ class IndexableDatasetTest(TestCase):
         )
         dset = dset.add_faiss_index("vecs")
         scores, examples = dset.get_nearest_examples("vecs", np.ones(5, dtype=np.float32))
-        self.assertEqual(examples[0]["filename"], "my_name-train_29")
+        self.assertEqual(examples["filename"][0], "my_name-train_29")
         dset.drop_index("vecs")
 
     def test_add_faiss_index_from_external_arrays(self):
@@ -64,7 +64,7 @@ class IndexableDatasetTest(TestCase):
             external_arrays=np.ones((30, 5)) * np.arange(30).reshape(-1, 1), index_name="vecs"
         )
         scores, examples = dset.get_nearest_examples("vecs", np.ones(5, dtype=np.float32))
-        self.assertEqual(examples[0]["filename"], "my_name-train_29")
+        self.assertEqual(examples["filename"][0], "my_name-train_29")
 
     def test_serialization(self):
         dset: Dataset = self._create_dummy_dataset()
@@ -75,7 +75,7 @@ class IndexableDatasetTest(TestCase):
             dset.save_faiss_index("vecs", tmp_file.name)
             dset.load_faiss_index("vecs2", tmp_file.name)
         scores, examples = dset.get_nearest_examples("vecs2", np.ones(5, dtype=np.float32))
-        self.assertEqual(examples[0]["filename"], "my_name-train_29")
+        self.assertEqual(examples["filename"][0], "my_name-train_29")
 
     def test_drop_index(self):
         dset: Dataset = self._create_dummy_dataset()
@@ -97,7 +97,7 @@ class IndexableDatasetTest(TestCase):
 
             dset.add_elasticsearch_index("filename", es_client=es_client)
             scores, examples = dset.get_nearest_examples("filename", "my_name-train_29")
-            self.assertEqual(examples[0]["filename"], "my_name-train_29")
+            self.assertEqual(examples["filename"][0], "my_name-train_29")
 
 
 class FaissIndexTest(TestCase):


### PR DESCRIPTION
As we are using a columnar format like arrow as the backend for datasets, we expect to have a dictionary of columns when we slice a dataset like in this example:
```python
my_examples = dataset[0:10]
print(type(my_examples))
# >>> dict
print(my_examples["my_column"][0]
# >>> this is the first element of the column 'my_column'
```

Therefore I wanted to keep this logic when calling `get_nearest_examples` that returns the top 10 nearest examples:
```python
dataset.add_faiss_index(column="embeddings")
scores, examples = dataset.get_nearest_examples("embeddings", query=my_numpy_embedding)
print(type(examples))
# >>> dict
```

Previously it was returning a list[dict]. It was the only place that was using this output format.

To make it work I had to implement `__getitem__(key)` where `key` is a list.
This is different from `.select` because `.select` is a dataset transform (it returns a new dataset object) while `__getitem__` is an extraction method (it returns python dictionaries).