### PR TITLE
Add package path to sys when downloading package as github archive

### DIFF
--- a/metrics/coval/coval.py
+++ b/metrics/coval/coval.py
@@ -12,11 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" ROUGE metric. """
+""" CoVal metric. """
 
+import pathlib
 import nlp
-import numpy
-import scipy
+import sys
+
+from os.path import join as pjoin
+
+backend_dir = pjoin(pathlib.Path(__file__).parent.absolute(), "coval_backend")
+sys.path.insert(1, backend_dir)
 
 from .coval_backend.conll import reader  # From: https://github.com/ns-moosavi/coval
 from .coval_backend.conll import util
@@ -28,7 +33,7 @@ _CITATION = """\
     title = {Using Automatically Extracted Minimum Spans to Disentangle Coreference Evaluation from Boundary Detection},
     year = {2019},
     booktitle = {Proceedings of the 57th Annual Meeting of
-		the Association for Computational Linguistics (Volume 1: Long Papers)},
+        the Association for Computational Linguistics (Volume 1: Long Papers)},
     publisher = {Association for Computational Linguistics},
     address = {Florence, Italy},
 }
@@ -95,9 +100,9 @@ The CoNLL format has one word per line with all the annotation for this word in 
 Column	Type	Description
 1	Document ID	This is a variation on the document filename
 2	Part number	Some files are divided into multiple parts numbered as 000, 001, 002, ... etc.
-3	Word number	
+3	Word number
 4	Word itself	This is the token as segmented/tokenized in the Treebank. Initially the *_skel file contain the placeholder [WORD] which gets replaced by the actual token from the Treebank which is part of the OntoNotes release.
-5	Part-of-Speech	
+5	Part-of-Speech
 6	Parse bit	This is the bracketed structure broken before the first open parenthesis in the parse, and the word/part-of-speech leaf replaced with a *. The full parse can be created by substituting the asterix with the "([pos] [word])" string (or leaf) and concatenating the items in the rows of that column.
 7	Predicate lemma	The predicate lemma is mentioned for the rows for which we have semantic role information. All other rows are marked with a "-"
 8	Predicate Frameset ID	This is the PropBank frameset ID of the predicate in Column 7.
@@ -148,13 +153,10 @@ Returns:
     'conll_score': averaged CoNLL score (the average of the F1 values of MUC, B-cubed and CEAFe)
 """
 
-def get_coref_infos(key_lines,
-        sys_lines,
-        NP_only=False,
-        remove_nested=False,
-        keep_singletons=True,
-        min_span=False,
-        doc="dummy_doc"):
+
+def get_coref_infos(
+    key_lines, sys_lines, NP_only=False, remove_nested=False, keep_singletons=True, min_span=False, doc="dummy_doc"
+):
 
     key_doc_lines = {doc: key_lines}
     sys_doc_lines = {doc: sys_lines}
@@ -168,88 +170,75 @@ def get_coref_infos(key_lines,
     key_singletons_num = 0
     sys_singletons_num = 0
 
-    key_clusters, singletons_num = reader.get_doc_mentions(
-            doc, key_doc_lines[doc], keep_singletons)
+    key_clusters, singletons_num = reader.get_doc_mentions(doc, key_doc_lines[doc], keep_singletons)
     key_singletons_num += singletons_num
 
     if NP_only or min_span:
-        key_clusters = reader.set_annotated_parse_trees(key_clusters,
-                key_doc_lines[doc],
-                NP_only, min_span)
+        key_clusters = reader.set_annotated_parse_trees(key_clusters, key_doc_lines[doc], NP_only, min_span)
 
-    sys_clusters, singletons_num = reader.get_doc_mentions(
-            doc, sys_doc_lines[doc], keep_singletons)
+    sys_clusters, singletons_num = reader.get_doc_mentions(doc, sys_doc_lines[doc], keep_singletons)
     sys_singletons_num += singletons_num
 
     if NP_only or min_span:
-        sys_clusters = reader.set_annotated_parse_trees(sys_clusters,
-                key_doc_lines[doc],
-                NP_only, min_span)
+        sys_clusters = reader.set_annotated_parse_trees(sys_clusters, key_doc_lines[doc], NP_only, min_span)
 
     if remove_nested:
-        nested_mentions, removed_clusters = reader.remove_nested_coref_mentions(
-                key_clusters, keep_singletons)
+        nested_mentions, removed_clusters = reader.remove_nested_coref_mentions(key_clusters, keep_singletons)
         key_nested_coref_num += nested_mentions
         key_removed_nested_clusters += removed_clusters
 
-        nested_mentions, removed_clusters = reader.remove_nested_coref_mentions(
-                sys_clusters, keep_singletons)
+        nested_mentions, removed_clusters = reader.remove_nested_coref_mentions(sys_clusters, keep_singletons)
         sys_nested_coref_num += nested_mentions
         sys_removed_nested_clusters += removed_clusters
 
-    sys_mention_key_cluster = reader.get_mention_assignments(
-            sys_clusters, key_clusters)
-    key_mention_sys_cluster = reader.get_mention_assignments(
-            key_clusters, sys_clusters)
+    sys_mention_key_cluster = reader.get_mention_assignments(sys_clusters, key_clusters)
+    key_mention_sys_cluster = reader.get_mention_assignments(key_clusters, sys_clusters)
 
-    doc_coref_infos[doc] = (key_clusters, sys_clusters,
-            key_mention_sys_cluster, sys_mention_key_cluster)
+    doc_coref_infos[doc] = (key_clusters, sys_clusters, key_mention_sys_cluster, sys_mention_key_cluster)
 
     if remove_nested:
-        print('Number of removed nested coreferring mentions in the key '
-                'annotation: %s; and system annotation: %s' % (
-                key_nested_coref_num, sys_nested_coref_num))
-        print('Number of resulting singleton clusters in the key '
-                'annotation: %s; and system annotation: %s' % (
-                key_removed_nested_clusters, sys_removed_nested_clusters))
+        print(
+            "Number of removed nested coreferring mentions in the key "
+            "annotation: %s; and system annotation: %s" % (key_nested_coref_num, sys_nested_coref_num)
+        )
+        print(
+            "Number of resulting singleton clusters in the key "
+            "annotation: %s; and system annotation: %s" % (key_removed_nested_clusters, sys_removed_nested_clusters)
+        )
 
     if not keep_singletons:
-        print('%d and %d singletons are removed from the key and system '
-                'files, respectively' % (
-                key_singletons_num, sys_singletons_num))
+        print(
+            "%d and %d singletons are removed from the key and system "
+            "files, respectively" % (key_singletons_num, sys_singletons_num)
+        )
 
     return doc_coref_infos
 
 
-def evaluate(key_lines,
-        sys_lines, metrics, NP_only, remove_nested,
-        keep_singletons, min_span):
-    doc_coref_infos = get_coref_infos(key_lines,
-        sys_lines, NP_only,
-            remove_nested, keep_singletons, min_span)
+def evaluate(key_lines, sys_lines, metrics, NP_only, remove_nested, keep_singletons, min_span):
+    doc_coref_infos = get_coref_infos(key_lines, sys_lines, NP_only, remove_nested, keep_singletons, min_span)
 
     output_scores = {}
     conll = 0
     conll_subparts_num = 0
 
     for name, metric in metrics:
-        recall, precision, f1 = evaluator.evaluate_documents(doc_coref_infos,
-                metric,
-                beta=1)
+        recall, precision, f1 = evaluator.evaluate_documents(doc_coref_infos, metric, beta=1)
         if name in ["muc", "bcub", "ceafe"]:
             conll += f1
             conll_subparts_num += 1
-        output_scores.update({f"{name}/recall": recall,
-                             f"{name}/precision": precision,
-                             f"{name}/f1": f1})
+        output_scores.update({f"{name}/recall": recall, f"{name}/precision": precision, f"{name}/f1": f1})
 
-        print(name.ljust(10), 'Recall: %.2f' % (recall * 100),
-                ' Precision: %.2f' % (precision * 100),
-                ' F1: %.2f' % (f1 * 100))
+        print(
+            name.ljust(10),
+            "Recall: %.2f" % (recall * 100),
+            " Precision: %.2f" % (precision * 100),
+            " F1: %.2f" % (f1 * 100),
+        )
 
     if conll_subparts_num == 3:
         conll = (conll / 3) * 100
-        print('CoNLL score: %.2f' % conll)
+        print("CoNLL score: %.2f" % conll)
         output_scores.update({f"conll_score": conll})
 
     return output_scores
@@ -259,7 +248,7 @@ def check_gold_parse_annotation(key_lines):
     has_gold_parse = False
     for line in key_lines:
         if not line.startswith("#"):
-            if len(line.split())> 6:
+            if len(line.split()) > 6:
                 parse_col = line.split()[5]
                 if not parse_col == "-":
                     has_gold_parse = True
@@ -278,21 +267,27 @@ class Coval(nlp.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Value('string', id='sequence'),
-                'references': nlp.Value('string', id='sequence'),
-            }),
+            features=nlp.Features(
+                {"predictions": nlp.Value("string", id="sequence"), "references": nlp.Value("string", id="sequence")}
+            ),
             codebase_urls=["https://github.com/ns-moosavi/coval"],
-            reference_urls=["https://github.com/ns-moosavi/coval",
-                            "https://www.aclweb.org/anthology/P16-1060",
-                            "http://www.conll.cemantix.org/2012/data.html"]
+            reference_urls=[
+                "https://github.com/ns-moosavi/coval",
+                "https://www.aclweb.org/anthology/P16-1060",
+                "http://www.conll.cemantix.org/2012/data.html",
+            ],
         )
 
-    def _compute(self, predictions, references, keep_singletons=True,
-                 NP_only=False, min_spans=False, remove_nested=False):
-        allmetrics = [('mentions', evaluator.mentions), ('muc', evaluator.muc),
-                      ('bcub', evaluator.b_cubed), ('ceafe', evaluator.ceafe),
-                      ('lea', evaluator.lea)]
+    def _compute(
+        self, predictions, references, keep_singletons=True, NP_only=False, min_spans=False, remove_nested=False
+    ):
+        allmetrics = [
+            ("mentions", evaluator.mentions),
+            ("muc", evaluator.muc),
+            ("bcub", evaluator.b_cubed),
+            ("ceafe", evaluator.ceafe),
+            ("lea", evaluator.lea),
+        ]
 
         if min_spans:
             has_gold_parse = util.check_gold_parse_annotation(references)
@@ -301,7 +296,6 @@ class Coval(nlp.Metric):
                 # util.parse_key_file(key_file)
                 # key_file = key_file + ".parsed"
 
-        score = evaluate(references, predictions, allmetrics, NP_only, remove_nested,
-                keep_singletons, min_spans)
+        score = evaluate(references, predictions, allmetrics, NP_only, remove_nested, keep_singletons, min_spans)
 
         return score


### PR DESCRIPTION
This fixes the `coval.py` metric so that imports within the downloaded module work correctly. We can use a similar trick to add the BLEURT metric (@ankparikh)

@thomwolf not sure how you feel about adding to the `PYTHONPATH` from the script. This is the only way I could make it work with my understanding of `importlib` but there might be a more elegant method.

This PR fixes https://github.com/huggingface/nlp/issues/305