### PR TITLE
Fix nested tensorflow format

### DIFF
--- a/datasets/docred/docred.py
+++ b/datasets/docred/docred.py
@@ -47,12 +47,16 @@ class DocRed(nlp.GeneratorBasedBuilder):
                 {
                     "title": nlp.Value("string"),
                     "sents": nlp.features.Sequence(nlp.features.Sequence(nlp.Value("string"))),
-                    "vertexSet": [[{
-                         "name": nlp.Value("string"),
-                          "sent_id": nlp.Value("int32"),
-                          "pos": nlp.features.Sequence(nlp.Value("int32")),
-                         "type": nlp.Value("string"),
-                     }]],
+                    "vertexSet": [
+                        [
+                            {
+                                "name": nlp.Value("string"),
+                                "sent_id": nlp.Value("int32"),
+                                "pos": nlp.features.Sequence(nlp.Value("int32")),
+                                "type": nlp.Value("string"),
+                            }
+                        ]
+                    ],
                     "labels": nlp.features.Sequence(
                         {
                             "head": nlp.Value("int32"),
@@ -75,7 +79,7 @@ class DocRed(nlp.GeneratorBasedBuilder):
             downloads[key] = dl_manager.download_and_extract(_URLS[key])
             #  Fix for dummy data
             if os.path.isdir(downloads[key]):
-                downloads[key] = os.path.join(downloads[key],key+".json")
+                downloads[key] = os.path.join(downloads[key], key + ".json")
 
         return [
             nlp.SplitGenerator(
@@ -116,4 +120,3 @@ class DocRed(nlp.GeneratorBasedBuilder):
                 del label["t"]
 
             yield idx, example
-

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ TESTS_REQUIRE = [
     'pytest',
     'pytest-xdist',
     'tensorflow',
+    'torch',
     'tldextract',
     'zstandard'
 ]

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -370,12 +370,14 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 return {k: v for k, v in outputs.items() if k in format_columns}
             return outputs
 
+        map_nested_kwargs = {}
         if format_type == "numpy":
             import numpy as np
 
             if "copy" not in format_kwargs:
                 format_kwargs["copy"] = False
             command = partial(np.array, **format_kwargs)
+            map_nested_kwargs["map_list"] = False  # convert lists to array
         elif format_type == "torch":
             import torch
 
@@ -399,7 +401,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 if format_columns is not None and k not in format_columns and not output_all_columns:
                     continue
                 if format_columns is None or k in format_columns:
-                    v = command(v)
+                    v = map_nested(command, v, **map_nested_kwargs)
                 output_dict[k] = v
         return output_dict
 

--- a/src/nlp/utils/py_utils.py
+++ b/src/nlp/utils/py_utils.py
@@ -154,14 +154,16 @@ class memoized_property(property):  # pylint: disable=invalid-name
         return cached
 
 
-def map_nested(function, data_struct, dict_only=False, map_tuple=False, map_numpy=False):
+def map_nested(function, data_struct, dict_only=False, map_list=True, map_tuple=False, map_numpy=False):
     """Apply a function recursively to each element of a nested data struct."""
 
     # Could add support for more exotic data_struct, like OrderedDict
     if isinstance(data_struct, dict):
         return {k: map_nested(function, v, dict_only, map_tuple, map_numpy) for k, v in data_struct.items()}
     elif not dict_only:
-        types = [list]
+        types = []
+        if map_list:
+            types.append(list)
         if map_tuple:
             types.append(tuple)
         if map_numpy:

--- a/src/nlp/utils/py_utils.py
+++ b/src/nlp/utils/py_utils.py
@@ -159,7 +159,7 @@ def map_nested(function, data_struct, dict_only=False, map_list=True, map_tuple=
 
     # Could add support for more exotic data_struct, like OrderedDict
     if isinstance(data_struct, dict):
-        return {k: map_nested(function, v, dict_only, map_tuple, map_numpy) for k, v in data_struct.items()}
+        return {k: map_nested(function, v, dict_only=dict_only, map_list=map_list, map_tuple=map_tuple, map_numpy=map_numpy) for k, v in data_struct.items()}
     elif not dict_only:
         types = []
         if map_list:
@@ -169,7 +169,7 @@ def map_nested(function, data_struct, dict_only=False, map_list=True, map_tuple=
         if map_numpy:
             types.append(np.ndarray)
         if isinstance(data_struct, tuple(types)):
-            mapped = [map_nested(function, v, dict_only, map_tuple, map_numpy) for v in data_struct]
+            mapped = [map_nested(function, v, dict_only=dict_only, map_list=map_list, map_tuple=map_tuple, map_numpy=map_numpy) for v in data_struct]
             if isinstance(data_struct, list):
                 return mapped
             else:

--- a/src/nlp/utils/py_utils.py
+++ b/src/nlp/utils/py_utils.py
@@ -159,7 +159,12 @@ def map_nested(function, data_struct, dict_only=False, map_list=True, map_tuple=
 
     # Could add support for more exotic data_struct, like OrderedDict
     if isinstance(data_struct, dict):
-        return {k: map_nested(function, v, dict_only=dict_only, map_list=map_list, map_tuple=map_tuple, map_numpy=map_numpy) for k, v in data_struct.items()}
+        return {
+            k: map_nested(
+                function, v, dict_only=dict_only, map_list=map_list, map_tuple=map_tuple, map_numpy=map_numpy
+            )
+            for k, v in data_struct.items()
+        }
     elif not dict_only:
         types = []
         if map_list:
@@ -169,11 +174,18 @@ def map_nested(function, data_struct, dict_only=False, map_list=True, map_tuple=
         if map_numpy:
             types.append(np.ndarray)
         if isinstance(data_struct, tuple(types)):
-            mapped = [map_nested(function, v, dict_only=dict_only, map_list=map_list, map_tuple=map_tuple, map_numpy=map_numpy) for v in data_struct]
+            mapped = [
+                map_nested(
+                    function, v, dict_only=dict_only, map_list=map_list, map_tuple=map_tuple, map_numpy=map_numpy
+                )
+                for v in data_struct
+            ]
             if isinstance(data_struct, list):
                 return mapped
-            else:
+            elif isinstance(data_struct, tuple):
                 return tuple(mapped)
+            else:
+                return np.array(mapped)
     # Singleton
     return function(data_struct)
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -281,7 +281,11 @@ class BaseDatasetTest(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_file = os.path.join(tmp_dir, "test.arrow")
-            dset = dset.map(lambda ex: {"nested": [{"foo": np.ones(3)}] * len(ex["filename"])}, cache_file_name=tmp_file, batched=True)
+            dset = dset.map(
+                lambda ex: {"nested": [{"foo": np.ones(3)}] * len(ex["filename"])},
+                cache_file_name=tmp_file,
+                batched=True,
+            )
 
             dset.set_format("tensorflow")
             self.assertIsNotNone(dset[0])

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -242,3 +242,55 @@ class BaseDatasetTest(TestCase):
             dset_sharded = dset.shard(num_shards=8, index=1)
             self.assertEqual(2, len(dset_sharded))
             self.assertEqual(["my_name-train_1", "my_name-train_9"], dset_sharded["filename"])
+
+    def test_format_vectors(self):
+        dset = self._create_dummy_dataset()
+        import numpy as np
+        import tensorflow as tf
+        import torch
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            dset = dset.map(lambda ex, i: {"vec": np.ones(3) * i}, with_indices=True, cache_file_name=tmp_file)
+            columns = dset.column_names
+
+            dset.set_format("tensorflow")
+            self.assertIsNotNone(dset[0])
+            self.assertIsNotNone(dset[:2])
+            for col in columns:
+                self.assertIsInstance(dset[0][col], (tf.Tensor, tf.RaggedTensor))
+                self.assertIsInstance(dset[:2][col][0], (tf.Tensor, tf.RaggedTensor))  # not stacked
+
+            dset.set_format("numpy")
+            self.assertIsNotNone(dset[0])
+            self.assertIsNotNone(dset[:2])
+            for col in columns:
+                self.assertIsInstance(dset[0][col], np.ndarray)
+                self.assertIsInstance(dset[:2][col], np.ndarray)  # stacked
+
+            dset.set_format("torch", columns=["vec"])
+            self.assertIsNotNone(dset[0])
+            self.assertIsNotNone(dset[:2])
+            # torch.Tensor is only for numerical columns
+            self.assertIsInstance(dset[0]["vec"], torch.Tensor)
+            self.assertIsInstance(dset[:2]["vec"][0], torch.Tensor)  # not stacked
+
+    def test_format_nested(self):
+        dset = self._create_dummy_dataset()
+        import numpy as np
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            dset = dset.map(lambda ex: {"nested": [{"foo": np.ones(3)}] * len(ex["filename"])}, cache_file_name=tmp_file, batched=True)
+
+            dset.set_format("tensorflow")
+            self.assertIsNotNone(dset[0])
+            self.assertIsNotNone(dset[:2])
+
+            dset.set_format("numpy")
+            self.assertIsNotNone(dset[0])
+            self.assertIsNotNone(dset[:2])
+
+            dset.set_format("torch", columns="nested")
+            self.assertIsNotNone(dset[0])
+            self.assertIsNotNone(dset[:2])


### PR DESCRIPTION
In #339 and #337 we are thinking about adding a way to export datasets to tfrecords.

However I noticed that it was not possible to do `dset.set_format("tensorflow")` on datasets with nested features like `squad`. I fixed that using a nested map operations to convert features to `tf.ragged.constant`.

I also added tests on the `set_format` function.