### PR TITLE
Make the json script more flexible

### DIFF
--- a/datasets/json/json.py
+++ b/datasets/json/json.py
@@ -1,13 +1,12 @@
 # coding=utf-8
 
+import json
 from dataclasses import dataclass
-from typing import Union, List
 from io import BytesIO
+from typing import List, Union
 
 import pyarrow as pa
 import pyarrow.json as paj
-
-import json
 
 import nlp
 
@@ -61,7 +60,7 @@ class Json(nlp.ArrowBasedBuilder):
     def _generate_tables(self, files):
         for i, file in enumerate(files):
             if self.config.field is not None:
-                with open(file, encoding='utf-8') as f:
+                with open(file, encoding="utf-8") as f:
                     dataset = json.load(f)
 
                 # We keep only the field we are interested in
@@ -70,7 +69,7 @@ class Json(nlp.ArrowBasedBuilder):
                 # We accept two format: a list of dicts or a dict of lists
                 if isinstance(dataset, (list, tuple)):
                     pa_table = paj.read_json(
-                        BytesIO('\n'.join(json.dumps(row) for row in dataset).encode('utf-8')),
+                        BytesIO("\n".join(json.dumps(row) for row in dataset).encode("utf-8")),
                         read_options=self.config.pa_read_options,
                         parse_options=self.config.pa_parse_options,
                     )
@@ -78,8 +77,6 @@ class Json(nlp.ArrowBasedBuilder):
                     pa_table = pa.Table.from_pydict(mapping=dataset, schema=self.config.schema)
             else:
                 pa_table = paj.read_json(
-                    file,
-                    read_options=self.config.pa_read_options,
-                    parse_options=self.config.pa_parse_options,
+                    file, read_options=self.config.pa_read_options, parse_options=self.config.pa_parse_options,
                 )
             yield i, pa_table

--- a/datasets/json/json.py
+++ b/datasets/json/json.py
@@ -76,7 +76,17 @@ class Json(nlp.ArrowBasedBuilder):
                 else:
                     pa_table = pa.Table.from_pydict(mapping=dataset, schema=self.config.schema)
             else:
-                pa_table = paj.read_json(
-                    file, read_options=self.config.pa_read_options, parse_options=self.config.pa_parse_options,
-                )
+                try:
+                    pa_table = paj.read_json(
+                        file, read_options=self.config.pa_read_options, parse_options=self.config.pa_parse_options,
+                    )
+                except pa.ArrowInvalid:
+                    with open(file, encoding="utf-8") as f:
+                        dataset = json.load(f)
+                    raise ValueError(
+                        f"Not able to read records in the JSON file at {file}. "
+                        f"You should probably indicate the field of the JSON file containing your records. "
+                        f"This JSON file contain the following fields: {str(list(dataset.keys()))}. "
+                        f"Select the correct one and provide it as `field='XXX'` to the `load_dataset` method. "
+                    )
             yield i, pa_table

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -1304,7 +1304,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         device: Optional[int] = None,
         string_factory: Optional[str] = None,
         metric_type: Optional[int] = None,
-        custom_index: Optional["faiss.Index"] = None,
+        custom_index: Optional["faiss.Index"] = None,  # noqa: F821
         train_size: Optional[int] = None,
         faiss_verbose: bool = False,
         dtype=np.float32,
@@ -1367,7 +1367,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         device: Optional[int] = None,
         string_factory: Optional[str] = None,
         metric_type: Optional[int] = None,
-        custom_index: Optional["faiss.Index"] = None,
+        custom_index: Optional["faiss.Index"] = None,  # noqa: F821
         train_size: Optional[int] = None,
         faiss_verbose: bool = False,
         dtype=np.float32,
@@ -1407,7 +1407,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         index_name: Optional[str] = None,
         host: Optional[str] = None,
         port: Optional[int] = None,
-        es_client: Optional["elasticsearch.Elasticsearch"] = None,
+        es_client: Optional["elasticsearch.Elasticsearch"] = None,  # noqa: F821
         es_index_name: Optional[str] = None,
         es_index_config: Optional[dict] = None,
     ):


### PR DESCRIPTION
Fix https://github.com/huggingface/nlp/issues/359
Fix https://github.com/huggingface/nlp/issues/369

JSON script now can accept JSON files containing a single dict with the records as a list in one attribute to the dict (previously it only accepted JSON files containing records as rows of dicts in the file).

In this case, you should indicate using `field=XXX` the name of the field in the JSON structure which contains the records you want to load. The records can be a dict of lists or a list of dicts.

E.g. to load the SQuAD dataset JSON (without using the `squad` specific dataset loading script), in which the data rows are in the `data` field of the JSON dict, you can do:
```python
from nlp import load_dataset
dataset = load_dataset('json', data_files='/PATH/TO/JSON', field='data')
```