### PR TITLE
Fix pickling of SplitDict

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -143,6 +143,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         self._format_columns: Optional[list] = None
         self._output_all_columns: bool = False
 
+    def __getstate__(self):
+        logging.warn("Pickling Dataset not supported, as this writes the dataset to disk. Prefer Dataset.from_file instead.")
+        return self.__dict__
+
     @classmethod
     def from_file(cls, filename: str, info: Optional["DatasetInfo"] = None, split: Optional["NamedSplit"] = None):
         """ Instantiate a Dataset backed by an Arrow table at filename """

--- a/src/nlp/splits.py
+++ b/src/nlp/splits.py
@@ -492,6 +492,19 @@ class SplitDict(dict):
     def __setitem__(self, key: Union[SplitBase, str], value: SplitInfo):
         raise ValueError("Cannot add elem. Use .add() instead.")
 
+    # The following three methods allow pickling and unpickling of SplitDicts.
+    # This is necessary because unpickling will try to call __setitem__ by default.
+    # See https://stackoverflow.com/questions/21144845
+    def __reduce__(self):
+        return SplitDict, (), self.__getstate__()
+
+    def __getstate__(self):
+        return self.dataset_name, dict(self)
+
+    def __setstate__(self, state):
+        self.dataset_name, data = state
+        self.update(data)
+
     def add(self, split_info: SplitInfo):
         """Add the split info."""
         if split_info.name in self:


### PR DESCRIPTION
It would be nice to pickle and unpickle Datasets, as done in [this tutorial](https://github.com/patil-suraj/exploring-T5/blob/master/T5_on_TPU.ipynb). Example:

```
wiki = nlp.load_dataset('wikipedia', split='train')
def sentencize(examples):
    ...

wiki = wiki.map(sentencize, batched=True)
torch.save(wiki, 'sentencized_wiki_dataset.pt')
```

However, upon unpickling the dataset via torch.load(...), this error is raised:

```
ValueError("Cannot add elem. Use .add() instead.")
```
On line [492 of splits.py](https://github.com/huggingface/nlp/blob/master/src/nlp/splits.py#L492). This is because SplitDict subclasses dict, and pickle treats [dicts specially](https://github.com/huggingface/nlp/blob/master/src/nlp/splits.py#L492). Pickle expects access to `dict.__setitem__`, but this is disallowed by the class.

The workaround is to provide an explicit interface for pickle to call when pickling and unpickling, thereby avoiding the use of `__setitem__`.

Testing:
- Manually pickled and unpickled a modified wikipedia dataset.
- Ran `make style`

I would be happy to run any other tests, but I couldn't find any in the contributing guidelines.