### PR TITLE
Fix extracted files directory for the DownloadManager

### DIFF
--- a/datasets/emotion/emotion.py
+++ b/datasets/emotion/emotion.py
@@ -39,7 +39,6 @@ _TEST_DOWNLOAD_URL = "https://www.dropbox.com/s/ikkqxfdbdec3fuj/test.txt?dl=1"
 
 
 class Emotion(nlp.GeneratorBasedBuilder):
-
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,

--- a/datasets/mlqa/mlqa.py
+++ b/datasets/mlqa/mlqa.py
@@ -91,11 +91,8 @@ class Mlqa(nlp.GeneratorBasedBuilder):
                 {
                     "context": nlp.Value("string"),
                     "questions": nlp.Value("string"),
-                    "answers": nlp.features.Sequence({
-                        "start": nlp.Value("int32"),
-                        "text":  nlp.Value("string")
-                    }),
-                    "ids":  nlp.Value("string"),
+                    "answers": nlp.features.Sequence({"start": nlp.Value("int32"), "text": nlp.Value("string")}),
+                    "ids": nlp.Value("string"),
                     # These are the features of your dataset like images, labels ...
                 }
             ),
@@ -190,10 +187,10 @@ class Mlqa(nlp.GeneratorBasedBuilder):
         for examples in data["data"]:
             for example in examples["paragraphs"]:
                 context = example["context"]
-                for qa in example['qas']:
-                    question = qa['question']
-                    id_ = qa['id']
-                    answers = qa['answers']
+                for qa in example["qas"]:
+                    question = qa["question"]
+                    id_ = qa["id"]
+                    answers = qa["answers"]
                     answers_start = [answer["answer_start"] for answer in answers]
                     answers_text = [answer["text"] for answer in answers]
                     yield id_, {

--- a/src/nlp/commands/test.py
+++ b/src/nlp/commands/test.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 from shutil import copyfile
 from typing import List
 
-from nlp.builder import FORCE_REDOWNLOAD, REUSE_CACHE_IF_EXISTS, DatasetBuilder, DownloadConfig
+from nlp.builder import FORCE_REDOWNLOAD, REUSE_CACHE_IF_EXISTS, DatasetBuilder
 from nlp.commands import BaseTransformersCLICommand
 from nlp.info import DATASET_INFOS_DICT_FILE_NAME
 from nlp.load import import_main_class, prepare_module
@@ -75,13 +75,12 @@ class TestCommand(BaseTransformersCLICommand):
         builders: List[DatasetBuilder] = []
         if self._all_configs and len(builder_cls.BUILDER_CONFIGS) > 0:
             for config in builder_cls.BUILDER_CONFIGS:
-                builders.append(builder_cls(name=config.name, data_dir=self._data_dir))
+                builders.append(builder_cls(name=config.name, hash=hash, cache_dir=self._cache_dir, data_dir=self._data_dir))
         else:
-            builders.append(builder_cls(name=name, hash=hash, data_dir=self._data_dir))
+            builders.append(builder_cls(name=name, hash=hash, cache_dir=self._cache_dir, data_dir=self._data_dir))
 
         for builder in builders:
             builder.download_and_prepare(
-                download_config=DownloadConfig(cache_dir=self._cache_dir),
                 download_mode=REUSE_CACHE_IF_EXISTS if not self._force_redownload else FORCE_REDOWNLOAD,
                 save_infos=self._save_infos,
                 ignore_verifications=self._ignore_verifications,

--- a/src/nlp/commands/test.py
+++ b/src/nlp/commands/test.py
@@ -75,7 +75,9 @@ class TestCommand(BaseTransformersCLICommand):
         builders: List[DatasetBuilder] = []
         if self._all_configs and len(builder_cls.BUILDER_CONFIGS) > 0:
             for config in builder_cls.BUILDER_CONFIGS:
-                builders.append(builder_cls(name=config.name, hash=hash, cache_dir=self._cache_dir, data_dir=self._data_dir))
+                builders.append(
+                    builder_cls(name=config.name, hash=hash, cache_dir=self._cache_dir, data_dir=self._data_dir)
+                )
         else:
             builders.append(builder_cls(name=name, hash=hash, cache_dir=self._cache_dir, data_dir=self._data_dir))
 

--- a/src/nlp/utils/download_manager.py
+++ b/src/nlp/utils/download_manager.py
@@ -195,7 +195,7 @@ class DownloadManager(object):
                 path_or_paths.
         """
         return map_nested(
-            lambda path: cached_path(path, extract_compressed_file=True, force_extract=False), path_or_paths,
+            lambda path: cached_path(path, cache_dir=self._download_config.cache_dir, extract_compressed_file=True, force_extract=False), path_or_paths,
         )
 
     def download_and_extract(self, url_or_urls):

--- a/src/nlp/utils/download_manager.py
+++ b/src/nlp/utils/download_manager.py
@@ -195,7 +195,10 @@ class DownloadManager(object):
                 path_or_paths.
         """
         return map_nested(
-            lambda path: cached_path(path, cache_dir=self._download_config.cache_dir, extract_compressed_file=True, force_extract=False), path_or_paths,
+            lambda path: cached_path(
+                path, cache_dir=self._download_config.cache_dir, extract_compressed_file=True, force_extract=False
+            ),
+            path_or_paths,
         )
 
     def download_and_extract(self, url_or_urls):

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -214,7 +214,7 @@ def cached_path(url_or_filename, download_config=None, **download_kwargs,) -> Op
         # Path where we extract compressed archives
         # We extract in the cache dir, and get the extracted path name by hashing the original path"
         abs_output_path = os.path.abspath(output_path)
-        output_path_extracted = os.path.join(cache_dir, hash_url_to_filename(abs_output_path))
+        output_path_extracted = os.path.join(cache_dir, "extracted", hash_url_to_filename(abs_output_path))
 
         if (
             os.path.isdir(output_path_extracted)


### PR DESCRIPTION
The cache dir was often cluttered by extracted files because of the download manager.

For downloaded files, we are using the `downloads` directory to make things easier to navigate, but extracted files were still placed at the root of the cache directory. To fix that I changed the directory for extracted files to cache_dir/downloads/extracted.