### PR TITLE
Add tests datasets gcp

### DIFF
--- a/datasets/blended_skill_talk/blended_skill_talk.py
+++ b/datasets/blended_skill_talk/blended_skill_talk.py
@@ -117,7 +117,7 @@ class BlendedSkillTalk(nlp.GeneratorBasedBuilder):
                     "previous_utterance": previous_utterance,
                     "context": context,
                     "free_messages": free_messages,
-                    "guided_messages":guided_messages,
+                    "guided_messages": guided_messages,
                     "suggestions": {
                         "convai2": convai_suggestions,
                         "empathetic_dialogues": empathetic_suggestions,

--- a/datasets/coqa/coqa.py
+++ b/datasets/coqa/coqa.py
@@ -144,5 +144,5 @@ class Coqa(nlp.GeneratorBasedBuilder):
                     "source": source,
                     "story": story,
                     "questions": questions,
-                    "answers": {"input_text": answers, "answer_start": answers_start, "answer_end": answers_end}
+                    "answers": {"input_text": answers, "answer_start": answers_start, "answer_end": answers_end},
                 }

--- a/datasets/emotion/emotion.py
+++ b/datasets/emotion/emotion.py
@@ -39,7 +39,6 @@ _TEST_DOWNLOAD_URL = "https://www.dropbox.com/s/ikkqxfdbdec3fuj/test.txt?dl=1"
 
 
 class Emotion(nlp.GeneratorBasedBuilder):
-
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,

--- a/datasets/mlqa/mlqa.py
+++ b/datasets/mlqa/mlqa.py
@@ -91,11 +91,8 @@ class Mlqa(nlp.GeneratorBasedBuilder):
                 {
                     "context": nlp.Value("string"),
                     "questions": nlp.Value("string"),
-                    "answers": nlp.features.Sequence({
-                        "start": nlp.Value("int32"),
-                        "text":  nlp.Value("string")
-                    }),
-                    "ids":  nlp.Value("string"),
+                    "answers": nlp.features.Sequence({"start": nlp.Value("int32"), "text": nlp.Value("string")}),
+                    "ids": nlp.Value("string"),
                     # These are the features of your dataset like images, labels ...
                 }
             ),
@@ -190,10 +187,10 @@ class Mlqa(nlp.GeneratorBasedBuilder):
         for examples in data["data"]:
             for example in examples["paragraphs"]:
                 context = example["context"]
-                for qa in example['qas']:
-                    question = qa['question']
-                    id_ = qa['id']
-                    answers = qa['answers']
+                for qa in example["qas"]:
+                    question = qa["question"]
+                    id_ = qa["id"]
+                    answers = qa["answers"]
                     answers_start = [answer["answer_start"] for answer in answers]
                     answers_text = [answer["text"] for answer in answers]
                     yield id_, {

--- a/datasets/qangaroo/qangaroo.py
+++ b/datasets/qangaroo/qangaroo.py
@@ -124,6 +124,6 @@ class Qangaroo(nlp.GeneratorBasedBuilder):
                     "id": example["id"],
                     "query": example["query"],
                     "supports": example["supports"],
-                    "candidates":example["candidates"],
+                    "candidates": example["candidates"],
                     "answer": example["answer"],
                 }

--- a/datasets/quarel/quarel.py
+++ b/datasets/quarel/quarel.py
@@ -42,7 +42,7 @@ class Quarel(nlp.GeneratorBasedBuilder):
                     # These are the features of your dataset like images, labels ...
                     "id": nlp.Value("string"),
                     "answer_index": nlp.Value("int32"),
-                    "logical_forms": nlp.features.Sequence( nlp.Value("string")),
+                    "logical_forms": nlp.features.Sequence(nlp.Value("string")),
                     "logical_form_pretty": nlp.Value("string"),
                     "world_literals": nlp.features.Sequence(
                         {"world1": nlp.Value("string"), "world2": nlp.Value("string")}

--- a/datasets/reclor/reclor.py
+++ b/datasets/reclor/reclor.py
@@ -54,7 +54,7 @@ class Reclor(nlp.GeneratorBasedBuilder):
                     # These are the features of your dataset like images, labels ...
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
-                    "answers": nlp.features.Sequence( nlp.Value("string")),
+                    "answers": nlp.features.Sequence(nlp.Value("string")),
                     "label": nlp.Value("string"),
                     "id_string": nlp.Value("string"),
                 }

--- a/datasets/scifact/scifact.py
+++ b/datasets/scifact/scifact.py
@@ -56,7 +56,8 @@ class Scifact(nlp.GeneratorBasedBuilder):
             features = {
                 "doc_id": nlp.Value("int32"),  # The document's S2ORC ID.
                 "title": nlp.Value("string"),  # The title.
-                "abstract": nlp.features.Sequence(nlp.Value("string")
+                "abstract": nlp.features.Sequence(
+                    nlp.Value("string")
                 ),  # The abstract, written as a list of sentences.
                 "structured": nlp.Value("bool"),  # Indicator for whether this is a structured abstract.
             }
@@ -67,8 +68,7 @@ class Scifact(nlp.GeneratorBasedBuilder):
                 "evidence_doc_id": nlp.Value("string"),
                 "evidence_label": nlp.Value("string"),  # Label for the rationale.
                 "evidence_sentences": nlp.features.Sequence(nlp.Value("int32")),  # Rationale sentences.
-                "cited_doc_ids": nlp.features.Sequence(nlp.Value("int32")
-                ),  # The claim's "cited documents".
+                "cited_doc_ids": nlp.features.Sequence(nlp.Value("int32")),  # The claim's "cited documents".
             }
 
         return nlp.DatasetInfo(

--- a/datasets/search_qa/search_qa.py
+++ b/datasets/search_qa/search_qa.py
@@ -24,6 +24,7 @@ import os
 
 import nlp
 
+
 _CITATION = """
     @article{DBLP:journals/corr/DunnSHGCC17,
     author    = {Matthew Dunn and
@@ -58,12 +59,11 @@ Following this approach, we built SearchQA, which consists of more than 140k que
 """
 
 _DL_URLS = {
-    
     "raw_jeopardy": "https://drive.google.com/uc?export=download&id=1U7WdBpd9kJ85S7BbBhWUSiy9NnXrKdO6",
     "train_test_val": "https://drive.google.com/uc?export=download&id=1aHPVfC5TrlnUjehtagVZoDfq4VccgaNT",
-    
 }
 # pylint: enable=line-too-long
+
 
 class SearchQaConfig(nlp.BuilderConfig):
     """BuilderConfig for SearchQA."""
@@ -74,24 +74,20 @@ class SearchQaConfig(nlp.BuilderConfig):
         Args:
           **kwargs: keyword arguments forwarded to super.
         """
-        super(SearchQaConfig, self).__init__(version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs)
+        super(SearchQaConfig, self).__init__(
+            version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
+        )
         self.data_url = data_url
+
 
 class SearchQa(nlp.GeneratorBasedBuilder):
     """Search QA Dataset."""
-    
-    BUILDER_CONFIGS = [
-        SearchQaConfig(
-            name= name,
-            description='',
-            data_url = _DL_URLS[name]
-            
-        ) for name in _DL_URLS.keys()
-    ]
-    
+
+    BUILDER_CONFIGS = [SearchQaConfig(name=name, description="", data_url=_DL_URLS[name]) for name in _DL_URLS.keys()]
+
     def _info(self):
         return nlp.DatasetInfo(
-            description=_DESCRIPTION + '\n' + self.config.description,
+            description=_DESCRIPTION + "\n" + self.config.description,
             features=nlp.Features(
                 {
                     "category": nlp.Value("string"),
@@ -102,107 +98,91 @@ class SearchQa(nlp.GeneratorBasedBuilder):
                     "round": nlp.Value("string"),
                     "category": nlp.Value("string"),
                     "show_number": nlp.Value("int32"),
-                    "search_results": nlp.features.Sequence({
-                        'urls': nlp.Value('string'),
-                        "snippets": nlp.Value('string'),
-                        "titles": nlp.Value('string'),
-                        "related_links": nlp.Value('string')
-                    })
+                    "search_results": nlp.features.Sequence(
+                        {
+                            "urls": nlp.Value("string"),
+                            "snippets": nlp.Value("string"),
+                            "titles": nlp.Value("string"),
+                            "related_links": nlp.Value("string"),
+                        }
+                    )
                     # These are the features of your dataset like images, labels ...
                 }
             ),
             homepage="https://github.com/nyu-dl/dl4ir-searchQA",
             citation=_CITATION,
         )
-    
+
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
         # TODO(jeopardy): Downloads the data and defines the splits
         # dl_manager is a nlp.download.DownloadManager that can be used to
         # download and extract URLs
-        
-        if self.config.name == 'raw_jeopardy':
-            filepath = dl_manager.download_and_extract(_DL_URLS['raw_jeopardy'])
-            sub_folders = sorted(os.listdir(os.path.join(filepath, 'jeopardy')))
-            all_files = []     
+
+        if self.config.name == "raw_jeopardy":
+            filepath = dl_manager.download_and_extract(_DL_URLS["raw_jeopardy"])
+            sub_folders = sorted(os.listdir(os.path.join(filepath, "jeopardy")))
+            all_files = []
             for zip_folder in sub_folders:
-                if 'lock' in zip_folder:
+                if "lock" in zip_folder:
                     continue
-                zip_folder_path = os.path.join(filepath, 'jeopardy', zip_folder)
+                zip_folder_path = os.path.join(filepath, "jeopardy", zip_folder)
                 file_path = dl_manager.extract(zip_folder_path)
-                zip_folder = zip_folder.split('.')[0]
+                zip_folder = zip_folder.split(".")[0]
                 if os.path.isdir(os.path.join(file_path, zip_folder)):
                     file_path = os.path.join(file_path, zip_folder)
-                    
+
                 else:
-                    #in some cases the subfolder name contains sapces as 050000 - 059999   and 050000-059999
-                    parts = zip_folder.split('-')
-                    zip_folder =parts[0]+' - '+parts[1]
+                    # in some cases the subfolder name contains sapces as 050000 - 059999   and 050000-059999
+                    parts = zip_folder.split("-")
+                    zip_folder = parts[0] + " - " + parts[1]
                     if os.path.isdir(os.path.join(file_path, zip_folder)):
                         file_path = os.path.join(file_path, zip_folder)
-                           
+
                 files = sorted(os.listdir(file_path))
-                
-                files_paths = [os.path.join(file_path, file) for file in files if '__MACOSX' not in file]
-                all_files.extend(files_paths) 
-            
+
+                files_paths = [os.path.join(file_path, file) for file in files if "__MACOSX" not in file]
+                all_files.extend(files_paths)
+
             return [
-                nlp.SplitGenerator(
-                    name=nlp.Split.TRAIN, 
-                    gen_kwargs={
-                        "filepaths": all_files
-                        }
-                    ),
+                nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepaths": all_files}),
             ]
-        elif self.config.name == 'train_test_val':
-            filepath = dl_manager.download_and_extract(_DL_URLS['train_test_val'])
-            train_path = dl_manager.extract(os.path.join(filepath, 'data_json', 'train.zip'))
-            test_path = dl_manager.extract(os.path.join(filepath, 'data_json', 'test.zip'))
-            val_path = dl_manager.extract(os.path.join(filepath, 'data_json', 'val.zip'))
-            
+        elif self.config.name == "train_test_val":
+            filepath = dl_manager.download_and_extract(_DL_URLS["train_test_val"])
+            train_path = dl_manager.extract(os.path.join(filepath, "data_json", "train.zip"))
+            test_path = dl_manager.extract(os.path.join(filepath, "data_json", "test.zip"))
+            val_path = dl_manager.extract(os.path.join(filepath, "data_json", "val.zip"))
+
             train_files = [os.path.join(train_path, file) for file in sorted(os.listdir(train_path))]
             test_files = [os.path.join(test_path, file) for file in sorted(os.listdir(test_path))]
             val_files = [os.path.join(val_path, file) for file in sorted(os.listdir(val_path))]
             return [
-                nlp.SplitGenerator(
-                    name=nlp.Split.TRAIN, 
-                    gen_kwargs={
-                        "filepaths": train_files
-                        }
-                    ),
-                nlp.SplitGenerator(
-                    name=nlp.Split.TEST, 
-                    gen_kwargs={
-                        "filepaths": test_files
-                        }
-                    ),
-                nlp.SplitGenerator(
-                    name=nlp.Split.VALIDATION, 
-                    gen_kwargs={
-                        "filepaths": val_files
-                        }
-                    )
+                nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepaths": train_files}),
+                nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"filepaths": test_files}),
+                nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"filepaths": val_files}),
             ]
-            
+
     def _generate_examples(self, filepaths):
         """Yields examples."""
         # TODO(searchQa): Yields (key, example) tuples from the dataset
         for i, filepath in enumerate(filepaths):
             with open(filepath) as f:
-                
-                data = json.load(f)   
+
+                data = json.load(f)
                 category = data["category"]
                 air_date = data["air_date"]
                 question = data["question"]
-                value = data['value']
+                value = data["value"]
                 answer = data["answer"]
                 round_ = data["round"]
                 show_number = int(data["show_number"])
-                search_results = data['search_results']
-                urls = [result['url'] for result in search_results]
-                snippets = [result['snippet'] for result in search_results]
-                titles = [result['title'] for result in search_results]
-                related_links = [result['related_links'] if result['related_links'] else '' for result in search_results]
+                search_results = data["search_results"]
+                urls = [result["url"] for result in search_results]
+                snippets = [result["snippet"] for result in search_results]
+                titles = [result["title"] for result in search_results]
+                related_links = [
+                    result["related_links"] if result["related_links"] else "" for result in search_results
+                ]
                 yield i, {
                     "category": category,
                     "air_date": air_date,
@@ -213,9 +193,9 @@ class SearchQa(nlp.GeneratorBasedBuilder):
                     "category": category,
                     "show_number": show_number,
                     "search_results": {
-                        'urls': urls,
+                        "urls": urls,
                         "snippets": snippets,
                         "titles": titles,
-                        "related_links": related_links
-                    }
+                        "related_links": related_links,
+                    },
                 }

--- a/datasets/wiqa/wiqa.py
+++ b/datasets/wiqa/wiqa.py
@@ -97,7 +97,7 @@ class Wiqa(nlp.GeneratorBasedBuilder):
 
                 yield id_, {
                     "question_stem": data["question"]["stem"],
-                    "question_para_step":data["question"]["para_steps"],
+                    "question_para_step": data["question"]["para_steps"],
                     "answer_label": data["question"]["answer_label"],
                     "answer_label_as_choice": data["question"]["answer_label_as_choice"],
                     "choices": {

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -48,11 +48,15 @@ class TestDatasetOnHfGcp(TestCase):
 
         with TemporaryDirectory() as tmp_dir:
             module_path, hash = prepare_module(dataset, dataset=True, cache_dir=tmp_dir)
+            local_module_path, local_hash = prepare_module(
+                os.path.join("datasets", dataset), dataset=True, cache_dir=tmp_dir, local_files_only=True
+            )
+            self.assertEqual(hash, local_hash)
 
-            builder_cls = import_main_class(module_path, dataset=True)
+            builder_cls = import_main_class(local_module_path, dataset=True)
 
             builder_instance: DatasetBuilder = builder_cls(
-                cache_dir=tmp_dir, name=config_name, hash=hash,
+                cache_dir=tmp_dir, name=config_name, hash=local_hash,
             )
 
             dataset_info_url = os.path.join(

--- a/tests/test_hf_gcp.py
+++ b/tests/test_hf_gcp.py
@@ -1,0 +1,62 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from absl.testing import parameterized
+
+from nlp.arrow_reader import HF_GCP_BASE_URL
+from nlp.builder import DatasetBuilder
+from nlp.info import DATASET_INFO_FILENAME
+from nlp.load import import_main_class, prepare_module
+from nlp.utils import cached_path
+
+
+DATASETS_ON_HF_GCP = [
+    {"dataset": "wikipedia", "config_name": "20200501.en"},
+    {"dataset": "wikipedia", "config_name": "20200501.it"},
+    {"dataset": "wikipedia", "config_name": "20200501.fr"},
+    {"dataset": "wikipedia", "config_name": "20200501.frr"},
+    {"dataset": "wikipedia", "config_name": "20200501.simple"},
+    {"dataset": "wikipedia", "config_name": "20200501.de"},
+    {"dataset": "snli", "config_name": "plain_text"},
+    {"dataset": "eli5", "config_name": "LFQA_reddit"},
+    {"dataset": "wiki40b", "config_name": "en"},
+    {"dataset": "wiki_dpr", "config_name": "psgs_w100_with_nq_embeddings"},
+    {"dataset": "wiki_dpr", "config_name": "psgs_w100_no_embeddings"},
+    {"dataset": "wiki_dpr", "config_name": "dummy_psgs_w100_with_nq_embeddings"},
+    {"dataset": "wiki_dpr", "config_name": "dummy_psgs_w100_no_embeddings"},
+]
+
+
+def list_datasets_on_hf_gcp_parameters():
+    return [
+        {
+            "testcase_name": d["dataset"] + "/" + d["config_name"],
+            "dataset": d["dataset"],
+            "config_name": d["config_name"],
+        }
+        for d in DATASETS_ON_HF_GCP
+    ]
+
+
+@parameterized.named_parameters(list_datasets_on_hf_gcp_parameters())
+class TestDatasetOnHfGcp(TestCase):
+    dataset = None
+    config_name = None
+
+    def test_dataset_info_available(self, dataset, config_name):
+
+        with TemporaryDirectory() as tmp_dir:
+            module_path, hash = prepare_module(dataset, dataset=True, cache_dir=tmp_dir)
+
+            builder_cls = import_main_class(module_path, dataset=True)
+
+            builder_instance: DatasetBuilder = builder_cls(
+                cache_dir=tmp_dir, name=config_name, hash=hash,
+            )
+
+            dataset_info_url = os.path.join(
+                HF_GCP_BASE_URL, builder_instance._relative_data_dir(), DATASET_INFO_FILENAME
+            )
+            datset_info_path = cached_path(dataset_info_url, cache_dir=tmp_dir)
+            self.assertTrue(os.path.exists(datset_info_path))


### PR DESCRIPTION
Some datasets are available on our google cloud storage in arrow format, so that the users don't need to process the data.
These tests make sure that they're always available. It also makes sure that their scripts are in sync between S3 and the repo.
This should avoid future issues like #407 