### PR TITLE
Fix docstrins multiple metrics instances

### DIFF
--- a/datasets/newsgroup/newsgroup.py
+++ b/datasets/newsgroup/newsgroup.py
@@ -43,48 +43,45 @@ machine learning techniques, such as text classification and text clustering.
 _DOWNLOAD_URL = {
     "bydate": "http://qwone.com/~jason/20Newsgroups/20news-bydate.tar.gz",
     "19997": "http://qwone.com/~jason/20Newsgroups/20news-19997.tar.gz",
-    "18828": "http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz"
+    "18828": "http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz",
 }
 _NEWS_GROUPS = [
     "comp.graphics",
     "comp.os.ms-windows.misc",
     "comp.sys.ibm.pc.hardware",
     "comp.sys.mac.hardware",
-    "comp.windows.x", 
+    "comp.windows.x",
     "rec.autos",
     "rec.motorcycles",
     "rec.sport.baseball",
-    "rec.sport.hockey",	
+    "rec.sport.hockey",
     "sci.crypt",
     "sci.electronics",
     "sci.med",
     "sci.space",
-    "misc.forsale",	
+    "misc.forsale",
     "talk.politics.misc",
     "talk.politics.guns",
-    "talk.politics.mideast",	
+    "talk.politics.mideast",
     "talk.religion.misc",
     "alt.atheism",
     "soc.religion.christian",
 ]
-_VERSIONS = {
-    "19997": "1.0.0",
-    
-    "bydate": "2.0.0",
-    "18828": "3.0.0"
-}
+_VERSIONS = {"19997": "1.0.0", "bydate": "2.0.0", "18828": "3.0.0"}
 
 _DESC = {
     "19997": "the original, unmodified version.",
     "bydate": "sorted by date into training(60%) and test(40%) sets, does not include cross-posts (duplicates) and does not include newsgroup-identifying headers (Xref, Newsgroups, Path, Followup-To, Date)",
-    "18828": 'does not include cross-posts and includes only the "From" and "Subject" headers.'
+    "18828": 'does not include cross-posts and includes only the "From" and "Subject" headers.',
 }
 _CONFIG_NAMES = []
 for version in _VERSIONS:
     for group in _NEWS_GROUPS:
-        _CONFIG_NAMES.append(version+'_'+group)
-        
+        _CONFIG_NAMES.append(version + "_" + group)
+
 _CONFIG_NAMES = sorted(_CONFIG_NAMES)
+
+
 class NewsgroupConfig(nlp.BuilderConfig):
     """BuilderConfig for 20Newsgroup."""
 
@@ -101,70 +98,62 @@ class NewsgroupConfig(nlp.BuilderConfig):
 
 
 class Newsgroups(nlp.GeneratorBasedBuilder):
-    
+
     BUILDER_CONFIGS = [
         NewsgroupConfig(
             name=name,
-            description = _DESC[name.split('_')[0]],
-            sub_dir=name.split('_')[1],
-            version=nlp.Version(_VERSIONS[name.split('_')[0]])
-        ) for name in _CONFIG_NAMES
+            description=_DESC[name.split("_")[0]],
+            sub_dir=name.split("_")[1],
+            version=nlp.Version(_VERSIONS[name.split("_")[0]]),
+        )
+        for name in _CONFIG_NAMES
     ]
 
     def _info(self):
         return nlp.DatasetInfo(
-            description=_DESCRIPTION + '\n' + self.config.description,
-            features=nlp.Features(
-                {
-                    "text": nlp.Value("string"),
-                }
-            ),
+            description=_DESCRIPTION + "\n" + self.config.description,
+            features=nlp.Features({"text": nlp.Value("string"),}),
             homepage="http://qwone.com/~jason/20Newsgroups/",
             citation=_CITATION,
         )
-    
+
     def _split_generators(self, dl_manager):
-        url = _DOWNLOAD_URL[self.config.name.split('_')[0]]
+        url = _DOWNLOAD_URL[self.config.name.split("_")[0]]
         path = dl_manager.download_and_extract(url)
         if self.config.name.startswith("bydate"):
 
             return [
                 nlp.SplitGenerator(
-                    name=nlp.Split.TRAIN, 
-                    gen_kwargs={
-                        "files_path":  os.path.join(path,"20news-bydate-train", self.config.sub_dir)
-                }),
+                    name=nlp.Split.TRAIN,
+                    gen_kwargs={"files_path": os.path.join(path, "20news-bydate-train", self.config.sub_dir)},
+                ),
                 nlp.SplitGenerator(
                     name=nlp.Split.TEST,
-                    gen_kwargs={
-                        "files_path":  os.path.join(path, "20news-bydate-train", self.config.sub_dir)
-                    }),
+                    gen_kwargs={"files_path": os.path.join(path, "20news-bydate-train", self.config.sub_dir)},
+                ),
             ]
-        elif self.config.name.startswith('19997'):
+        elif self.config.name.startswith("19997"):
             return [
                 nlp.SplitGenerator(
-                    name=nlp.Split.TRAIN, gen_kwargs={
-                        "files_path":  os.path.join(path, "20_newsgroups", self.config.sub_dir)
-                })
+                    name=nlp.Split.TRAIN,
+                    gen_kwargs={"files_path": os.path.join(path, "20_newsgroups", self.config.sub_dir)},
+                )
             ]
         else:
             return [
                 nlp.SplitGenerator(
-                    name=nlp.Split.TRAIN, gen_kwargs={
-                        "files_path":  os.path.join(path, "20news-18828", self.config.sub_dir)
-                })
+                    name=nlp.Split.TRAIN,
+                    gen_kwargs={"files_path": os.path.join(path, "20news-18828", self.config.sub_dir)},
+                )
             ]
-            
+
     def _generate_examples(self, files_path):
         """Yields examples."""
         files = sorted(os.listdir(files_path))
         for id_, file in enumerate(files):
             filepath = os.path.join(files_path, file)
-            with open(filepath, encoding="utf8", errors='ignore') as f:  #here we can ignore byte encoded tokens. we only have a very few and in most case it happens at the end of the file (kind of \FF)
+            with open(
+                filepath, encoding="utf8", errors="ignore"
+            ) as f:  # here we can ignore byte encoded tokens. we only have a very few and in most case it happens at the end of the file (kind of \FF)
                 text = f.read()
-                yield id_, {
-                    'text': text
-                }
-                
-                
-        
+                yield id_, {"text": text}

--- a/datasets/style_change_detection/style_change_detection.py
+++ b/datasets/style_change_detection/style_change_detection.py
@@ -102,7 +102,6 @@ class StyleChangeDetection(nlp.GeneratorBasedBuilder):
                 )
             )
 
-
         return [
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,

--- a/src/nlp/metric.py
+++ b/src/nlp/metric.py
@@ -17,6 +17,7 @@
 """ Metrics base class."""
 import logging
 import os
+import types
 from contextlib import contextmanager
 from typing import Any, Dict, Optional
 
@@ -28,7 +29,7 @@ from .arrow_reader import ArrowReader
 from .arrow_writer import ArrowWriter
 from .info import MetricInfo
 from .naming import camelcase_to_snakecase
-from .utils import HF_METRICS_CACHE, Version
+from .utils import HF_METRICS_CACHE, Version, copyfunc
 
 
 logger = logging.getLogger(__file__)
@@ -103,6 +104,9 @@ class Metric(object):
         self.info = info
 
         # Update 'compute' and 'add' docstring
+        self.compute = types.MethodType(copyfunc(self.compute), self)
+        self.add_batch = types.MethodType(copyfunc(self.add_batch), self)
+        self.add = types.MethodType(copyfunc(self.add), self)
         self.compute.__func__.__doc__ += self.info.inputs_description
         self.add_batch.__func__.__doc__ += self.info.inputs_description
         self.add.__func__.__doc__ += self.info.inputs_description

--- a/src/nlp/metric.py
+++ b/src/nlp/metric.py
@@ -104,6 +104,7 @@ class Metric(object):
         self.info = info
 
         # Update 'compute' and 'add' docstring
+        # methods need to be copied otherwise it changes the docstrings of every instance
         self.compute = types.MethodType(copyfunc(self.compute), self)
         self.add_batch = types.MethodType(copyfunc(self.add_batch), self)
         self.add = types.MethodType(copyfunc(self.add), self)

--- a/src/nlp/utils/py_utils.py
+++ b/src/nlp/utils/py_utils.py
@@ -22,6 +22,7 @@ import contextlib
 import functools
 import itertools
 import os
+import types
 from io import BytesIO as StringIO
 from shutil import disk_usage
 from types import CodeType
@@ -358,3 +359,7 @@ def save_code(pickler, obj):
     pickler.save_reduce(CodeType, args, obj=obj)
     dill._dill.log.info("# Co")
     return
+
+
+def copyfunc(func):
+    return types.FunctionType(func.__code__, func.__globals__, func.__name__, func.__defaults__, func.__closure__)


### PR DESCRIPTION
We change the docstrings of `nlp.Metric.compute`, `nlp.Metric.add` and `nlp.Metric.add_batch` depending on which metric is instantiated. However we had issues when instantiating multiple metrics (docstrings were duplicated).

This should fix #304 