### PR TITLE
- Corrected encoding for IMDB.

### DIFF
--- a/datasets/imdb/imdb.py
+++ b/datasets/imdb/imdb.py
@@ -105,11 +105,11 @@ class Imdb(nlp.GeneratorBasedBuilder):
             for key in files:
                 for id_, file in enumerate(files[key]):
                     filepath = os.path.join(directory, key, file)
-                    with open(filepath) as f:
+                    with open(filepath, encoding='UTF-8') as f:
                         yield key + "_" + str(id_), {"text": f.read(), "label": key}
         else:
             unsup_files = sorted(os.listdir(os.path.join(directory, "unsup")))
             for id_, file in enumerate(unsup_files):
                 filepath = os.path.join(directory, "unsup", file)
-                with open(filepath) as f:
+                with open(filepath, encoding='UTF-8') as f:
                     yield id_, {"text": f.read(), "label": -1}


### PR DESCRIPTION
The preparation phase (after the download phase) crashed on windows because of charmap encoding not being able to decode certain characters. This change suggested in Issue #347 fixes it for the IMDB dataset.