### PR TITLE
Fix handling of config files while loading datasets from multiple processes

### DIFF
--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -15,7 +15,7 @@
 
 # Lint as: python3
 """Access datasets."""
-
+import filecmp
 import importlib
 import inspect
 import itertools
@@ -356,7 +356,7 @@ def prepare_module(
             else:
                 logger.info("Couldn't find dataset infos file at %s", dataset_infos)
         else:
-            if local_dataset_infos_path is not None:
+            if local_dataset_infos_path is not None and not filecmp.cmp(local_dataset_infos_path, dataset_infos_path):
                 logger.info("Updating dataset infos file from %s to %s", dataset_infos, dataset_infos_path)
                 shutil.copyfile(local_dataset_infos_path, dataset_infos_path)
             else:


### PR DESCRIPTION
When loading shards on several processes, each process upon loading the dataset will overwrite dataset_infos.json in <package path>/datasets/<dataset name>/<hash>/dataset_infos.json. It does so every time, even when the target file already exists and is identical. Because multiple processes rewrite the same file in parallel, it creates a race condition when a process tries to load the file, often resulting in a JSON decoding exception because the file is only partially written.

This pull requests partially address this by comparing if the files are already identical before copying over the downloaded copy to the cached destination. There's still a race condition, but now it's less likely to occur if some basic precautions are taken by the library user, e.g., download all datasets to cache before spawning multiple processes.