### PR TITLE
Fixed check for pyarrow

### DIFF
--- a/src/nlp/__init__.py
+++ b/src/nlp/__init__.py
@@ -37,7 +37,7 @@ from .utils import *
 from .utils.tqdm_utils import disable_progress_bar
 
 
-if int(pyarrow.__version__.split(".")[1]) < 16 or int(pyarrow.__version__.split(".")[0]) > 0:
+if int(pyarrow.__version__.split(".")[1]) < 16 and int(pyarrow.__version__.split(".")[0]) == 0:
     raise ImportWarning(
         "To use `nlp`, the module `pyarrow>=0.16.0` is required, and the current version of `pyarrow` doesn't match this condition.\n"
         "If you are running this in a Google Colab, you should probably just restart the runtime to use the right version of `pyarrow`."


### PR DESCRIPTION
Fix check for pyarrow in __init__.py.  Previously would raise an error for pyarrow >= 1.0.0