### PR TITLE
Fix user specified features in map

### DIFF
--- a/datasets/emo/emo.py
+++ b/datasets/emo/emo.py
@@ -16,8 +16,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import nlp
 import json
+
+import nlp
 
 
 _CITATION = """\

--- a/datasets/web_of_science/web_of_science.py
+++ b/datasets/web_of_science/web_of_science.py
@@ -40,7 +40,9 @@ full dataset. WOS-11967 and WOS-5736 are two subsets of WOS-46985.
 
 """
 
-_DATA_URL = "https://data.mendeley.com/datasets/9rw3vkcfy4/6/files/c9ea673d-5542-44c0-ab7b-f1311f7d61df/WebOfScience.zip?dl=1"
+_DATA_URL = (
+    "https://data.mendeley.com/datasets/9rw3vkcfy4/6/files/c9ea673d-5542-44c0-ab7b-f1311f7d61df/WebOfScience.zip?dl=1"
+)
 
 
 class WebOfScienceConfig(nlp.BuilderConfig):
@@ -52,11 +54,14 @@ class WebOfScienceConfig(nlp.BuilderConfig):
         Args:
         **kwargs: keyword arguments forwarded to super.
         """
-        super(WebOfScienceConfig, self).__init__(version=nlp.Version("6.0.0", "New split API (https://tensorflow.org/datasets/splits)"),**kwargs)
-        
+        super(WebOfScienceConfig, self).__init__(
+            version=nlp.Version("6.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
+        )
+
 
 class WebOfScience(nlp.GeneratorBasedBuilder):
     """Web of Science"""
+
     BUILDER_CONFIGS = [
         WebOfScienceConfig(
             name="WOS5736",
@@ -64,24 +69,23 @@ class WebOfScience(nlp.GeneratorBasedBuilder):
         ),
         WebOfScienceConfig(
             name="WOS11967",
-            description="""Web of Science Dataset WOS-11967: This dataset contains 11,967 documents with 35 categories which include 7 parents categories."""
+            description="""Web of Science Dataset WOS-11967: This dataset contains 11,967 documents with 35 categories which include 7 parents categories.""",
         ),
         WebOfScienceConfig(
             name="WOS46985",
-            description="""Web of Science Dataset WOS-46985: This dataset contains 46,985 documents with 134 categories which include 7 parents categories."""
-        )
+            description="""Web of Science Dataset WOS-46985: This dataset contains 46,985 documents with 134 categories which include 7 parents categories.""",
+        ),
     ]
-    
 
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION + self.config.description,
             features=nlp.Features(
                 {
-                   "input_data": nlp.Value('string'),
-                   "label": nlp.Value('int32'),
-                   "label_level_1": nlp.Value("int32"),
-                   "label_level_2": nlp.Value("int32"),
+                    "input_data": nlp.Value("string"),
+                    "label": nlp.Value("int32"),
+                    "label_level_1": nlp.Value("int32"),
+                    "label_level_2": nlp.Value("int32"),
                 }
             ),
             # No default supervised_keys (as we have to pass both premise
@@ -90,10 +94,10 @@ class WebOfScience(nlp.GeneratorBasedBuilder):
             homepage="https://data.mendeley.com/datasets/9rw3vkcfy4/6",
             citation=_CITATION,
         )
-        
+
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
-        
+
         # dl_manager is a nlp.download.DownloadManager that can be used to
 
         dl_path = dl_manager.download_and_extract(_DATA_URL)
@@ -101,10 +105,12 @@ class WebOfScience(nlp.GeneratorBasedBuilder):
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
                 # These kwargs will be passed to _generate_examples
-                gen_kwargs={"input_file": os.path.join(dl_path, self.config.name, 'X.txt'),
-                            "label_file": os.path.join(dl_path, self.config.name, 'Y.txt'),
-                            "label_level_1_file": os.path.join(dl_path, self.config.name, 'YL1.txt'),
-                            "label_level_2_file": os.path.join(dl_path, self.config.name, 'YL2.txt')},
+                gen_kwargs={
+                    "input_file": os.path.join(dl_path, self.config.name, "X.txt"),
+                    "label_file": os.path.join(dl_path, self.config.name, "Y.txt"),
+                    "label_level_1_file": os.path.join(dl_path, self.config.name, "YL1.txt"),
+                    "label_level_2_file": os.path.join(dl_path, self.config.name, "YL2.txt"),
+                },
             )
         ]
 

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -842,10 +842,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file
 
             # Create new Dataset from buffer or file
+            info = self.info.copy()
+            info.features = writer._features
             if buf_writer is None:
-                return Dataset.from_file(cache_file_name, info=self.info, split=self.split)
+                return Dataset.from_file(cache_file_name, info=info, split=self.split)
             else:
-                return Dataset.from_buffer(buf_writer.getvalue(), info=self.info, split=self.split)
+                return Dataset.from_buffer(buf_writer.getvalue(), info=info, split=self.split)
         else:
             return self
 

--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -73,7 +73,6 @@ class ArrowWriter(object):
         if disable_nullable and self._schema is not None:
             self._schema = pa.schema(pa.field(field.name, field.type, nullable=False) for field in self._type)
             self._type = pa.struct(pa.field(field.name, field.type, nullable=False) for field in self._type)
-            self._features = Features.from_arrow_schema(self._schema)
 
         self._path = path
         if stream is None:
@@ -93,8 +92,10 @@ class ArrowWriter(object):
 
     def _build_writer(self, schema: pa.Schema):
         self._schema: pa.Schema = schema
-        self._type: pa.DataType = pa.struct(field for field in self._schema)
-        self._features = Features.from_arrow_schema(self._schema)
+        if self._type is None:
+            self._type: pa.DataType = pa.struct(field for field in self._schema)
+        if self._features is None:
+            self._features: Features = Features.from_arrow_schema(self._schema)
         self.pa_writer = pa.RecordBatchStreamWriter(self.stream, schema)
 
     @property

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 
 from nlp import concatenate_datasets
 from nlp.arrow_dataset import Dataset
-from nlp.features import Features, Sequence, Value
+from nlp.features import ClassLabel, Features, Sequence, Value
 from nlp.info import DatasetInfo
 
 
@@ -109,6 +109,20 @@ class BaseDatasetTest(TestCase):
             self.assertDictEqual(
                 dset_test_with_indices.features,
                 Features({"filename": Value("string"), "name": Value("string"), "id": Value("int64")}),
+            )
+
+    def test_new_features(self):
+        dset = self._create_dummy_dataset()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            features = Features({"filename": Value("string"), "label": ClassLabel(names=["positive", "negative"])})
+            dset_test_with_indices = dset.map(
+                lambda x, i: {"label": i % 2}, with_indices=True, cache_file_name=tmp_file, features=features
+            )
+            self.assertEqual(len(dset_test_with_indices), 30)
+            self.assertDictEqual(
+                dset_test_with_indices.features, features,
             )
 
     def test_map_batched(self):


### PR DESCRIPTION
`.map` didn't keep the user specified features because of an issue in the writer.
The writer used to overwrite the user specified features with inferred features.

I also added tests to make sure it doesn't happen again.