### PR TITLE
Fix csv/json/txt cache dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ REQUIRED_PKGS = [
     "dataclasses;python_version<'3.7'",
     # filesystem locks e.g. to prevent parallel downloads
     "filelock",
+    # for fast hashing
+    "xxhash"
 ]
 
 TESTS_REQUIRE = [

--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -24,10 +24,10 @@ import os
 import shutil
 from dataclasses import dataclass
 from functools import partial
-from hashlib import sha256
 from typing import Dict, List, Optional, Union
 
 import pyarrow as pa
+import xxhash
 
 from . import utils
 from .arrow_dataset import Dataset
@@ -232,7 +232,7 @@ class DatasetBuilder:
             # if not builder_config.description:
             #     raise ValueError("BuilderConfig %s must have a description" % name)
         if builder_config.data_files is not None:
-            m = sha256()
+            m = xxhash.xxh64()
             if isinstance(builder_config.data_files, str):
                 data_files = [builder_config.data_files]
             elif isinstance(builder_config.data_files, (tuple, list)):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -121,3 +121,74 @@ class BuilderTest(TestCase):
                     os.path.join(tmp_dir, "dummy_generator_based_builder", "dummy", "0.0.0", "dataset_info.json")
                 )
             )
+
+    def test_cache_dir_for_data_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dummy_data1 = os.path.join(tmp_dir, "dummy_data1.txt")
+            with open(dummy_data1, "w") as f:
+                f.writelines("foo bar")
+            dummy_data2 = os.path.join(tmp_dir, "dummy_data2.txt")
+            with open(dummy_data2, "w") as f:
+                f.writelines("foo bar\n")
+
+            dummy_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=dummy_data1)
+            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=dummy_data1)
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1])
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1}
+            )
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"train": [dummy_data1]}
+            )
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"test": dummy_data1}
+            )
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=dummy_data2)
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(cache_dir=tmp_dir, name="dummy", data_files=[dummy_data2])
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1, dummy_data2]
+            )
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+
+            dummy_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1, dummy_data2]
+            )
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files=[dummy_data1, dummy_data2]
+            )
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files=[dummy_data2, dummy_data1]
+            )
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+
+            dummy_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1, "test": dummy_data2}
+            )
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1, "test": dummy_data2}
+            )
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"train": [dummy_data1], "test": dummy_data2}
+            )
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"test": dummy_data2, "train": dummy_data1}
+            )
+            self.assertEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"train": dummy_data1, "validation": dummy_data2}
+            )
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)
+            other_builder = DummyGeneratorBasedBuilder(
+                cache_dir=tmp_dir, name="dummy", data_files={"train": [dummy_data1, dummy_data2], "test": dummy_data2}
+            )
+            self.assertNotEqual(dummy_builder.cache_dir, other_builder.cache_dir)

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# Copyright 2020 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import tempfile
+
+from absl.testing import parameterized
+
+from nlp import DownloadConfig, GenerateMode, hf_api, load_metric
+
+from .utils import aws, slow
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def get_aws_metric_names():
+    api = hf_api.HfApi()
+    # fetch all metric names
+    metrics = [x.id for x in api.metric_list()]
+    return [{"testcase_name": x, "metric_name": x} for x in metrics]
+
+
+@parameterized.named_parameters(get_aws_metric_names())
+@aws
+class AWSMetricTest(parameterized.TestCase):
+    metric_name = None
+
+    @slow
+    def test_load_real_metric(self, metric_name):
+        with tempfile.TemporaryDirectory() as temp_data_dir:
+            download_config = DownloadConfig()
+            download_config.download_mode = GenerateMode.FORCE_REDOWNLOAD
+            load_metric(metric_name, data_dir=temp_data_dir, download_config=download_config)


### PR DESCRIPTION
The cache dir for csv/json/txt datasets was always the same. This is an issue because it should be different depending on the data files provided by the user.

To fix that, I added a line that use the hash of the data files provided by the user to define the cache dir.

This should fix #444 