### PR TITLE
add set_format to DatasetDict + tests

### DIFF
--- a/datasets/sogou_news/sogou_news.py
+++ b/datasets/sogou_news/sogou_news.py
@@ -17,15 +17,15 @@
 """Sogou News"""
 
 from __future__ import absolute_import, division, print_function
+
+import csv
 import os
+import sys
 
 import nlp
 
-import sys
-import csv
 
 csv.field_size_limit(sys.maxsize)
-
 
 
 _CITATION = """\
@@ -59,37 +59,33 @@ class Sogou_News(nlp.GeneratorBasedBuilder):
                 {
                     "title": nlp.Value("string"),
                     "content": nlp.Value("string"),
-                    "label": nlp.features.ClassLabel(names=["sports", "finance", "entertainment", "automobile", "technology"])
+                    "label": nlp.features.ClassLabel(
+                        names=["sports", "finance", "entertainment", "automobile", "technology"]
+                    ),
                 }
             ),
             # No default supervised_keys (as we have to pass both premise
             # and hypothesis as input).
             supervised_keys=None,
-            homepage="", #didn't find a real homepage
+            homepage="",  # didn't find a real homepage
             citation=_CITATION,
         )
-        
 
     def _split_generators(self, dl_manager):
         dl_dir = dl_manager.download_and_extract(_DATA_URL)
-        
+
         return [
-            nlp.SplitGenerator(name=nlp.Split.TEST, 
-                               gen_kwargs={"filepath": os.path.join(dl_dir, "sogou_news_csv", "test.csv")}),
-           
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, 
-                               gen_kwargs={"filepath": os.path.join(dl_dir, "sogou_news_csv",  "train.csv")}),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST, gen_kwargs={"filepath": os.path.join(dl_dir, "sogou_news_csv", "test.csv")}
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN, gen_kwargs={"filepath": os.path.join(dl_dir, "sogou_news_csv", "train.csv")}
+            ),
         ]
 
     def _generate_examples(self, filepath):
         """This function returns the examples in the raw (text) form."""
         with open(filepath) as csv_file:
-            data =csv.reader(csv_file)
+            data = csv.reader(csv_file)
             for id_, row in enumerate(data):
-                yield id_, {
-                    "title": row[1],
-                    "content": row[2],
-                    "label": int(row[0]) - 1
-                }
-            
-           
+                yield id_, {"title": row[1], "content": row[2], "label": int(row[0]) - 1}

--- a/datasets/xtreme/xtreme.py
+++ b/datasets/xtreme/xtreme.py
@@ -454,11 +454,13 @@ class Xtreme(nlp.GeneratorBasedBuilder):
             features["gold_label"] = nlp.Value("string")
 
         if self.config.name.startswith("PAN-X"):
-            features = nlp.Features({
-                "words": nlp.Sequence(nlp.Value("string")),
-                "ner_tags": nlp.Sequence(nlp.Value("string")),
-                "langs": nlp.Sequence(nlp.Value("string")),
-            })
+            features = nlp.Features(
+                {
+                    "words": nlp.Sequence(nlp.Value("string")),
+                    "ner_tags": nlp.Sequence(nlp.Value("string")),
+                    "langs": nlp.Sequence(nlp.Value("string")),
+                }
+            )
         return nlp.DatasetInfo(
             # This is the description that will appear on the datasets page.
             description=self.config.description + "\n" + _DESCRIPTION,

--- a/docs/source/package_reference/main_classes.rst
+++ b/docs/source/package_reference/main_classes.rst
@@ -34,7 +34,7 @@ Dictionary with split names as keys ('train', 'test' for example), and :obj:`nlp
 It also has dataset transform methods like map or filter, to process all the splits at once.
 
 .. autoclass:: nlp.DatasetDict
-    :members: map, filter, sort, shuffle
+    :members: map, filter, sort, shuffle, set_format, reset_format, formated_as
 
 
 ``Features``

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -445,8 +445,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 logger.error("Tensorflow needs to be installed to be able to return Tensorflow tensors.")
         else:
             assert not (
-                type == "pandas" and format_kwargs is not None
-            ), "Format type 'pandas' doesn't have any `**format_kwargs`."
+                type == "pandas" and (output_all_columns or format_kwargs)
+            ), "Format type 'pandas' doesn't allow the use of `output_all_columns` or `**format_kwargs`."
             assert (
                 type is None or type == "numpy" or type == "pandas"
             ), "Return type should be None or selected in ['numpy', 'torch', 'tensorflow', 'pandas']."
@@ -516,6 +516,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         if isinstance(outputs, (list, tuple)):
             return command(outputs)
+        elif isinstance(outputs, pd.DataFrame):
+            if format_columns is not None and not output_all_columns:
+                to_remove_columns = [col for col in self.column_names if col not in format_columns]
+                output_dict = outputs.drop(to_remove_columns, axis=1)
         else:
             output_dict = {}
             for k, v in outputs.items():
@@ -552,26 +556,28 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 key = self._data.num_rows + key
             if key >= self._data.num_rows:
                 raise IndexError(f"Index ({key}) outside of table length ({self._data.num_rows}).")
-            if format_type is not None and format_type == "pandas":
-                outputs = self._data.slice(key, 1).to_pandas()
-            if format_type is not None and format_type in ("numpy", "torch", "tensorflow"):
-                outputs = self._unnest(self._data.slice(key, 1).to_pandas().to_dict("list"))
+            if format_type is not None:
+                if format_type == "pandas":
+                    outputs = self._data.slice(key, 1).to_pandas()
+                else:
+                    outputs = self._unnest(self._data.slice(key, 1).to_pandas().to_dict("list"))
             else:
                 outputs = self._unnest(self._data.slice(key, 1).to_pydict())
         elif isinstance(key, slice):
             key_indices = key.indices(self._data.num_rows)
             if key_indices[2] != 1 or key_indices[1] < key_indices[0]:
                 raise ValueError("Slicing can only take contiguous and ordered slices.")
-            if format_type is not None and format_type == "pandas":
-                outputs = self._data.slice(key_indices[0], key_indices[1] - key_indices[0]).to_pandas(
-                    split_blocks=True
-                )
-            elif format_type is not None and format_type in ("numpy", "torch", "tensorflow"):
-                outputs = (
-                    self._data.slice(key_indices[0], key_indices[1] - key_indices[0])
-                    .to_pandas(split_blocks=True)
-                    .to_dict("list")
-                )
+            if format_type is not None:
+                if format_type == "pandas":
+                    outputs = self._data.slice(key_indices[0], key_indices[1] - key_indices[0]).to_pandas(
+                        split_blocks=True
+                    )
+                else:
+                    outputs = (
+                        self._data.slice(key_indices[0], key_indices[1] - key_indices[0])
+                        .to_pandas(split_blocks=True)
+                        .to_dict("list")
+                    )
             else:
                 outputs = self._data.slice(key_indices[0], key_indices[1] - key_indices[0]).to_pydict()
         elif isinstance(key, str):
@@ -581,7 +587,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 if format_columns is None or key in format_columns:
                     if format_type == "pandas":
                         outputs = self._data[key].to_pandas(split_blocks=True)
-                    if format_type in ("numpy", "torch", "tensorflow"):
+                    elif format_type in ("numpy", "torch", "tensorflow"):
                         outputs = self._data[key].to_pandas(split_blocks=True).to_numpy()
                     else:
                         outputs = self._data[key].to_pylist()
@@ -591,21 +597,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 outputs = self._data[key].to_pylist()
         elif isinstance(key, Iterable):
             data_subset = pa.concat_tables(self._data.slice(int(i), 1) for i in key)
-            if format_type is not None and format_type == "pandas":
-                outputs = data_subset.to_pandas(split_blocks=True)
-            if format_type is not None and format_type in ("numpy", "torch", "tensorflow"):
-                outputs = data_subset.to_pandas(split_blocks=True).to_dict("list")
+            if format_type is not None:
+                if format_type == "pandas":
+                    outputs = data_subset.to_pandas(split_blocks=True)
+                else:
+                    outputs = data_subset.to_pandas(split_blocks=True).to_dict("list")
             else:
                 outputs = data_subset.to_pydict()
 
         else:
             raise ValueError("Can only get row(s) (int or slice or list[int]) or columns (string).")
 
-        if (
-            (format_type is not None or format_columns is not None)
-            and not isinstance(key, str)
-            and format_type != "pandas"
-        ):
+        if (format_type is not None or format_columns is not None) and not isinstance(key, str):
             outputs = self._convert_outputs(
                 outputs,
                 format_type=format_type,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -20,9 +20,7 @@ class BaseDatasetTest(TestCase):
             data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}
             dset = Dataset.from_dict(data)
         else:
-            dset = Dataset(
-                pa.Table.from_pydict({"filename": ["my_name-train" + "_" + str(x) for x in np.arange(30).tolist()]})
-            )
+            dset = Dataset.from_dict({"filename": ["my_name-train" + "_" + str(x) for x in np.arange(30).tolist()]})
         return dset
 
     def test_dummy_dataset(self):

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -4,21 +4,147 @@ from typing import Dict
 from unittest import TestCase
 
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 
 from nlp.arrow_dataset import Dataset
 from nlp.dataset_dict import DatasetDict
 
+from .utils import require_tf, require_torch
+
 
 class DatasetDictTest(TestCase):
-    def _create_dummy_dataset(self) -> Dataset:
-        dset = Dataset(
-            pa.Table.from_pydict({"filename": ["my_name-train" + "_" + str(x) for x in np.arange(30).tolist()]})
-        )
+    def _create_dummy_dataset(self, multiple_columns=False):
+        if multiple_columns:
+            data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}
+            dset = Dataset.from_dict(data)
+        else:
+            dset = Dataset(
+                pa.Table.from_pydict({"filename": ["my_name-train" + "_" + str(x) for x in np.arange(30).tolist()]})
+            )
         return dset
 
-    def _create_dummy_dataset_dict(self) -> DatasetDict:
-        return DatasetDict({"train": self._create_dummy_dataset(), "test": self._create_dummy_dataset()})
+    def _create_dummy_dataset_dict(self, multiple_columns=False) -> DatasetDict:
+        return DatasetDict(
+            {
+                "train": self._create_dummy_dataset(multiple_columns=multiple_columns),
+                "test": self._create_dummy_dataset(multiple_columns=multiple_columns),
+            }
+        )
+
+    def test_set_format_numpy(self):
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        dset.set_format(type="numpy", columns=["col_1"])
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 1)
+            self.assertIsInstance(dset_split[0]["col_1"], np.ndarray)
+            self.assertListEqual(list(dset_split[0]["col_1"].shape), [])
+            self.assertEqual(dset_split[0]["col_1"].item(), 3)
+
+        dset.reset_format()
+        with dset.formated_as(type="numpy", columns=["col_1"]):
+            for dset_split in dset.values():
+                self.assertEqual(len(dset_split[0]), 1)
+                self.assertIsInstance(dset_split[0]["col_1"], np.ndarray)
+                self.assertListEqual(list(dset_split[0]["col_1"].shape), [])
+                self.assertEqual(dset_split[0]["col_1"].item(), 3)
+
+        for dset_split in dset.values():
+            self.assertEqual(dset_split.format["type"], "python")
+            self.assertEqual(dset_split.format["format_kwargs"], {})
+            self.assertEqual(dset_split.format["columns"], dset_split.column_names)
+            self.assertEqual(dset_split.format["output_all_columns"], False)
+
+        dset.set_format(type="numpy", columns=["col_1"], output_all_columns=True)
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 2)
+            self.assertIsInstance(dset_split[0]["col_2"], str)
+            self.assertEqual(dset_split[0]["col_2"], "a")
+
+        dset.set_format(type="numpy", columns=["col_1", "col_2"])
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 2)
+            self.assertEqual(dset_split[0]["col_2"].item(), "a")
+
+    @require_torch
+    def test_set_format_torch(self):
+        import torch
+
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        dset.set_format(type="torch", columns=["col_1"])
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 1)
+            self.assertIsInstance(dset_split[0]["col_1"], torch.Tensor)
+            self.assertListEqual(list(dset_split[0]["col_1"].shape), [])
+            self.assertEqual(dset_split[0]["col_1"].item(), 3)
+
+        dset.set_format(type="torch", columns=["col_1"], output_all_columns=True)
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 2)
+            self.assertIsInstance(dset_split[0]["col_2"], str)
+            self.assertEqual(dset_split[0]["col_2"], "a")
+
+        dset.set_format(type="torch", columns=["col_1", "col_2"])
+        for dset_split in dset.values():
+            with self.assertRaises(TypeError):
+                dset_split[0]
+
+    @require_tf
+    def test_set_format_tf(self):
+        import tensorflow as tf
+
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        dset.set_format(type="tensorflow", columns=["col_1"])
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 1)
+            self.assertIsInstance(dset_split[0]["col_1"], tf.Tensor)
+            self.assertListEqual(list(dset_split[0]["col_1"].shape), [])
+            self.assertEqual(dset_split[0]["col_1"].numpy().item(), 3)
+
+        dset.set_format(type="tensorflow", columns=["col_1"], output_all_columns=True)
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 2)
+            self.assertIsInstance(dset_split[0]["col_2"], str)
+            self.assertEqual(dset_split[0]["col_2"], "a")
+
+        dset.set_format(type="tensorflow", columns=["col_1", "col_2"])
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0]), 2)
+            self.assertEqual(dset_split[0]["col_2"].numpy().decode("utf-8"), "a")
+
+    def test_set_format_pandas(self):
+        dset = self._create_dummy_dataset_dict(multiple_columns=True)
+        dset.set_format(type="pandas", columns=["col_1"])
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0].columns), 1)
+            self.assertIsInstance(dset_split[0], pd.DataFrame)
+            self.assertListEqual(list(dset_split[0].shape), [1, 1])
+            self.assertEqual(dset_split[0]["col_1"].item(), 3)
+
+        dset.set_format(type="pandas", columns=["col_1", "col_2"])
+        for dset_split in dset.values():
+            self.assertEqual(len(dset_split[0].columns), 2)
+            self.assertEqual(dset_split[0]["col_2"].item(), "a")
+
+    def test_set_format(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dsets = self._create_dummy_dataset_dict()
+
+            mapped_dsets_1: Dict[str, Dataset] = dsets.map(
+                lambda ex: {"foo": ["bar"] * len(ex["filename"])}, batched=True
+            )
+            self.assertListEqual(list(dsets.keys()), list(mapped_dsets_1.keys()))
+            self.assertListEqual(mapped_dsets_1["train"].column_names, ["filename", "foo"])
+
+            cache_file_names = {
+                "train": os.path.join(tmp_dir, "train.arrow"),
+                "test": os.path.join(tmp_dir, "test.arrow"),
+            }
+            mapped_dsets_2: Dict[str, Dataset] = mapped_dsets_1.map(
+                lambda ex: {"bar": ["foo"] * len(ex["filename"])}, batched=True, cache_file_names=cache_file_names
+            )
+            self.assertListEqual(list(dsets.keys()), list(mapped_dsets_2.keys()))
+            self.assertListEqual(mapped_dsets_2["train"].column_names, ["filename", "foo", "bar"])
 
     def test_map(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,8 @@ import os
 import unittest
 from distutils.util import strtobool
 
+from nlp.utils.file_utils import _tf_available, _torch_available
+
 
 def parse_flag_from_env(key, default=False):
     try:
@@ -22,6 +24,30 @@ def parse_flag_from_env(key, default=False):
 _run_slow_tests = parse_flag_from_env("RUN_SLOW", default=False)
 _run_aws_tests = parse_flag_from_env("RUN_AWS", default=True)
 _run_local_tests = parse_flag_from_env("RUN_LOCAL", default=True)
+
+
+def require_torch(test_case):
+    """
+    Decorator marking a test that requires PyTorch.
+
+    These tests are skipped when PyTorch isn't installed.
+
+    """
+    if not _torch_available:
+        test_case = unittest.skip("test requires PyTorch")(test_case)
+    return test_case
+
+
+def require_tf(test_case):
+    """
+    Decorator marking a test that requires TensorFlow.
+
+    These tests are skipped when TensorFlow isn't installed.
+
+    """
+    if not _tf_available:
+        test_case = unittest.skip("test requires TensorFlow")(test_case)
+    return test_case
 
 
 def slow(test_case):


### PR DESCRIPTION
Add the `set_format` and `formated_as` and `reset_format` to `DatasetDict`.
Add tests to these for `Dataset` and `DatasetDict`.
Fix some bugs uncovered by the tests for `pandas` formating.