### PR TITLE
Fix KeyboardInterrupt in map and bad indices in select

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -861,7 +861,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file
         except (Exception, KeyboardInterrupt):
             if tmp_file is not None:
-                os.remove(tmp_file.name)
+                if os.path.exists(tmp_file.name):
+                    os.remove(tmp_file.name)
             raise
 
         if tmp_file is not None:
@@ -1040,7 +1041,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file
         except (Exception, KeyboardInterrupt):
             if tmp_file is not None:
-                os.remove(tmp_file.name)
+                if os.path.exists(tmp_file.name):
+                    os.remove(tmp_file.name)
             raise
 
         if tmp_file is not None:

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -861,7 +861,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 writer.finalize()  # close_stream=bool(buf_writer is None))  # We only close if we are writing in a file
         except (Exception, KeyboardInterrupt):
             if tmp_file is not None:
-                pass
                 os.remove(tmp_file.name)
             raise
 


### PR DESCRIPTION
If you interrupted a map function while it was writing, the cached file was not discarded.
Therefore the next time you called map, it was loading an incomplete arrow file.

We had the same issue with select if there was a bad indice at one point.

To fix that I used temporary files that are renamed once everything is finished.