### PR TITLE
Add rename, remove and cast in-place operations

### DIFF
--- a/docs/source/package_reference/main_classes.rst
+++ b/docs/source/package_reference/main_classes.rst
@@ -18,6 +18,7 @@ The base class :class:`nlp.Dataset` implements a Dataset backed by an Apache Arr
         drop, unique, dictionary_encode_column, flatten,
         __len__, __iter__, formated_as, set_format, reset_format,
         __getitem__, cleanup_cache_files,
+        cast_, remove_column_, rename_column_,
         map, filter, select, sort, shuffle, train_test_split, shard, export,
         add_faiss_index, add_faiss_index_from_external_arrays, save_faiss_index, load_faiss_index,
         add_elasticsearch_index,
@@ -34,7 +35,7 @@ Dictionary with split names as keys ('train', 'test' for example), and :obj:`nlp
 It also has dataset transform methods like map or filter, to process all the splits at once.
 
 .. autoclass:: nlp.DatasetDict
-    :members: map, filter, sort, shuffle, set_format, reset_format, formated_as
+    :members: map, filter, sort, shuffle, set_format, reset_format, formated_as, cast_, remove_column_, rename_column_
 
 
 ``Features``

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -369,11 +369,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         You can also remove a column using :func:`Dataset.map` with `feature` but :func:`cast_`
         is in-place (doesn't copy the data to a new dataset) and is thus faster.
         """
-        if any(field_name not in self.features for field_name in features):
+        if list(features) != self._data.column_names:
             raise ValueError(
-                "Field {} not in the dataset. Current fields in the dataset: {}".format(
-                    list(filter(lambda col: col not in self._data.column_names, features)), self._data.column_names
-                )
+                f"The columns in features ({list(features)}) must be identical and in the same order "
+                f"as the columns in the dataset: {self._data.column_names}"
             )
 
         self._info.features = features

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -362,12 +362,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
     def cast_(self, features: Features):
         """
-        Cast the dataset to a new set of features. The name of the fields in the features must match.
-        The type of the data must also be convertible from one type to the other.
-        For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
+        Cast the dataset to a new set of features.
 
         You can also remove a column using :func:`Dataset.map` with `feature` but :func:`cast_`
         is in-place (doesn't copy the data to a new dataset) and is thus faster.
+
+        Args:
+            features (:class:`nlp.Features`): New features to cast the dataset to.
+                The name and order of the fields in the features must match the current column names.
+                The type of the data must also be convertible from one type to the other.
+                For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
         """
         if list(features) != self._data.column_names:
             raise ValueError(
@@ -385,6 +389,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         You can also remove a column using :func:`Dataset.map` with `remove_columns` but the present method
         is in-place (doesn't copy the data to a new dataset) and is thus faster.
+
+        Args:
+            column_name (:obj:`str`): Name of the column to remove.
         """
         if column_name not in self._data.column_names:
             raise ValueError(
@@ -405,6 +412,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         You can also rename a column using :func:`Dataset.map` with `remove_columns` but the present method:
             - takes care of moving the original features under the new column name.
             - doesn't copy the data to a new dataset and is thus much faster.
+
+        Args:
+            original_column_name (:obj:`str`): Name of the column to rename.
+            new_column_name (:obj:`str`): New name for the column.
         """
         if original_column_name not in self._data.column_names:
             raise ValueError(

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -360,6 +360,68 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             "Flattened dataset from depth {} to depth {}.".format(depth, 1 if depth + 1 < max_depth else "unknown")
         )
 
+    def cast_(self, features: Features):
+        """
+        Cast the dataset to a new set of features. The name of the fields in the features must match.
+        The type of the data must also be convertible from one type to the other.
+        For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
+
+        You can also remove a column using :func:`Dataset.map` with `feature` but :func:`cast_`
+        is in-place (doesn't copy the data to a new dataset) and is thus faster.
+        """
+        if any(field_name not in self.features for field_name in features):
+            raise ValueError(
+                "Field {} not in the dataset. Current fields in the dataset: {}".format(
+                    list(filter(lambda col: col not in self._data.column_names, features)), self._data.column_names
+                )
+            )
+
+        self._info.features = features
+        schema = pa.schema(features.type)
+        self._data = self._data.cast(schema)
+
+    def remove_column_(self, column_name: str):
+        """
+        Remove a column in the dataset and the features associated to the column.
+
+        You can also remove a column using :func:`Dataset.map` with `remove_columns` but the present method
+        is in-place (doesn't copy the data to a new dataset) and is thus faster.
+        """
+        if column_name not in self._data.column_names:
+            raise ValueError(
+                f"Column name {column_name} not in the dataset. "
+                f"Current columns in the dataset: {self._data.column_names}"
+            )
+
+        column_index = (self._data.column_names).index(column_name)
+
+        del self._info.features[column_name]
+
+        self._data = self._data.remove_column(column_index)
+
+    def rename_column_(self, original_column_name: str, new_column_name: str):
+        """
+        Rename a column in the dataset and move the features associated to the original column under the new column name.
+
+        You can also rename a column using :func:`Dataset.map` with `remove_columns` but the present method:
+            - takes care of moving the original features under the new column name.
+            - doesn't copy the data to a new dataset and is thus much faster.
+        """
+        if original_column_name not in self._data.column_names:
+            raise ValueError(
+                f"Orignal column name {original_column_name} not in the dataset. "
+                f"Current columns in the dataset: {self._data.column_names}"
+            )
+        if not new_column_name:
+            raise ValueError("New column name is empty.")
+
+        new_column_names = [new_column_name if col == original_column_name else col for col in self._data.column_names]
+
+        self._info.features[new_column_name] = self._info.features[original_column_name]
+        del self._info.features[original_column_name]
+
+        self._data = self._data.rename_columns(new_column_names)
+
     def __len__(self):
         """ Number of rows in the dataset """
         return self._data.num_rows

--- a/src/nlp/dataset_dict.py
+++ b/src/nlp/dataset_dict.py
@@ -17,6 +17,56 @@ class DatasetDict(dict):
                     "Values in `DatasetDict` should of type `Dataset` but got type '{}'".format(type(dataset))
                 )
 
+    def cast_(self, features: Features):
+        """
+        Cast the dataset to a new set of features.
+        The transformation is applied to all the datasets of the dataset dictionary.
+
+        You can also remove a column using :func:`Dataset.map` with `feature` but :func:`cast_`
+        is in-place (doesn't copy the data to a new dataset) and is thus faster.
+
+        Args:
+            features (:class:`nlp.Features`): New features to cast the dataset to.
+                The name and order of the fields in the features must match the current column names.
+                The type of the data must also be convertible from one type to the other.
+                For non-trivial conversion, e.g. string <-> ClassLabel you should use :func:`map` to update the Dataset.
+        """
+        self._check_values_type()
+        for dataset in self.values():
+            dataset.cast_(features=features)
+
+    def remove_column_(self, column_name: str):
+        """
+        Remove a column in the dataset and the features associated to the column.
+        The transformation is applied to all the datasets of the dataset dictionary.
+
+        You can also remove a column using :func:`Dataset.map` with `remove_columns` but the present method
+        is in-place (doesn't copy the data to a new dataset) and is thus faster.
+
+        Args:
+            column_name (:obj:`str`): Name of the column to remove.
+        """
+        self._check_values_type()
+        for dataset in self.values():
+            dataset.remove_column_(column_name=column_name)
+
+    def rename_column_(self, original_column_name: str, new_column_name: str):
+        """
+        Rename a column in the dataset and move the features associated to the original column under the new column name.
+        The transformation is applied to all the datasets of the dataset dictionary.
+
+        You can also rename a column using :func:`Dataset.map` with `remove_columns` but the present method:
+            - takes care of moving the original features under the new column name.
+            - doesn't copy the data to a new dataset and is thus much faster.
+
+        Args:
+            original_column_name (:obj:`str`): Name of the column to rename.
+            new_column_name (:obj:`str`): New name for the column.
+        """
+        self._check_values_type()
+        for dataset in self.values():
+            dataset.rename_column_(original_column_name=original_column_name, new_column_name=new_column_name)
+
     @contextlib.contextmanager
     def formated_as(
         self,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -145,6 +145,27 @@ class BaseDatasetTest(TestCase):
         self.assertEqual(len(dset[0].columns), 2)
         self.assertEqual(dset[0]["col_2"].item(), "a")
 
+    def test_cast_(self):
+        dset = self._create_dummy_dataset(multiple_columns=True)
+        features = dset.features
+        features["col_1"] = Value("float64")
+        dset.cast_(features)
+        self.assertEqual(dset.num_columns, 2)
+        self.assertEqual(dset.features["col_1"], Value("float64"))
+        self.assertIsInstance(dset[0]["col_1"], float)
+
+    def test_remove_column_(self):
+        dset = self._create_dummy_dataset(multiple_columns=True)
+        dset.remove_column_(column_name="col_1")
+        self.assertEqual(dset.num_columns, 1)
+        self.assertListEqual(list(dset.column_names), ["col_2"])
+
+    def test_rename_column_(self):
+        dset = self._create_dummy_dataset(multiple_columns=True)
+        dset.rename_column_(original_column_name="col_1", new_column_name="new_name")
+        self.assertEqual(dset.num_columns, 2)
+        self.assertListEqual(list(dset.column_names), ["new_name", "col_2"])
+
     def test_concatenate(self):
         data1, data2, data3 = {"id": [0, 1, 2]}, {"id": [3, 4, 5]}, {"id": [6, 7]}
         info1 = DatasetInfo(description="Dataset1")


### PR DESCRIPTION
Add a bunch of in-place operation leveraging the Arrow back-end to rename and remove columns and cast to new features without using the more expensive `map` method.

These methods are added to `Dataset` as well as `DatasetDict`.

Added tests for these new methods and add the methods to the doc.

Naming follows the new pattern with a trailing underscore indicating in-place methods.