### PR TITLE
Keep features after transform

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -148,10 +148,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         self._output_all_columns: bool = False
         inferred_features = Features.from_arrow_schema(arrow_table.schema)
         if self.info.features is None:  # try to load features from the arrow file metadata
-            if self._data.schema.metadata is not None and "huggingface/datasets".encode("utf-8") in self._data.schema.metadata:
-                self.info.features = DatasetInfo.from_dict(json.loads(
-                    self._data.schema.metadata["huggingface/datasets".encode("utf-8")].decode()
-                )).features
+            if (
+                self._data.schema.metadata is not None
+                and "huggingface/datasets".encode("utf-8") in self._data.schema.metadata
+            ):
+                self.info.features = DatasetInfo.from_dict(
+                    json.loads(self._data.schema.metadata["huggingface/datasets".encode("utf-8")].decode())
+                ).features
         if self.info.features is not None:  # make sure features in self.info match the data
             if self.info.features.type != inferred_features.type:
                 raise ValueError(

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -148,10 +148,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         self._output_all_columns: bool = False
         inferred_features = Features.from_arrow_schema(arrow_table.schema)
         if self.info.features is None:  # try to load features from the arrow file metadata
-            if (
-                self._data.schema.metadata is not None
-                and "huggingface".encode("utf-8") in self._data.schema.metadata
-            ):
+            if self._data.schema.metadata is not None and "huggingface".encode("utf-8") in self._data.schema.metadata:
                 self.info.features = DatasetInfo.from_dict(
                     json.loads(self._data.schema.metadata["huggingface".encode("utf-8")].decode())
                 ).features

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -150,10 +150,10 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if self.info.features is None:  # try to load features from the arrow file metadata
             if (
                 self._data.schema.metadata is not None
-                and "huggingface/datasets".encode("utf-8") in self._data.schema.metadata
+                and "huggingface".encode("utf-8") in self._data.schema.metadata
             ):
                 self.info.features = DatasetInfo.from_dict(
-                    json.loads(self._data.schema.metadata["huggingface/datasets".encode("utf-8")].decode())
+                    json.loads(self._data.schema.metadata["huggingface".encode("utf-8")].decode())
                 ).features
         if self.info.features is not None:  # make sure features in self.info match the data
             if self.info.features.type != inferred_features.type:

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -839,13 +839,23 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             if keep_in_memory or cache_file_name is None:
                 buf_writer = pa.BufferOutputStream()
                 tmp_file = None
-                writer = ArrowWriter(features=features, stream=buf_writer, writer_batch_size=writer_batch_size, update_features=update_features)
+                writer = ArrowWriter(
+                    features=features,
+                    stream=buf_writer,
+                    writer_batch_size=writer_batch_size,
+                    update_features=update_features,
+                )
             else:
                 buf_writer = None
                 if verbose:
                     logger.info("Caching processed dataset at %s", cache_file_name)
                 tmp_file = tempfile.NamedTemporaryFile("wb", dir=os.path.dirname(cache_file_name), delete=False)
-                writer = ArrowWriter(features=features, path=tmp_file.name, writer_batch_size=writer_batch_size, update_features=update_features)
+                writer = ArrowWriter(
+                    features=features,
+                    path=tmp_file.name,
+                    writer_batch_size=writer_batch_size,
+                    update_features=update_features,
+                )
 
         try:
             # Loop over single examples or batches and write to buffer/file if examples are to be updated

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -149,8 +149,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if self.info.features is not None:
             if self.info.features.type != inferred_features.type:
                 raise ValueError(
-                    "External features info don't match the dataset:\nGot\n{}\nbut expected something like\n{}".format(
-                        self.info.features, inferred_features
+                    "External features info don't match the dataset:\nGot\n{}\nwith type\n{}\n\nbut expected something like\n{}\nwith type\n{}".format(
+                        self.info.features, self.info.features.type, inferred_features, inferred_features.type
                     )
                 )
             else:
@@ -158,7 +158,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         else:
             self.info.features = inferred_features
         assert self.features is not None, "Features can't be None in a Dataset object"
-        assert self.features.type == inferred_features.type, "Features should match inferred type"
 
     @classmethod
     def from_file(
@@ -213,6 +212,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 )
             )
         features = features if features is not None else info.features if info is not None else None
+        if info is None:
+            info = DatasetInfo()
+        info.features = features
         pa_table: pa.Table = pa.Table.from_pandas(
             df=df, schema=pa.schema(features.type) if features is not None else None
         )
@@ -243,6 +245,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 )
             )
         features = features if features is not None else info.features if info is not None else None
+        if info is None:
+            info = DatasetInfo()
+        info.features = features
         pa_table: pa.Table = pa.Table.from_pydict(
             mapping=mapping, schema=pa.schema(features.type) if features is not None else None
         )
@@ -826,16 +831,21 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         # Prepare output buffer and batched writer in memory or on file if we update the table
         if update_data:
+            if features is None:
+                features = self.features
+                update_features = True
+            else:
+                update_features = False
             if keep_in_memory or cache_file_name is None:
                 buf_writer = pa.BufferOutputStream()
                 tmp_file = None
-                writer = ArrowWriter(features=features, stream=buf_writer, writer_batch_size=writer_batch_size)
+                writer = ArrowWriter(features=features, stream=buf_writer, writer_batch_size=writer_batch_size, update_features=update_features)
             else:
                 buf_writer = None
                 if verbose:
                     logger.info("Caching processed dataset at %s", cache_file_name)
                 tmp_file = tempfile.NamedTemporaryFile("wb", dir=os.path.dirname(cache_file_name), delete=False)
-                writer = ArrowWriter(features=features, path=tmp_file.name, writer_batch_size=writer_batch_size)
+                writer = ArrowWriter(features=features, path=tmp_file.name, writer_batch_size=writer_batch_size, update_features=update_features)
 
         try:
             # Loop over single examples or batches and write to buffer/file if examples are to be updated

--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -135,7 +135,8 @@ class ArrowWriter(object):
     def write_on_file(self):
         """ Write stored examples
         """
-        type = None if self.update_features else self._type
+        # infer type on first write
+        type = None if self.update_features and self.pa_writer is None else self._type
         if self.current_rows:
             pa_array = pa.array(self.current_rows, type=type)
             first_example = pa.array(self.current_rows[0:1], type=type)[0]

--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -121,9 +121,7 @@ class ArrowWriter(object):
     def _build_metadata(self, info) -> Dict[str, str]:
         keys = ["features"]  # we can add support for more DatasetInfo keys in the future
         info_as_dict = asdict(info)
-        return {"huggingface/datasets": json.dumps({
-            key: info_as_dict[key] for key in keys
-        })}
+        return {"huggingface/datasets": json.dumps({key: info_as_dict[key] for key in keys})}
 
     def _write_array_on_file(self, pa_array):
         """Write a PyArrow Array"""

--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -121,7 +121,7 @@ class ArrowWriter(object):
     def _build_metadata(self, info) -> Dict[str, str]:
         keys = ["features"]  # we can add support for more DatasetInfo keys in the future
         info_as_dict = asdict(info)
-        return {"huggingface/datasets": json.dumps({key: info_as_dict[key] for key in keys})}
+        return {"huggingface": json.dumps({key: info_as_dict[key] for key in keys})}
 
     def _write_array_on_file(self, pa_array):
         """Write a PyArrow Array"""

--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -143,9 +143,7 @@ class ArrowWriter(object):
                 n_batches = len(self.current_rows) // new_batch_size
                 n_batches += int(len(self.current_rows) % new_batch_size != 0)
                 for i in range(n_batches):
-                    pa_array = pa.array(
-                        self.current_rows[i * new_batch_size : (i + 1) * new_batch_size], type=type,
-                    )
+                    pa_array = pa.array(self.current_rows[i * new_batch_size : (i + 1) * new_batch_size], type=type,)
                     self._write_array_on_file(pa_array)
             else:
                 # All good

--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -378,7 +378,9 @@ def get_nested_type(schema: FeatureType) -> pa.DataType:
     """ Convert our Feature nested object in an Apache Arrow type """
     # Nested structures: we allow dict, list/tuples, sequences
     if isinstance(schema, dict):
-        return pa.struct({key: get_nested_type(schema[key]) for key in sorted(schema)})  # sort to make the type deterministic
+        return pa.struct(
+            {key: get_nested_type(schema[key]) for key in sorted(schema)}
+        )  # sort to make the type deterministic
     elif isinstance(schema, (list, tuple)):
         assert len(schema) == 1, "We defining list feature, you should just provide one example of the inner type"
         inner_type = get_nested_type(schema[0])

--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -460,7 +460,8 @@ def generate_from_arrow_type(pa_type: pa.DataType):
     elif isinstance(pa_type, pa.FixedSizeListType):
         return Sequence(feature=generate_from_arrow_type(pa_type.value_type), length=pa_type.list_size)
     elif isinstance(pa_type, pa.ListType):
-        return [generate_from_arrow_type(pa_type.value_type)]
+        # return [generate_from_arrow_type(pa_type.value_type)]
+        return Sequence(feature=generate_from_arrow_type(pa_type.value_type))
     elif isinstance(pa_type, pa.DictionaryType):
         raise NotImplementedError  # TODO(thom) this will need access to the dictionary as well (for labels). I.e. to the py_table
     elif isinstance(pa_type, pa.DataType):

--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -277,7 +277,7 @@ class Translation:
     _type: str = field(default="Translation", init=False, repr=False)
 
     def __call__(self):
-        return pa.struct({lang: pa.string() for lang in self.languages})
+        return pa.struct({lang: pa.string() for lang in sorted(self.languages)})
 
 
 @dataclass

--- a/src/nlp/features.py
+++ b/src/nlp/features.py
@@ -460,8 +460,10 @@ def generate_from_arrow_type(pa_type: pa.DataType):
     elif isinstance(pa_type, pa.FixedSizeListType):
         return Sequence(feature=generate_from_arrow_type(pa_type.value_type), length=pa_type.list_size)
     elif isinstance(pa_type, pa.ListType):
-        # return [generate_from_arrow_type(pa_type.value_type)]
-        return Sequence(feature=generate_from_arrow_type(pa_type.value_type))
+        feature = generate_from_arrow_type(pa_type.value_type)
+        if isinstance(feature, (dict, tuple, list)):
+            return [feature]
+        return Sequence(feature=feature)
     elif isinstance(pa_type, pa.DictionaryType):
         raise NotImplementedError  # TODO(thom) this will need access to the dictionary as well (for labels). I.e. to the py_table
     elif isinstance(pa_type, pa.DataType):

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -353,22 +353,21 @@ class BaseDatasetTest(TestCase):
             self.assertEqual(inverted_dset.features.type, features.type)
             self.assertDictEqual(inverted_dset.features, features)
 
-    # TODO(QL): keep features in arrow metadata
-    # def test_keep_features_after_transform_from_file(self):
-    #     features = Features(
-    #         {"tokens": Sequence(Value("string")), "labels": Sequence(ClassLabel(names=["negative", "positive"]))}
-    #     )
-    #     dset = Dataset.from_dict({"tokens": [["foo"] * 5] * 10, "labels": [[1] * 5] * 10}, features=features)
+    def test_keep_features_after_transform_from_file(self):
+        features = Features(
+            {"tokens": Sequence(Value("string")), "labels": Sequence(ClassLabel(names=["negative", "positive"]))}
+        )
+        dset = Dataset.from_dict({"tokens": [["foo"] * 5] * 10, "labels": [[1] * 5] * 10}, features=features)
 
-    #     def invert_labels(x):
-    #         return {"labels": [(1 - label) for label in x["labels"]]}
+        def invert_labels(x):
+            return {"labels": [(1 - label) for label in x["labels"]]}
 
-    #     with tempfile.TemporaryDirectory() as tmp_dir:
-    #         tmp_file = os.path.join(tmp_dir, "test.arrow")
-    #         dset.map(invert_labels, cache_file_name=tmp_file)
-    #         inverted_dset = Dataset.from_file(tmp_file)
-    #         self.assertEqual(inverted_dset.features.type, features.type)
-    #         self.assertDictEqual(inverted_dset.features, features)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "test.arrow")
+            dset.map(invert_labels, cache_file_name=tmp_file)
+            inverted_dset = Dataset.from_file(tmp_file)
+            self.assertEqual(inverted_dset.features.type, features.type)
+            self.assertDictEqual(inverted_dset.features, features)
 
     def test_select(self):
         dset = self._create_dummy_dataset()

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -369,6 +369,19 @@ class BaseDatasetTest(TestCase):
             self.assertEqual(inverted_dset.features.type, features.type)
             self.assertDictEqual(inverted_dset.features, features)
 
+    def test_keep_features_after_transform_in_memory(self):
+        features = Features(
+            {"tokens": Sequence(Value("string")), "labels": Sequence(ClassLabel(names=["negative", "positive"]))}
+        )
+        dset = Dataset.from_dict({"tokens": [["foo"] * 5] * 10, "labels": [[1] * 5] * 10}, features=features)
+
+        def invert_labels(x):
+            return {"labels": [(1 - label) for label in x["labels"]]}
+
+        inverted_dset = dset.map(invert_labels, keep_in_memory=True)
+        self.assertEqual(inverted_dset.features.type, features.type)
+        self.assertDictEqual(inverted_dset.features, features)
+
     def test_select(self):
         dset = self._create_dummy_dataset()
         # select every two example


### PR DESCRIPTION
When applying a transform like `map`, some features were lost (and inferred features were used).
It was the case for ClassLabel, Translation, etc.

To fix that, I did some modifications in the `ArrowWriter`:

- added the `update_features` parameter. When it's `True`, then the features specified by the user (if any) can be updated with inferred features if their type don't match. `map` transform sets `update_features=True` when writing to cache file or buffer. Features won't change by default in `map`.

- added the `with_metadata` parameter. If `True`, the `features` (after update) will be written inside the metadata of the schema in this format:
```
{
    "huggingface": {"features" : <serialized Features exactly like dataset_info.json>}
} 
```
Then, once a dataset is instantiated without info/features, these metadata are used to set the features of the dataset.