### PR TITLE
misc. bugs and quality of life

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Here is a quick example:
 import nlp
 
 # Print all the available datasets
-print([dataset.id for dataset in nlp.list_datasets()])
+print(nlp.list_datasets(id_only=True))
 
 # Load a dataset and print the first examples in the training set
 squad_dataset = nlp.load_dataset('squad')
 print(squad_dataset['train'][0])
 
 # List all the available metrics
-print([metric.id for metric in nlp.list_metrics()])
+print(nlp.list_metrics(id_only=True))
 
 # Load a metric
 squad_metric = nlp.load_metric('squad')

--- a/docs/source/exploring.rst
+++ b/docs/source/exploring.rst
@@ -157,6 +157,18 @@ While you can access a single row with the ``dataset[i]`` pattern, you can also 
      'idx': [1, 3, 5]
     }
 
+Or use an iterable of type ``bool`` for boolean array indexing:
+
+.. code-block::
+
+    >>> label_mask = np.array(dataset['label']) == 0
+    >>> dataset[label_mask]['sentence1'][:3]
+    ["Yucaipa owned Dominick 's before selling the chain to Safeway in 1998 for $ 2.5 billion .",
+     'Around 0335 GMT , Tab shares were up 19 cents , or 4.4 % , at A $ 4.56 , having earlier set a record high of A $ 4.57 .',
+     'The Nasdaq had a weekly gain of 17.27 , or 1.2 percent , closing at 1,520.15 on Friday .']
+    >>> dataset[label_mask]['label'][:10]
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
 You can also get a full columns by querying its name as a string. This will return a list of elements:
 
 .. code-block::

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -1120,7 +1120,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             cache_file_name=cache_file_name,
             writer_batch_size=writer_batch_size,
             verbose=verbose,
-            fn_kwargs=fn_kwargs
+            fn_kwargs=fn_kwargs,
         )
 
     def select(

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -702,7 +702,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             else:
                 outputs = self._data[key].to_pylist()
         elif isinstance(key, Iterable):
-            data_subset = pa.concat_tables(self._data.slice(int(i), 1) for i in key)
+            if len(key) > 0 and isinstance(key[0], (bool, np.bool_)):
+                if len(key) != self.__len__():
+                    raise ValueError(
+                        f"Iterable with bool entries must be length of dataset ({self.__len__()}), "
+                        f"not {len(key)}"
+                    )
+                indices = [i for i, val in enumerate(key) if val]
+            else:
+                indices = key
+            data_subset = pa.concat_tables(self._data.slice(int(i), 1) for i in indices)
             if format_type is not None:
                 if format_type == "pandas":
                     outputs = data_subset.to_pandas(split_blocks=True)

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -705,8 +705,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             if len(key) > 0 and isinstance(key[0], (bool, np.bool_)):
                 if len(key) != self.__len__():
                     raise ValueError(
-                        f"Iterable with bool entries must be length of dataset ({self.__len__()}), "
-                        f"not {len(key)}"
+                        f"Iterable with bool entries must be length of dataset ({self.__len__()}), " f"not {len(key)}"
                     )
                 indices = [i for i, val in enumerate(key) if val]
             else:
@@ -802,7 +801,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         features: Optional[Features] = None,
         disable_nullable: bool = True,
         verbose: bool = True,
-        **fn_kwargs
+        **fn_kwargs,
     ) -> "Dataset":
         """ Apply a function to all the elements in the table (individually or in batches)
             and update the table (if function does updated examples).
@@ -866,7 +865,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         def does_function_return_dict(inputs, indices):
             """ Does the function returns a dict. """
             fn_input = inputs if input_column is None else inputs[input_column]
-            processed_inputs = function(fn_input, indices, **fn_kwargs) if with_indices else function(fn_input, **fn_kwargs)
+            processed_inputs = (
+                function(fn_input, indices, **fn_kwargs) if with_indices else function(fn_input, **fn_kwargs)
+            )
             does_return_dict = isinstance(processed_inputs, Mapping)
 
             if does_return_dict is False and processed_inputs is not None:
@@ -901,7 +902,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         def apply_function_on_filtered_inputs(inputs, indices, check_same_num_examples=False):
             """ Utility to apply the function on a selection of columns. """
             fn_input = inputs if input_column is None else inputs[input_column]
-            processed_inputs = function(fn_input, indices, **fn_kwargs) if with_indices else function(fn_input, **fn_kwargs)
+            processed_inputs = (
+                function(fn_input, indices, **fn_kwargs) if with_indices else function(fn_input, **fn_kwargs)
+            )
             if not update_data:
                 return None  # Nothing to update, let's move on
             if remove_columns is not None:

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -801,7 +801,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         features: Optional[Features] = None,
         disable_nullable: bool = True,
         verbose: bool = True,
-        **fn_kwargs,
+        fn_kwargs: Optional[dict] = None,
     ) -> "Dataset":
         """ Apply a function to all the elements in the table (individually or in batches)
             and update the table (if function does updated examples).
@@ -832,7 +832,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     instead of the automatically generated one.
                 `disable_nullable` (`bool`, default: `True`): Allow null values in the table.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
-                `**fn_kwargs`: Keyword arguments to be passed to `function`
+                `fn_kwargs` (`Optional[dict]`, default: `None`): Keyword arguments to be passed to `function`
         """
         assert (
             not keep_in_memory or cache_file_name is None
@@ -1034,7 +1034,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         cache_file_name: Optional[str] = None,
         writer_batch_size: Optional[int] = 1000,
         verbose: bool = True,
-        **fn_kwargs,
+        fn_kwargs: Optional[dict] = None,
     ) -> "Dataset":
         """ Apply a filter function to all the elements in the table in batches
             and update the table so that the dataset only includes examples according to the filter function.
@@ -1059,7 +1059,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 `writer_batch_size` (`int`, default: `1000`): Number of rows per write operation for the cache file writer.
                     Higher value gives smaller cache files, lower value consume less temporary memory while running `.map()`.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
-                `**fn_kwargs`: Keyword arguments to be passed to `function`.
+                `fn_kwargs` (`Optional[dict]`, default: `None`): Keyword arguments to be passed to `function`
         """
         if len(self.list_indexes()) > 0:
             raise DatasetTransformationNotAllowedError(

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -791,6 +791,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         self,
         function,
         with_indices: bool = False,
+        input_column: Optional[str] = None,
         batched: bool = False,
         batch_size: Optional[int] = 1000,
         remove_columns: Optional[List[str]] = None,
@@ -801,17 +802,20 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         features: Optional[Features] = None,
         disable_nullable: bool = True,
         verbose: bool = True,
+        **fn_kwargs
     ) -> "Dataset":
         """ Apply a function to all the elements in the table (individually or in batches)
             and update the table (if function does updated examples).
 
             Args:
                 `function` (`callable`): with one of the following signature:
-                    - `function(example: Dict) -> Union[Dict, Any]` if `batched=False` and `with_indices=False`
-                    - `function(example: Dict, indices: int) -> Union[Dict, Any]` if `batched=False` and `with_indices=True`
-                    - `function(batch: Dict[List]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False`
-                    - `function(batch: Dict[List], indices: List[int]) -> Union[Dict, Any]` if `batched=True` and `with_indices=True`
+                    - `function(example: Union[Dict, Any]) -> Union[Dict, Any]` if `batched=False` and `with_indices=False`
+                    - `function(example: Union[Dict, Any], indices: int) -> Union[Dict, Any]` if `batched=False` and `with_indices=True`
+                    - `function(batch: Union[Dict[List], List[Any]]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False`
+                    - `function(batch: Union[Dict[List], List[Any]], indices: List[int]) -> Union[Dict, Any]` if `batched=True` and `with_indices=True`
                 `with_indices` (`bool`, default: `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
+                `input_column` (`Optional[str]`, default: `None`): The column to be passed into `function`. If `None`, a dict
+                    mapping to all formatted columns is passed.
                 `batched` (`bool`, default: `False`): Provide batch of examples to `function`
                 `batch_size` (`Optional[int]`, default: `1000`): Number of examples per batch provided to `function` if `batched=True`
                     `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`
@@ -829,6 +833,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     instead of the automatically generated one.
                 `disable_nullable` (`bool`, default: `True`): Allow null values in the table.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
+                `**fn_kwargs`: Keyword arguments to be passed to `function`
         """
         assert (
             not keep_in_memory or cache_file_name is None
@@ -846,6 +851,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 )
             )
 
+        if input_column is not None and input_column not in self._data.column_names:
+            raise ValueError(
+                "Input column {} not in the dataset. Current columns in the dataset: {}".format(
+                    input_column, self._data.column_names
+                )
+            )
+
         # If we do batch computation but no batch sze is provided, default to the full dataset
         if batched and (batch_size is None or batch_size <= 0):
             batch_size = self._data.num_rows
@@ -853,7 +865,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         # Check if the function returns updated examples
         def does_function_return_dict(inputs, indices):
             """ Does the function returns a dict. """
-            processed_inputs = function(inputs, indices) if with_indices else function(inputs)
+            fn_input = inputs if input_column is None else inputs[input_column]
+            processed_inputs = function(fn_input, indices, **fn_kwargs) if with_indices else function(fn_input, **fn_kwargs)
             does_return_dict = isinstance(processed_inputs, Mapping)
 
             if does_return_dict is False and processed_inputs is not None:
@@ -887,7 +900,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         def apply_function_on_filtered_inputs(inputs, indices, check_same_num_examples=False):
             """ Utility to apply the function on a selection of columns. """
-            processed_inputs = function(inputs, indices) if with_indices else function(inputs)
+            fn_input = inputs if input_column is None else inputs[input_column]
+            processed_inputs = function(fn_input, indices, **fn_kwargs) if with_indices else function(fn_input, **fn_kwargs)
             if not update_data:
                 return None  # Nothing to update, let's move on
             if remove_columns is not None:
@@ -1009,6 +1023,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         self,
         function,
         with_indices=False,
+        input_column: Optional[str] = None,
         batch_size: Optional[int] = 1000,
         remove_columns: Optional[List[str]] = None,
         keep_in_memory: bool = False,
@@ -1016,15 +1031,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         cache_file_name: Optional[str] = None,
         writer_batch_size: Optional[int] = 1000,
         verbose: bool = True,
+        **fn_kwargs,
     ) -> "Dataset":
         """ Apply a filter function to all the elements in the table in batches
             and update the table so that the dataset only includes examples according to the filter function.
 
             Args:
                 `function` (`callable`): with one of the following signature:
-                    - `function(example: Dict) -> bool` if `with_indices=False`
-                    - `function(example: Dict, indices: int) -> bool` if `with_indices=True`
+                    - `function(example: Union[Dict, Any]) -> bool` if `with_indices=False`
+                    - `function(example: Union[Dict, Any], indices: int) -> bool` if `with_indices=True`
                 `with_indices` (`bool`, default: `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
+                `input_column` (`Optional[str]`, default: `None`): The column to be passed into `function`. If `None`, a dict
+                    mapping to all formatted columns is passed.
                 `batch_size` (`Optional[int]`, default: `1000`): Number of examples per batch provided to `function` if `batched=True`
                     `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`
                 `remove_columns` (`Optional[List[str]]`, default: `None`): Remove a selection of columns while doing the mapping.
@@ -1038,6 +1056,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 `writer_batch_size` (`int`, default: `1000`): Number of rows per write operation for the cache file writer.
                     Higher value gives smaller cache files, lower value consume less temporary memory while running `.map()`.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
+                `**fn_kwargs`: Keyword arguments to be passed to `function`.
         """
         if len(self.list_indexes()) > 0:
             raise DatasetTransformationNotAllowedError(
@@ -1052,12 +1071,13 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             # create single examples
             for i in range(num_examples):
                 example = map_nested(lambda x: x[i], batch, dict_only=True)
+                fn_input = example if input_column is None else example[input_column]
 
                 # check if example should be fildered or not
                 if with_indices:
-                    keep_example = function(example, args[0][i])
+                    keep_example = function(fn_input, args[0][i], **fn_kwargs)
                 else:
-                    keep_example = function(example)
+                    keep_example = function(fn_input, **fn_kwargs)
 
                 assert isinstance(
                     keep_example, bool

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -832,7 +832,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     instead of the automatically generated one.
                 `disable_nullable` (`bool`, default: `True`): Allow null values in the table.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
-                `fn_kwargs` (`Optional[dict]`, default: `None`): Keyword arguments to be passed to `function`
+                `fn_kwargs` (`Optional[Dict]`, default: `None`): Keyword arguments to be passed to `function`
         """
         assert (
             not keep_in_memory or cache_file_name is None
@@ -1064,11 +1064,18 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 `writer_batch_size` (`int`, default: `1000`): Number of rows per write operation for the cache file writer.
                     Higher value gives smaller cache files, lower value consume less temporary memory while running `.map()`.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
-                `fn_kwargs` (`Optional[dict]`, default: `None`): Keyword arguments to be passed to `function`
+                `fn_kwargs` (`Optional[Dict]`, default: `None`): Keyword arguments to be passed to `function`
         """
         if len(self.list_indexes()) > 0:
             raise DatasetTransformationNotAllowedError(
                 "Using `.filter` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it.`"
+            )
+
+        if input_column is not None and input_column not in self._data.column_names:
+            raise ValueError(
+                "Input column {} not in the dataset. Current columns in the dataset: {}".format(
+                    input_column, self._data.column_names
+                )
             )
 
         if fn_kwargs is None:

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -1586,7 +1586,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 "aforementioned parameters."
             )
 
-        if generator is None:
+        if generator is None and shuffle is True:
             generator = np.random.default_rng(seed)
 
         # Check if we've already cached this computation (indexed by a hash)

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -857,6 +857,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 )
             )
 
+        if fn_kwargs is None:
+            fn_kwargs = dict()
+
         # If we do batch computation but no batch sze is provided, default to the full dataset
         if batched and (batch_size is None or batch_size <= 0):
             batch_size = self._data.num_rows
@@ -1065,6 +1068,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             raise DatasetTransformationNotAllowedError(
                 "Using `.filter` on a dataset with attached indexes is not allowed. You can first run `.drop_index() to remove your index and then re-add it.`"
             )
+
+        if fn_kwargs is None:
+            fn_kwargs = dict()
 
         # transforme the filter function into the map function
         def map_function(batch, *args):

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -1300,7 +1300,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         ), "The provided generator must be an instance of numpy.random.Generator"
 
         # Check if we've already cached this computation (indexed by a hash)
-        if self._data_files:
+        if self._data_files and (seed is not None or generator is not None):
             if cache_file_name is None:
                 # we create a unique hash from the function, current dataset file and the mapping args
                 cache_kwargs = {
@@ -1538,7 +1538,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             )
 
         # Check if we've already cached this computation (indexed by a hash)
-        if self._data_files:
+        if self._data_files and (seed is not None or generator is not None):
             if train_cache_file_name is None or test_cache_file_name is None:
                 # we create a unique hash from the function, current dataset file and the mapping args
                 cache_kwargs = {

--- a/src/nlp/dataset_dict.py
+++ b/src/nlp/dataset_dict.py
@@ -136,6 +136,7 @@ class DatasetDict(dict):
         self,
         function,
         with_indices: bool = False,
+        input_column: Optional[str] = None,
         batched: bool = False,
         batch_size: Optional[int] = 1000,
         remove_columns: Optional[List[str]] = None,
@@ -146,6 +147,7 @@ class DatasetDict(dict):
         features: Optional[Features] = None,
         disable_nullable: bool = True,
         verbose: bool = True,
+        fn_kwargs: Optional[dict] = None,
     ) -> "DatasetDict":
         """ Apply a function to all the elements in the table (individually or in batches)
             and update the table (if function does updated examples).
@@ -158,6 +160,8 @@ class DatasetDict(dict):
                     - `function(batch: Dict[List]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False`
                     - `function(batch: Dict[List], indices: List[int]) -> Union[Dict, Any]` if `batched=True` and `with_indices=True`
                 `with_indices` (`bool`, default: `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
+                `input_column` (`Optional[str]`, default: `None`): The column to be passed into `function`. If `None`, a dict
+                    mapping to all formatted columns is passed.
                 `batched` (`bool`, default: `False`): Provide batch of examples to `function`
                 `batch_size` (`Optional[int]`, default: `1000`): Number of examples per batch provided to `function` if `batched=True`
                     `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`
@@ -176,6 +180,7 @@ class DatasetDict(dict):
                     instead of the automatically generated one.
                 `disable_nullable` (`bool`, default: `True`): Allow null values in the table.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
+                `fn_kwargs` (`Optional[Dict]`, default: `None`): Keyword arguments to be passed to `function`
         """
         self._check_values_type()
         if cache_file_names is None:
@@ -185,6 +190,7 @@ class DatasetDict(dict):
                 k: dataset.map(
                     function=function,
                     with_indices=with_indices,
+                    input_column=input_column,
                     batched=batched,
                     batch_size=batch_size,
                     remove_columns=remove_columns,
@@ -195,6 +201,7 @@ class DatasetDict(dict):
                     features=features,
                     disable_nullable=disable_nullable,
                     verbose=verbose,
+                    fn_kwargs=fn_kwargs,
                 )
                 for k, dataset in self.items()
             }
@@ -204,6 +211,7 @@ class DatasetDict(dict):
         self,
         function,
         with_indices=False,
+        input_column: Optional[str] = None,
         batch_size: Optional[int] = 1000,
         remove_columns: Optional[List[str]] = None,
         keep_in_memory: bool = False,
@@ -211,6 +219,7 @@ class DatasetDict(dict):
         cache_file_names: Optional[Dict[str, str]] = None,
         writer_batch_size: Optional[int] = 1000,
         verbose: bool = True,
+        fn_kwargs: Optional[dict] = None,
     ) -> "DatasetDict":
         """ Apply a filter function to all the elements in the table in batches
             and update the table so that the dataset only includes examples according to the filter function.
@@ -221,6 +230,8 @@ class DatasetDict(dict):
                     - `function(example: Dict) -> bool` if `with_indices=False`
                     - `function(example: Dict, indices: int) -> bool` if `with_indices=True`
                 `with_indices` (`bool`, default: `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
+                `input_column` (`Optional[str]`, default: `None`): The column to be passed into `function`. If `None`, a dict
+                    mapping to all formatted columns is passed.
                 `batch_size` (`Optional[int]`, default: `1000`): Number of examples per batch provided to `function` if `batched=True`
                     `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`
                 `remove_columns` (`Optional[List[str]]`, default: `None`): Remove a selection of columns while doing the mapping.
@@ -235,6 +246,7 @@ class DatasetDict(dict):
                 `writer_batch_size` (`int`, default: `1000`): Number of rows per write operation for the cache file writer.
                     Higher value gives smaller cache files, lower value consume less temporary memory while running `.map()`.
                 `verbose` (`bool`, default: `True`): Set to `False` to deactivate the tqdm progress bar and informations.
+                `fn_kwargs` (`Optional[Dict]`, default: `None`): Keyword arguments to be passed to `function`
         """
         self._check_values_type()
         if cache_file_names is None:
@@ -244,6 +256,7 @@ class DatasetDict(dict):
                 k: dataset.filter(
                     function=function,
                     with_indices=with_indices,
+                    input_column=input_column,
                     batch_size=batch_size,
                     remove_columns=remove_columns,
                     keep_in_memory=keep_in_memory,
@@ -251,6 +264,7 @@ class DatasetDict(dict):
                     cache_file_name=cache_file_names[k],
                     writer_batch_size=writer_batch_size,
                     verbose=verbose,
+                    fn_kwargs=fn_kwargs,
                 )
                 for k, dataset in self.items()
             }

--- a/src/nlp/dataset_dict.py
+++ b/src/nlp/dataset_dict.py
@@ -1,5 +1,5 @@
 import contextlib
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 

--- a/src/nlp/dataset_dict.py
+++ b/src/nlp/dataset_dict.py
@@ -136,7 +136,7 @@ class DatasetDict(dict):
         self,
         function,
         with_indices: bool = False,
-        input_column: Optional[str] = None,
+        input_columns: Optional[Union[str, List[str]]] = None,
         batched: bool = False,
         batch_size: Optional[int] = 1000,
         remove_columns: Optional[List[str]] = None,
@@ -160,8 +160,8 @@ class DatasetDict(dict):
                     - `function(batch: Dict[List]) -> Union[Dict, Any]` if `batched=True` and `with_indices=False`
                     - `function(batch: Dict[List], indices: List[int]) -> Union[Dict, Any]` if `batched=True` and `with_indices=True`
                 `with_indices` (`bool`, default: `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
-                `input_column` (`Optional[str]`, default: `None`): The column to be passed into `function`. If `None`, a dict
-                    mapping to all formatted columns is passed.
+                `input_columns` (`Optional[Union[str, List[str]]]`, default: `None`): The columns to be passed into `function` as
+                    positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
                 `batched` (`bool`, default: `False`): Provide batch of examples to `function`
                 `batch_size` (`Optional[int]`, default: `1000`): Number of examples per batch provided to `function` if `batched=True`
                     `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`
@@ -190,7 +190,7 @@ class DatasetDict(dict):
                 k: dataset.map(
                     function=function,
                     with_indices=with_indices,
-                    input_column=input_column,
+                    input_columns=input_columns,
                     batched=batched,
                     batch_size=batch_size,
                     remove_columns=remove_columns,
@@ -211,7 +211,7 @@ class DatasetDict(dict):
         self,
         function,
         with_indices=False,
-        input_column: Optional[str] = None,
+        input_columns: Optional[Union[str, List[str]]] = None,
         batch_size: Optional[int] = 1000,
         remove_columns: Optional[List[str]] = None,
         keep_in_memory: bool = False,
@@ -230,8 +230,8 @@ class DatasetDict(dict):
                     - `function(example: Dict) -> bool` if `with_indices=False`
                     - `function(example: Dict, indices: int) -> bool` if `with_indices=True`
                 `with_indices` (`bool`, default: `False`): Provide example indices to `function`. Note that in this case the signature of `function` should be `def function(example, idx): ...`.
-                `input_column` (`Optional[str]`, default: `None`): The column to be passed into `function`. If `None`, a dict
-                    mapping to all formatted columns is passed.
+                `input_columns` (`Optional[Union[str, List[str]]]`, default: `None`): The columns to be passed into `function` as
+                    positional arguments. If `None`, a dict mapping to all formatted columns is passed as one argument.
                 `batch_size` (`Optional[int]`, default: `1000`): Number of examples per batch provided to `function` if `batched=True`
                     `batch_size <= 0` or `batch_size == None`: Provide the full dataset as a single batch to `function`
                 `remove_columns` (`Optional[List[str]]`, default: `None`): Remove a selection of columns while doing the mapping.
@@ -256,7 +256,7 @@ class DatasetDict(dict):
                 k: dataset.filter(
                     function=function,
                     with_indices=with_indices,
-                    input_column=input_column,
+                    input_columns=input_columns,
                     batch_size=batch_size,
                     remove_columns=remove_columns,
                     keep_in_memory=keep_in_memory,

--- a/src/nlp/hf_api.py
+++ b/src/nlp/hf_api.py
@@ -235,7 +235,7 @@ class HfApi:
         )
         r.raise_for_status()
 
-    def dataset_list(self, with_community_datasets=True) -> List[ObjectInfo]:
+    def dataset_list(self, with_community_datasets=True, id_only=False) -> List[ObjectInfo]:
         """
         Get the public list of all the datasets on huggingface, including the community datasets
         """
@@ -246,9 +246,11 @@ class HfApi:
         datasets = [ObjectInfo(**x) for x in d]
         if not with_community_datasets:
             datasets = [d for d in datasets if "/" not in d.id]
+        if id_only:
+            datasets = [d.id for d in datasets]
         return datasets
 
-    def metric_list(self, with_community_metrics=True) -> List[ObjectInfo]:
+    def metric_list(self, with_community_metrics=True, id_only=False) -> List[ObjectInfo]:
         """
         Get the public list of all the metrics on huggingface, including the community metrics
         """
@@ -259,6 +261,8 @@ class HfApi:
         metrics = [ObjectInfo(**x) for x in d]
         if not with_community_metrics:
             metrics = [m for m in metrics if "/" not in m.id]
+        if id_only:
+            metrics = [m.id for m in metrics]
         return metrics
 
 

--- a/src/nlp/hf_api.py
+++ b/src/nlp/hf_api.py
@@ -109,8 +109,8 @@ class ObjectInfo:
             setattr(self, k, v)
 
     def __repr__(self):
-        single_line_description = self.description.replace("\n", "")
-        return f"nlp.ObjectInfo(id='{self.id}', description='{single_line_description}', files={self.siblings})"
+        single_line_description = self.description.replace("\n", "") if self.description is not None else ""
+        return f"nlp.ObjectInfo(\n\tid='{self.id}',\n\tdescription='{single_line_description}',\n\tfiles={self.siblings}\n)"
 
 
 class HfApi:

--- a/src/nlp/inspect.py
+++ b/src/nlp/inspect.py
@@ -27,16 +27,16 @@ from .utils import DownloadConfig
 logger = logging.getLogger(__name__)
 
 
-def list_datasets(with_community_datasets=True):
+def list_datasets(with_community_datasets=True, id_only=False):
     """ List all the datasets scripts available on HuggingFace AWS bucket """
     api = HfApi()
-    return api.dataset_list(with_community_datasets=with_community_datasets)
+    return api.dataset_list(with_community_datasets=with_community_datasets, id_only=id_only)
 
 
-def list_metrics(with_community_metrics=True):
+def list_metrics(with_community_metrics=True, id_only=False):
     """ List all the metrics script available on HuggingFace AWS bucket """
     api = HfApi()
-    return api.metric_list(with_community_metrics=with_community_metrics)
+    return api.metric_list(with_community_metrics=with_community_metrics, id_only=id_only)
 
 
 def inspect_dataset(path: str, local_path: str, download_config: Optional[DownloadConfig] = None, **download_kwargs):


### PR DESCRIPTION
A few misc. bugs and QOL improvements that I've come across in using the library. Let me know if you don't like any of them and I can adjust/remove them.

1. Printing datasets without a description field throws an error when formatting the `single_line_description`. This fixes that, and also adds some formatting to the repr to make it slightly more readable.
```
>>> print(list_datasets()[0])
nlp.ObjectInfo(
	id='aeslc',
	description='A collection of email messages of employees in the Enron Corporation.There are two features:  - email_body: email body text.  - subject_line: email subject text.',
	files=[nlp.S3Object('aeslc.py'), nlp.S3Object('dataset_infos.json'), nlp.S3Object('dummy/1.0.0/dummy_data-zip-extracted/dummy_data/AESLC-master/enron_subject_line/dev/allen-p_inbox_29.subject'), nlp.S3Object('dummy/1.0.0/dummy_data-zip-extracted/dummy_data/AESLC-master/enron_subject_line/test/allen-p_inbox_24.subject'), nlp.S3Object('dummy/1.0.0/dummy_data-zip-extracted/dummy_data/AESLC-master/enron_subject_line/train/allen-p_inbox_20.subject'), nlp.S3Object('dummy/1.0.0/dummy_data.zip'), nlp.S3Object('urls_checksums/checksums.txt')]
)
```

2. Add id-only option to `list_datasets` and `list_metrics` to allow the user to easily print out just the names of the datasets & metrics. I often found myself annoyed that this took so many strokes to do.

```python
[dataset.id for dataset in list_datasets()] # before
list_datasets(id_only=True) # after
```

3. Fix null-seed randomization caching. When using `train_test_split` and `shuffle`, the computation was being cached even without a seed or generator being passed. The result was that calling `.shuffle` more than once on the same dataset didn't do anything without passing a distinct seed or generator. Likewise with `train_test_split`.

4. Indexing by iterables of bool. I added support for passing an iterable of type bool to `_getitem` as a numpy/pandas-like indexing method. Let me know if you think it's redundant with `filter` (I know it's not optimal memory-wise), but I think it's nice to have as a lightweight alternative to do simple things without having to create a copy of the entire dataset, e.g.

```python
dataset[dataset['label'] == 0] # numpy-like bool indexing to look at instances with labels of 0
```

5. Add an `input_column` argument to `map` and `filter`, which allows you to filter/map on a particular column rather than passing the whole dict to the function. Also adds `fn_kwargs` to be passed to the function. I think these together make mapping much cleaner in many cases such as mono-column tokenization:

```python
# before
dataset = dataset.map(lambda batch: tokenizer(batch["text"])
# after
dataset = dataset.map(tokenizer, input_column="text")
dataset = dataset.map(tokenizer, input_column="text", fn_kwargs={"truncation": True, "padding": True})
```