### PR TITLE
add METEOR metric

### DIFF
--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace NLP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" METEOR metric. """
+
+import nlp
+
+import numpy as np
+
+from nltk.translate import meteor_score
+
+_CITATION = """\
+@inproceedings{banarjee2005,
+  title     = {{METEOR}: An Automatic Metric for {MT} Evaluation with Improved Correlation with Human Judgments},
+  author    = {Banerjee, Satanjeev  and Lavie, Alon},
+  booktitle = {Proceedings of the {ACL} Workshop on Intrinsic and Extrinsic Evaluation Measures for Machine Translation and/or Summarization},
+  month     = jun,
+  year      = {2005},
+  address   = {Ann Arbor, Michigan},
+  publisher = {Association for Computational Linguistics},
+  url       = {https://www.aclweb.org/anthology/W05-0909},
+  pages     = {65--72},
+}
+"""
+
+_DESCRIPTION = """\
+METEOR, an automatic metric for machine translation evaluation
+that is based on a generalized concept of unigram matching between the
+machine-produced translation and human-produced reference translations.
+Unigrams can be matched based on their surface forms, stemmed forms,
+and meanings; further-more, METEOR can be easily extended to include more
+advanced matching strate-gies. Once all generalized unigram matches
+between the two strings have been found, METEOR computes a score for
+this matching using a combination of unigram-precision, unigram-recall, and
+a measure of fragmentation that is designed to directly capture how
+well-ordered the matched words in the machine translation are in relation
+to the reference.  
+
+METEOR gets an R correlation value of 0.347 with human evaluation on the Arabic
+data and 0.331 on the Chinese data. This is shown to be an im-provement on
+using simply unigram-precision, unigram-recall and their har-monic F1
+combination. 
+"""
+
+_KWARGS_DESCRIPTION = """
+Computes METEOR score of translated segments against one or more references.
+Args:
+    predictions: list of predictions to score. Each predictions
+        should be a string with tokens separated by spaces.
+    references: list of reference for each prediction. Each
+        reference should be a string with tokens separated by spaces.
+    alpha: Paramter for controlling relative weights of precision and recall. default: 0.9
+    beta: Paramter for controlling shape of penalty as a function of fragmentation. default: 3
+    gamma: Relative weight assigned to fragmentation penalty. default: 0.5
+Returns:
+    'meteor': meteor score.
+"""
+
+
+class Meteor(nlp.Metric):
+    def _info(self):
+        return nlp.MetricInfo(
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=nlp.Features({
+                'predictions': nlp.Value('string', id='sequence'),
+                'references': nlp.Value('string', id='sequence')
+            }),
+            codebase_urls=[
+                "https://github.com/nltk/nltk/blob/develop/nltk/translate/meteor_score.py"],
+            reference_urls=["https://www.nltk.org/api/nltk.translate.html#module-nltk.translate.meteor_score",
+                            "https://en.wikipedia.org/wiki/METEOR"]
+        )
+
+    def _compute(self, predictions, references, alpha=0.9, beta=3, gamma=0.5):
+        scores = [meteor_score.single_meteor_score(ref, pred, alpha=alpha, beta=beta, gamma=gamma)
+                  for ref, pred in zip(references, predictions)]
+
+        return {"meteor": np.mean(scores)}

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -48,7 +48,7 @@ well-ordered the matched words in the machine translation are in relation
 to the reference.  
 
 METEOR gets an R correlation value of 0.347 with human evaluation on the Arabic
-data and 0.331 on the Chinese data. This is shown to be an im-provement on
+data and 0.331 on the Chinese data. This is shown to be an improvement on
 using simply unigram-precision, unigram-recall and their harmonic F1
 combination. 
 """
@@ -56,12 +56,12 @@ combination.
 _KWARGS_DESCRIPTION = """
 Computes METEOR score of translated segments against one or more references.
 Args:
-    predictions: list of predictions to score. Each predictions
+    predictions: list of predictions to score. Each prediction
         should be a string with tokens separated by spaces.
     references: list of reference for each prediction. Each
         reference should be a string with tokens separated by spaces.
-    alpha: Paramter for controlling relative weights of precision and recall. default: 0.9
-    beta: Paramter for controlling shape of penalty as a function of fragmentation. default: 3
+    alpha: Parameter for controlling relative weights of precision and recall. default: 0.9
+    beta: Parameter for controlling shape of penalty as a function of fragmentation. default: 3
     gamma: Relative weight assigned to fragmentation penalty. default: 0.5
 Returns:
     'meteor': meteor score.

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -39,8 +39,8 @@ METEOR, an automatic metric for machine translation evaluation
 that is based on a generalized concept of unigram matching between the
 machine-produced translation and human-produced reference translations.
 Unigrams can be matched based on their surface forms, stemmed forms,
-and meanings; further-more, METEOR can be easily extended to include more
-advanced matching strate-gies. Once all generalized unigram matches
+and meanings; furthermore, METEOR can be easily extended to include more
+advanced matching strategies. Once all generalized unigram matches
 between the two strings have been found, METEOR computes a score for
 this matching using a combination of unigram-precision, unigram-recall, and
 a measure of fragmentation that is designed to directly capture how
@@ -49,7 +49,7 @@ to the reference.
 
 METEOR gets an R correlation value of 0.347 with human evaluation on the Arabic
 data and 0.331 on the Chinese data. This is shown to be an im-provement on
-using simply unigram-precision, unigram-recall and their har-monic F1
+using simply unigram-precision, unigram-recall and their harmonic F1
 combination. 
 """
 


### PR DESCRIPTION
Added the METEOR metric. Can be used like this:

```python
import nlp
meteor = nlp.load_metric('metrics/meteor')
meteor.compute(["some string", "some string"], ["some string", "some similar string"])
# {'meteor': 0.6411637931034483}
meteor.add("some string", "some string")
meteor.add('some string", "some similar string")
meteor.compute()
# {'meteor': 0.6411637931034483}
```

Uses [NLTK's implementation](https://www.nltk.org/api/nltk.translate.html#module-nltk.translate.meteor_score), [(source)](https://github.com/nltk/nltk/blob/develop/nltk/translate/meteor_score.py)