### PR TITLE
Fix elasticsearch result ids returning as strings

### DIFF
--- a/src/nlp/search.py
+++ b/src/nlp/search.py
@@ -179,7 +179,7 @@ class ElasticSearchIndex(BaseIndex):
             body={"query": {"multi_match": {"query": query, "fields": ["text"], "type": "cross_fields"}}, "size": k},
         )
         hits = response["hits"]["hits"]
-        return SearchResults([hit["_score"] for hit in hits], [hit["_id"] for hit in hits])
+        return SearchResults([hit["_score"] for hit in hits], [int(hit["_id"]) for hit in hits])
 
 
 class FaissIndex(BaseIndex):


### PR DESCRIPTION
I am using the latest elasticsearch binary and master of nlp. For me elasticsearch searches failed because the resultant "id_" returned for searches are strings, but our library assumes them to be integers.