### PR TITLE
Fix numpy stacking

### DIFF
--- a/datasets/crd3/crd3.py
+++ b/datasets/crd3/crd3.py
@@ -17,9 +17,9 @@
 """CRD3  dataset"""
 
 from __future__ import absolute_import, division, print_function
-import logging
 
 import json
+import logging
 import os
 
 import nlp
@@ -46,10 +46,11 @@ and semantic ties to the previous dialogues.
 
 _URL = "https://github.com/RevanthRameshkumar/CRD3/archive/master.zip"
 
+
 def get_train_test_dev_files(files, test_split, train_split, dev_split):
     test_files = dev_files = train_files = []
     for file in files:
-        filename = os.path.split(file)[1].split('_')[0]
+        filename = os.path.split(file)[1].split("_")[0]
         if filename in test_split:
             test_files.append(file)
         elif filename in train_split:
@@ -59,25 +60,23 @@ def get_train_test_dev_files(files, test_split, train_split, dev_split):
         else:
             logging.info("skipped file {}".format(file))
     return test_files, train_files, dev_files
-    
+
 
 class CRD3(nlp.GeneratorBasedBuilder):
-    
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({
-                "chunk": nlp.Value("string"),
-                "chunk_id": nlp.Value("int32"),
-                "turn_start": nlp.Value("int32"),
-                "turn_end": nlp.Value("int32"),
-                "alignment_score": nlp.Value("float32"),
-                "turn_num": nlp.Value("int32"),
-                "turns":nlp.features.Sequence({
-                    "names": nlp.Value("string"),
-                    "utterances": nlp.Value("string"),
-            }),
-            }),
+            features=nlp.Features(
+                {
+                    "chunk": nlp.Value("string"),
+                    "chunk_id": nlp.Value("int32"),
+                    "turn_start": nlp.Value("int32"),
+                    "turn_end": nlp.Value("int32"),
+                    "alignment_score": nlp.Value("float32"),
+                    "turn_num": nlp.Value("int32"),
+                    "turns": nlp.features.Sequence({"names": nlp.Value("string"), "utterances": nlp.Value("string"),}),
+                }
+            ),
             homepage="https://github.com/RevanthRameshkumar/CRD3",
             citation=_CITATION,
         )
@@ -89,7 +88,7 @@ class CRD3(nlp.GeneratorBasedBuilder):
         dev_file = os.path.join(path, "CRD3-master", "data", "aligned data", "val_files")
         with open(test_file) as f:
             test_splits = [file.replace("\n", "") for file in f.readlines()]
-            
+
         with open(train_file) as f:
             train_splits = [file.replace("\n", "") for file in f.readlines()]
         with open(dev_file) as f:
@@ -98,29 +97,20 @@ class CRD3(nlp.GeneratorBasedBuilder):
         c3 = "CRD3-master/data/aligned data/c=3"
         c4 = "CRD3-master/data/aligned data/c=4"
         files = [os.path.join(path, c2, file) for file in sorted(os.listdir(os.path.join(path, c2)))]
-        files.extend([os.path.join(path, c3, file) for file in sorted(os.listdir(os.path.join(path, c3)))])  
-        files.extend([os.path.join(path, c4, file) for file in sorted(os.listdir(os.path.join(path, c4)))])  
-        
+        files.extend([os.path.join(path, c3, file) for file in sorted(os.listdir(os.path.join(path, c3)))])
+        files.extend([os.path.join(path, c4, file) for file in sorted(os.listdir(os.path.join(path, c4)))])
+
         test_files, train_files, dev_files = get_train_test_dev_files(files, test_splits, train_splits, dev_splits)
-    
+
         return [
-            nlp.SplitGenerator(
-                name=nlp.Split.TRAIN,
-                gen_kwargs={"files_path": train_files},
-            ),
-            nlp.SplitGenerator(
-                name=nlp.Split.TEST,
-                gen_kwargs={"files_path": test_files},
-            ),
-            nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION,
-                gen_kwargs={"files_path": dev_files},
-            )
+            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"files_path": train_files},),
+            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"files_path": test_files},),
+            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"files_path": dev_files},),
         ]
 
     def _generate_examples(self, files_path):
         """Yields examples."""
-        
+
         for file in files_path:
             with open(file) as f:
                 data = json.load(f)
@@ -130,21 +120,16 @@ class CRD3(nlp.GeneratorBasedBuilder):
                     turn_start = row["ALIGNMENT"]["TURN START"]
                     turn_end = row["ALIGNMENT"]["TURN END"]
                     score = row["ALIGNMENT"]["ALIGNMENT SCORE"]
-                    for id2, turn in enumerate(row['TURNS']):
+                    for id2, turn in enumerate(row["TURNS"]):
                         turn_names = turn["NAMES"]
                         turn_utterances = turn["UTTERANCES"]
                         turn_num = turn["NUMBER"]
-                        yield str(id1)+'_'+str(id2), {
-                            "chunk":chunk,
+                        yield str(id1) + "_" + str(id2), {
+                            "chunk": chunk,
                             "chunk_id": chunk_id,
                             "turn_start": turn_start,
                             "turn_end": turn_end,
                             "alignment_score": score,
                             "turn_num": turn_num,
-                            "turns": {
-                                "names": turn_names,
-                                "utterances": turn_utterances,
-                        },
+                            "turns": {"names": turn_names, "utterances": turn_utterances,},
                         }
-                            
-

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -583,8 +583,6 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
         map_nested_kwargs = {}
         if format_type == "numpy":
-            import numpy as np
-
             if "copy" not in format_kwargs:
                 format_kwargs["copy"] = False
             command = partial(np.array, **format_kwargs)
@@ -603,8 +601,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                 return x
 
             command = identity
-
-        if isinstance(outputs, (list, tuple)):
+        if isinstance(outputs, (list, tuple, np.ndarray)):
             return command(outputs)
         elif isinstance(outputs, pd.DataFrame):
             if format_columns is not None and not output_all_columns:
@@ -678,7 +675,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     if format_type == "pandas":
                         outputs = self._data[key].to_pandas(split_blocks=True)
                     elif format_type in ("numpy", "torch", "tensorflow"):
-                        outputs = self._data[key].to_pandas(split_blocks=True).to_numpy()
+                        outputs = self._data.to_pandas(split_blocks=True).to_dict("list")[key]
                     else:
                         outputs = self._data[key].to_pylist()
                 else:
@@ -698,7 +695,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         else:
             raise ValueError("Can only get row(s) (int or slice or list[int]) or columns (string).")
 
-        if (format_type is not None or format_columns is not None) and not isinstance(key, str):
+        if format_type is not None or format_columns is not None:
             outputs = self._convert_outputs(
                 outputs,
                 format_type=format_type,


### PR DESCRIPTION
When getting items using a column name as a key, numpy arrays were not stacked.
I fixed that and added some tests.

There is another issue that still needs to be fixed though: when getting items using a column name as a key, pytorch tensors are not stacked (it outputs a list of tensors). This PR should help with the to fix this issue.