### PR TITLE
Fix batched map for formatted dataset

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -926,7 +926,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
                     inputs.pop(column)
             if self._format_type is not None:
                 inputs = self._getitem(
-                    key=(indices if isinstance(indices, int) else slice(indices[0], indices[-1])),
+                    key=(indices if isinstance(indices, int) else slice(indices[0], indices[-1] + 1)),
                     format_type=None,
                     format_columns=None,
                     format_kwargs=None,

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -326,6 +326,17 @@ class BaseDatasetTest(TestCase):
                 dset_test_batched.features, Features({"filename": Value("string"), "filename_new": Value("string")})
             )
 
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with dset.formated_as("numpy", columns=["filename"]):
+                tmp_file = os.path.join(tmp_dir, "test.arrow")
+                dset_test_batched = dset.map(map_batched, batched=True, cache_file_name=tmp_file)
+                self.assertEqual(len(dset_test_batched), 30)
+                self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+                self.assertDictEqual(
+                    dset_test_batched.features,
+                    Features({"filename": Value("string"), "filename_new": Value("string")}),
+                )
+
         def map_batched_with_indices(example, idx):
             return {"filename_new": [x + "_extension_" + str(idx) for x in example["filename"]]}
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -327,7 +327,7 @@ class BaseDatasetTest(TestCase):
             )
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with dset.formated_as("numpy", columns=["filename"]):
+            with dset.formatted_as("numpy", columns=["filename"]):
                 tmp_file = os.path.join(tmp_dir, "test.arrow")
                 dset_test_batched = dset.map(map_batched, batched=True, cache_file_name=tmp_file)
                 self.assertEqual(len(dset_test_batched), 30)


### PR DESCRIPTION
If you had a dataset formatted as numpy for example, and tried to do a batched map, then it would crash because one of the elements from the inputs was missing for unchanged columns (ex: batch of length 999 instead of 1000).
The happened during the creation of the `pa.Table`, since columns had different lengths.