### PR TITLE
[METRICS, breaking] Refactor caching behavior, pickle/cloudpickle metrics and dataset, add tests on metrics

### DIFF
--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -259,7 +259,7 @@ class ArrowReader(BaseReader):
         """Initializes ArrowReader.
 
         Args:
-            path (str): path where tfrecords are stored.
+            path (str): path where Arrow files are stored.
             info (DatasetInfo): info about the dataset.
         """
         super().__init__(path, info)

--- a/src/nlp/info.py
+++ b/src/nlp/info.py
@@ -267,7 +267,7 @@ class MetricInfo:
     # Set later by the builder
     metric_name: Optional[str] = None
     config_name: Optional[str] = None
-    version: Optional[str] = None
+    experiment_id: Optional[str] = None
 
     def __post_init__(self):
         assert "predictions" in self.features, "Need to have at least a 'predictions' field in 'features'."

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -410,12 +410,11 @@ def prepare_module(
 
 def load_metric(
     path: str,
-    name: Optional[str] = None,
+    config_name: Optional[str] = None,
     process_id: int = 0,
     num_process: int = 1,
     data_dir: Optional[str] = None,
-    experiment_id: Optional[str] = None,
-    in_memory: bool = False,
+    keep_in_memory: bool = False,
     download_config: Optional[DownloadConfig] = None,
     **metric_init_kwargs,
 ) -> Metric:
@@ -429,7 +428,7 @@ def load_metric(
                     e.g. ``'./dataset/squad'`` or ``'./dataset/squad/squad.py'``
                 - a dataset identifier on HuggingFace AWS bucket (list all available datasets and ids with ``nlp.list_datasets()``)
                     e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``
-        name (Optional ``str``): defining the name of the dataset configuration
+        config_name (Optional ``str``): selecting a configuration for the metric (e.g. the GLUE metric has a configuration for each subset)
         process_id (Optional ``int``): for distributed evaluation: id of the process
         num_process (Optional ``int``): for distributed evaluation: total number of processes
         data_dir (Optional str): path to store the temporary predictions and references (default to `~/.nlp/`)
@@ -442,13 +441,11 @@ def load_metric(
     module_path, hash = prepare_module(path, download_config=download_config, dataset=False)
     metric_cls = import_main_class(module_path, dataset=False)
     metric = metric_cls(
-        name=name,
-        hash=hash,
+        config_name=config_name,
         process_id=process_id,
         num_process=num_process,
         data_dir=data_dir,
-        experiment_id=experiment_id,
-        in_memory=in_memory,
+        keep_in_memory=keep_in_memory,
         **metric_init_kwargs,
     )
 

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -433,7 +433,7 @@ def load_metric(
         num_process (Optional ``int``): for distributed evaluation: total number of processes
         data_dir (Optional str): path to store the temporary predictions and references (default to `~/.nlp/`)
         experiment_id (Optional str): An optional unique id for the experiment.
-        in_memory (bool): Weither to store the temporary results in memory (default: False)
+        keep_in_memory (bool): Weither to store the temporary results in memory (default: False)
         download_config (Optional ``nlp.DownloadConfig``: specific download configuration parameters.
 
     Returns: `nlp.Metric`.

--- a/src/nlp/metric.py
+++ b/src/nlp/metric.py
@@ -210,8 +210,14 @@ class Metric(object):
             file_paths, filelocks = self._get_all_cache_files(timeout=timeout)
 
             # Read the predictions and references
-            reader = ArrowReader(path=self.data_dir, info=None)
-            self.data = Dataset(**reader.read_files([{"filename": f} for f in file_paths]))
+            try:
+                reader = ArrowReader(path=self.data_dir, info=None)
+                self.data = Dataset(**reader.read_files([{"filename": f} for f in file_paths]))
+            except FileNotFoundError:
+                raise ValueError(
+                    "Another metric instance is already using the local cache file. "
+                    "Please specify an experiment_id to avoid colision between distributed metric instances."
+                )
 
             # Store file paths and locks and we will release/delete them after the computation.
             self.file_paths = file_paths

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -45,6 +45,7 @@ try:
 except ImportError:
     _torch_available = False  # pylint: disable=invalid-name
 
+
 try:
     USE_TF = os.environ.get("USE_TF", "AUTO").upper()
     USE_TORCH = os.environ.get("USE_TORCH", "AUTO").upper()
@@ -61,13 +62,6 @@ try:
 except (ImportError, AssertionError):
     _tf_available = False  # pylint: disable=invalid-name
 
-try:
-    import transformers
-
-    _transformers_available = True  # pylint: disable=invalid-name
-    logger.info("transformers version {} available.".format(transformers.__version__))
-except ImportError:
-    _transformers_available = False  # pylint: disable=invalid-name
 
 hf_cache_home = os.path.expanduser(
     os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface"))

--- a/src/nlp/utils/py_utils.py
+++ b/src/nlp/utils/py_utils.py
@@ -30,8 +30,6 @@ from types import CodeType
 import dill
 import numpy as np
 
-from .file_utils import _transformers_available
-
 
 # NOTE: When used on an instance method, the cache is shared across all
 # instances and IS NOT per-instance.
@@ -276,7 +274,7 @@ def dump(obj, file):
 
 @contextlib.contextmanager
 def _no_cache_fields(obj):
-    if _transformers_available:
+    try:
         import transformers as tr
 
         if isinstance(obj, tr.PreTrainedTokenizerBase) and hasattr(obj, "cache") and isinstance(obj.cache, dict):
@@ -284,7 +282,8 @@ def _no_cache_fields(obj):
                 yield
         else:
             yield
-    else:
+
+    except ImportError:
         yield
 
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import tempfile
 from unittest import TestCase
 
@@ -33,6 +34,22 @@ class BaseDatasetTest(TestCase):
         self.assertDictEqual(dset.features, Features({"col_1": Value("int64"), "col_2": Value("string")}))
         self.assertEqual(dset[0]["col_1"], 3)
         self.assertEqual(dset["col_1"][0], 3)
+
+    def test_dummy_dataset_pickle(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "dset.pt")
+
+            dset = self._create_dummy_dataset()
+
+            with open(tmp_file, "wb") as f:
+                pickle.dump(dset, f)
+
+            with open(tmp_file, "rb") as f:
+                dset = pickle.load(f)
+
+        self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+        self.assertEqual(dset[0]["filename"], "my_name-train_0")
+        self.assertEqual(dset["filename"][0], "my_name-train_0")
 
     def test_from_pandas(self):
         data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import tempfile
+from multiprocessing import Pool
 from unittest import TestCase
 
 from nlp.features import Features, Value
@@ -18,29 +19,175 @@ class DummyMetric(Metric):
         )
 
     def _compute(self, predictions, references):
-        return sum(i == j for i, j in zip(predictions, references)) / len(predictions)
+        return {
+            "accuracy": sum(i == j for i, j in zip(predictions, references)) / len(predictions),
+            "set_equality": set(predictions) == set(references),
+        }
+
+    @classmethod
+    def predictions_and_references(cls):
+        return ([1, 2, 3, 4], [1, 2, 4, 3])
+
+    @classmethod
+    def expected_results(cls):
+        return {"accuracy": 0.5, "set_equality": True}
+
+    @classmethod
+    def other_predictions_and_references(cls):
+        return ([1, 3, 4, 5], [1, 2, 3, 4])
+
+    @classmethod
+    def other_expected_results(cls):
+        return {"accuracy": 0.25, "set_equality": False}
+
+    @classmethod
+    def distributed_predictions_and_references(cls):
+        return ([1, 2, 3, 4], [1, 2, 3, 4]), ([1, 2, 4, 5], [1, 2, 3, 4])
+
+    @classmethod
+    def distributed_expected_results(cls):
+        return {"accuracy": 0.75, "set_equality": False}
+
+
+def metric_compute(arg):
+    """ Thread worker function for distributed evaluation testing.
+        On base level to be pickable.
+    """
+    process_id, preds, refs = arg
+    metric = DummyMetric(num_process=2, process_id=process_id)
+    return metric.compute(predictions=preds, references=refs)
+
+
+def metric_add_batch_and_compute(arg):
+    """ Thread worker function for distributed evaluation testing.
+        On base level to be pickable.
+    """
+    process_id, preds, refs = arg
+    metric = DummyMetric(num_process=2, process_id=process_id)
+    metric.add_batch(predictions=preds, references=refs)
+    return metric.compute()
+
+
+def metric_add_and_compute(arg):
+    """ Thread worker function for distributed evaluation testing.
+        On base level to be pickable.
+    """
+    process_id, preds, refs = arg
+    metric = DummyMetric(num_process=2, process_id=process_id)
+    for pred, ref in zip(preds, refs):
+        metric.add(prediction=pred, reference=ref)
+    return metric.compute()
+
+
+def metric_add_and_compute_exp_id(arg):
+    """ Thread worker function for distributed evaluation testing.
+        On base level to be pickable.
+    """
+    process_id, preds, refs, exp_id = arg
+    metric = DummyMetric(num_process=2, process_id=process_id, experiment_id=exp_id)
+    for pred, ref in zip(preds, refs):
+        metric.add(prediction=pred, reference=ref)
+    return metric.compute()
 
 
 class TestMetric(TestCase):
     def test_dummy_metric(self):
-        preds, refs = [1, 2, 3, 4], [1, 2, 4, 3]
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
 
         metric = DummyMetric()
-        self.assertEqual(0.5, metric.compute(predictions=preds, references=refs))
+        self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
 
         metric = DummyMetric()
         metric.add_batch(predictions=preds, references=refs)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())
 
         metric = DummyMetric()
         for pred, ref in zip(preds, refs):
             metric.add(prediction=pred, reference=ref)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())
+
+    def test_concurrent_metrics(self):
+        preds, refs = DummyMetric.predictions_and_references()
+        other_preds, other_refs = DummyMetric.other_predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+        other_expected_results = DummyMetric.other_expected_results()
+
+        metric = DummyMetric()
+        other_metric = DummyMetric()
+
+        self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
+        self.assertDictEqual(
+            other_expected_results, other_metric.compute(predictions=other_preds, references=other_refs)
+        )
+
+        metric = DummyMetric()
+        other_metric = DummyMetric()
+        metric.add_batch(predictions=preds, references=refs)
+        other_metric.add_batch(predictions=other_preds, references=other_refs)
+        self.assertDictEqual(expected_results, metric.compute())
+        self.assertDictEqual(other_expected_results, other_metric.compute())
+
+        for pred, ref, other_pred, other_ref in zip(preds, refs, other_preds, other_refs):
+            metric.add(prediction=pred, reference=ref)
+            other_metric.add(prediction=other_pred, reference=other_ref)
+        self.assertDictEqual(expected_results, metric.compute())
+        self.assertDictEqual(other_expected_results, other_metric.compute())
+
+    def test_distributed_metrics(self):
+        (preds_0, refs_0), (preds_1, refs_1) = DummyMetric.distributed_predictions_and_references()
+        expected_results = DummyMetric.distributed_expected_results()
+
+        pool = Pool()
+
+        results = pool.map(metric_compute, [(0, preds_0, refs_0), (1, preds_1, refs_1)])
+        self.assertDictEqual(expected_results, results[0])
+        self.assertIsNone(results[1])
+
+        results = pool.map(metric_add_and_compute, [(0, preds_0, refs_0), (1, preds_1, refs_1)])
+        self.assertDictEqual(expected_results, results[0])
+        self.assertIsNone(results[1])
+
+        results = pool.map(metric_add_batch_and_compute, [(0, preds_0, refs_0), (1, preds_1, refs_1)])
+        self.assertDictEqual(expected_results, results[0])
+        self.assertIsNone(results[1])
+
+        # To use several distributed metrics on the same local file system, need to specify an experiment_id
+        try:
+            results = pool.map(
+                metric_add_and_compute,
+                [(0, preds_0, refs_0), (1, preds_1, refs_1), (0, preds_0, refs_0), (1, preds_1, refs_1)],
+            )
+        except ValueError:
+            # We are fine with either raising a ValueError or computing well the metric
+            # Being sure we raise the error would means making the dummy dataset bigger
+            # and the test longer...
+            pass
+        else:
+            self.assertDictEqual(expected_results, results[0])
+            self.assertDictEqual(expected_results, results[2])
+            self.assertIsNone(results[1])
+            self.assertIsNone(results[3])
+
+        results = pool.map(
+            metric_add_and_compute_exp_id,
+            [
+                (0, preds_0, refs_0, "exp_0"),
+                (1, preds_1, refs_1, "exp_0"),
+                (0, preds_0, refs_0, "exp_1"),
+                (1, preds_1, refs_1, "exp_1"),
+            ],
+        )
+        self.assertDictEqual(expected_results, results[0])
+        self.assertDictEqual(expected_results, results[2])
+        self.assertIsNone(results[1])
+        self.assertIsNone(results[3])
 
     def test_dummy_metric_pickle(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_file = os.path.join(tmp_dir, "metric.pt")
-            preds, refs = [1, 2, 3, 4], [1, 2, 4, 3]
+            preds, refs = DummyMetric.predictions_and_references()
+            expected_results = DummyMetric.expected_results()
 
             metric = DummyMetric()
 
@@ -49,57 +196,63 @@ class TestMetric(TestCase):
 
             with open(tmp_file, "rb") as f:
                 metric = pickle.load(f)
-            self.assertEqual(0.5, metric.compute(predictions=preds, references=refs))
+            self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
 
     def test_input_numpy(self):
         import numpy as np
 
-        preds, refs = np.array([1, 2, 3, 4]), np.array([1, 2, 4, 3])
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+        preds, refs = np.array(preds), np.array(refs)
 
         metric = DummyMetric()
-        self.assertEqual(0.5, metric.compute(predictions=preds, references=refs))
+        self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
 
         metric = DummyMetric()
         metric.add_batch(predictions=preds, references=refs)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())
 
         metric = DummyMetric()
         for pred, ref in zip(preds, refs):
             metric.add(prediction=pred, reference=ref)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())
 
     @require_torch
     def test_input_torch(self):
         import torch
 
-        preds, refs = torch.Tensor([1, 2, 3, 4]), torch.Tensor([1, 2, 4, 3])
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+        preds, refs = torch.Tensor(preds), torch.Tensor(refs)
 
         metric = DummyMetric()
-        self.assertEqual(0.5, metric.compute(predictions=preds, references=refs))
+        self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
 
         metric = DummyMetric()
         metric.add_batch(predictions=preds, references=refs)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())
 
         metric = DummyMetric()
         for pred, ref in zip(preds, refs):
             metric.add(prediction=pred, reference=ref)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())
 
     @require_tf
     def test_input_tf(self):
         import tensorflow as tf
 
-        preds, refs = tf.constant([1, 2, 3, 4]), tf.constant([1, 2, 4, 3])
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+        preds, refs = tf.constant(preds), tf.constant(refs)
 
         metric = DummyMetric()
-        self.assertEqual(0.5, metric.compute(predictions=preds, references=refs))
+        self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
 
         metric = DummyMetric()
         metric.add_batch(predictions=preds, references=refs)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())
 
         metric = DummyMetric()
         for pred, ref in zip(preds, refs):
             metric.add(prediction=pred, reference=ref)
-        self.assertEqual(0.5, metric.compute())
+        self.assertDictEqual(expected_results, metric.compute())

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,3 +1,6 @@
+import os
+import pickle
+import tempfile
 from unittest import TestCase
 
 from nlp.features import Features, Value
@@ -33,6 +36,20 @@ class TestMetric(TestCase):
         for pred, ref in zip(preds, refs):
             metric.add(prediction=pred, reference=ref)
         self.assertEqual(0.5, metric.compute())
+
+    def test_dummy_metric_pickle(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "metric.pt")
+            preds, refs = [1, 2, 3, 4], [1, 2, 4, 3]
+
+            metric = DummyMetric()
+
+            with open(tmp_file, "wb") as f:
+                pickle.dump(metric, f)
+
+            with open(tmp_file, "rb") as f:
+                metric = pickle.load(f)
+            self.assertEqual(0.5, metric.compute(predictions=preds, references=refs))
 
     def test_input_numpy(self):
         import numpy as np

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from distutils.util import strtobool
 
-from nlp.utils.file_utils import _tf_available, _torch_available, _transformers_available
+from nlp.utils.file_utils import _tf_available, _torch_available
 
 
 def parse_flag_from_env(key, default=False):
@@ -57,9 +57,12 @@ def require_transformers(test_case):
     These tests are skipped when transformers isn't installed.
 
     """
-    if not _transformers_available:
-        test_case = unittest.skip("test requires transformers")(test_case)
-    return test_case
+    try:
+        import transformers  # noqa F401
+    except ImportError:
+        return unittest.skip("test requires transformers")(test_case)
+    else:
+        return test_case
 
 
 def slow(test_case):


### PR DESCRIPTION
Move the acquisition of the filelock at a later stage during metrics processing so it can be pickled/cloudpickled after instantiation.

Also add some tests on pickling, concurrent but separate metric instances and concurrent and distributed metric instances.

Changes significantly the caching behavior for the metrics:
- if the metric is used in a non-distributed setup (most common case) we try to find a free cache file using UUID instead of asking for an `experiment_id` if we can't lock the cache file this allows to use several instances of the same metrics in parallel.
- if the metrics is used in a distributed setup we ask for an `experiment_id` if we can't lock the cache file (because all the nodes need to have related cache file names for the final sync.
- after the computation, we free the locks and delete all the cache files.

Breaking: Some arguments for Metrics initialization have been removed for simplicity (`version`...) and some have been renamed for consistency with the rest of the library (`in_memory` => `keep_in_memory`).

Also remove the `_has_transformers` detection in utils to avoid importing transformers everytime during loading.