### PR TITLE
Fix config used for slow test on real dataset

### DIFF
--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -207,7 +207,9 @@ class LocalDatasetTest(parameterized.TestCase):
         path = "./datasets/" + dataset_name
         module_path, hash = prepare_module(path, download_config=DownloadConfig(local_files_only=True), dataset=True)
         builder_cls = import_main_class(module_path, dataset=True)
-        config_names = [config.name for config in builder_cls.BUILDER_CONFIGS] if len(builder_cls.BUILDER_CONFIGS) > 0 else [None]
+        config_names = (
+            [config.name for config in builder_cls.BUILDER_CONFIGS] if len(builder_cls.BUILDER_CONFIGS) > 0 else [None]
+        )
         for name in config_names:
             with tempfile.TemporaryDirectory() as temp_cache_dir:
                 dataset = load_dataset(
@@ -282,7 +284,9 @@ class AWSDatasetTest(parameterized.TestCase):
         path = dataset_name
         module_path, hash = prepare_module(path, download_config=DownloadConfig(force_download=True), dataset=True)
         builder_cls = import_main_class(module_path, dataset=True)
-        config_names = [config.name for config in builder_cls.BUILDER_CONFIGS] if len(builder_cls.BUILDER_CONFIGS) > 0 else [None]
+        config_names = (
+            [config.name for config in builder_cls.BUILDER_CONFIGS] if len(builder_cls.BUILDER_CONFIGS) > 0 else [None]
+        )
         for name in config_names:
             with tempfile.TemporaryDirectory() as temp_cache_dir:
                 dataset = load_dataset(


### PR DESCRIPTION
As noticed in #470, #474, #476, #504 , the slow test `test_load_real_dataset` couldn't run on datasets that require config parameters.

To fix that I replaced it with one test with the first config of BUILDER_CONFIGS `test_load_real_dataset`, and another test that runs all of the configs in BUILDER_CONFIGS `test_load_real_dataset_all_configs`