### PR TITLE
use ragged tensor by default

### DIFF
--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -599,9 +599,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             map_nested_kwargs["map_list"] = False  # convert lists to tensors
 
             def command(x):
-                if isinstance(x, Iterable):  # add support for nested types like struct of list of struct
+                if isinstance(
+                    x, (list, tuple, np.ndarray)
+                ):  # add support for nested types like struct of list of struct
                     x = np.array(x, copy=False)
-                    if x.dtype == np.object:
+                    if x.dtype == np.object:  # pytorch tensors cannot be instantied from an array of objects
                         return [map_nested(command, i, **map_nested_kwargs) for i in x]
                 return torch.tensor(x, **format_kwargs)
 
@@ -611,14 +613,16 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             map_nested_kwargs["map_list"] = False  # convert lists to tensors
 
             def command(x):
-                if isinstance(x, Iterable):  # add support for nested types like struct of list of struct
+                if isinstance(
+                    x, (list, tuple, np.ndarray)
+                ):  # add support for nested types like struct of list of struct
                     x = np.array(x, copy=False)
-                    if x.dtype == np.object:
+                    if x.dtype == np.object:  # tensorflow tensors can sometimes be instantied from an array of objects
                         try:
-                            return tensorflow.ragged.constant(x)
+                            return tensorflow.ragged.constant(x, **format_kwargs)
                         except ValueError:
                             return [map_nested(command, i, **map_nested_kwargs) for i in x]
-                return tensorflow.constant(x, **format_kwargs)
+                return tensorflow.ragged.constant(x, **format_kwargs)
 
         else:
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -806,8 +806,8 @@ class BaseDatasetTest(TestCase):
                 self.assertIsInstance(dset[0][col], (tf.Tensor, tf.RaggedTensor))
                 self.assertIsInstance(dset[:2][col], (tf.Tensor, tf.RaggedTensor))
                 self.assertIsInstance(dset[col], (tf.Tensor, tf.RaggedTensor))
-            self.assertEqual(dset[:2]["vec"].shape, (2, 3))
-            self.assertEqual(dset["vec"][:2].shape, (2, 3))
+            self.assertEqual(tuple(dset[:2]["vec"].shape), (2, None))
+            self.assertEqual(tuple(dset["vec"][:2].shape), (2, None))
 
             dset.set_format("numpy")
             self.assertIsNotNone(dset[0])


### PR DESCRIPTION
I think it's better if it's clear whether the returned tensor is ragged or not when the type is set to tensorflow.
Previously it was a tensor (not ragged) if numpy could stack the output (which can change depending on the batch of example you take), which make things difficult to handle, as it may sometimes return a ragged tensor and sometimes not.

Therefore I reverted this behavior to always return a ragged tensor as we used to do.