### PR TITLE
Fix bleurt logging import

### DIFF
--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -17,7 +17,7 @@
 import os
 
 import nlp
-from nlp.logging import get_logger
+from nlp.utils.logging import get_logger
 from bleurt import score  # From: git+https://github.com/google-research/bleurt.git
 
 


### PR DESCRIPTION
Bleurt started throwing an error in some code we have.
This looks like the fix but...

It's also unnerving that even a prebuilt docker image with pinned versions can be working 1 day and then fail the next (especially for production systems).

Any way for us to pin your metrics code so that they are guaranteed not to to change and possibly fail on repository changes?

Thanks (and also for your continued work on the lib...)