### PR TITLE
[Reproductibility] Allow to pin versions of datasets/metrics

### DIFF
--- a/src/nlp/info.py
+++ b/src/nlp/info.py
@@ -262,6 +262,7 @@ class MetricInfo:
     reference_urls: List[str] = field(default_factory=list)
     streamable: bool = False
     format: Optional[str] = None
+    version: Optional[Union[str, Version]] = None,
 
     # Set later by the builder
     metric_name: Optional[str] = None
@@ -277,6 +278,11 @@ class MetricInfo:
                         f"When using 'numpy' format, all features should be a `nlp.Value` feature. "
                         f"Here {key} is an instance of {value.__class__.__name__}"
                     )
+        if self.version is not None and not isinstance(self.version, Version):
+            if isinstance(self.version, str):
+                self.version = Version(self.version)
+            else:
+                self.version = Version.from_dict(self.version)
 
     def write_to_directory(self, metric_info_dir):
         """Write `MetricInfo` as JSON to `metric_info_dir`.

--- a/src/nlp/info.py
+++ b/src/nlp/info.py
@@ -262,7 +262,7 @@ class MetricInfo:
     reference_urls: List[str] = field(default_factory=list)
     streamable: bool = False
     format: Optional[str] = None
-    version: Optional[Union[str, Version]] = None,
+    version: Optional[Union[str, Version]] = None
 
     # Set later by the builder
     metric_name: Optional[str] = None

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -44,6 +44,7 @@ from .utils.file_utils import DownloadConfig, cached_path, hf_bucket_url
 from .utils.logging import get_logger
 from .utils.version import Version
 
+
 logger = get_logger(__name__)
 
 CURRENT_FILE_DIRECTORY = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Repurpose the `version` attribute in datasets and metrics to let the user pin a specific version of datasets and metric scripts:
```
dataset = nlp.load_dataset('squad', version='1.0.0')
metric = nlp.load_metric('squad', version='1.0.0')
```

Notes:
- version number are the release version of the library
- currently only possible for canonical datasets/metrics, ie. integrated in the GitHub repo of the library