### PR TITLE
Remove logger pickling to fix gg colab issues

### DIFF
--- a/src/nlp/fingerprint.py
+++ b/src/nlp/fingerprint.py
@@ -142,15 +142,17 @@ def fingerprint(inplace, use_kwargs=None, ignore_kwargs=None, fingerprint_names=
                     kwargs_for_fingerprint["generator"] = np.random.default_rng(None)
 
             # compute new_fingerprint and add it to the args of not in-place transforms
-
+            transform = func.__module__ + "." + func.__qualname__
             if inplace:
-                new_fingerprint = update_fingerprint(self._fingerprint, func, kwargs_for_fingerprint)
+                new_fingerprint = update_fingerprint(self._fingerprint, transform, kwargs_for_fingerprint)
                 new_inplace_history_item = (func.__name__, deepcopy(args), deepcopy(kwargs))
             else:
                 for fingerprint_name in fingerprint_names:  # transforms like `train_test_split` have several hashes
                     if kwargs.get(fingerprint_name) is None:
                         kwargs_for_fingerprint["fingerprint_name"] = fingerprint_name
-                        kwargs[fingerprint_name] = update_fingerprint(self._fingerprint, func, kwargs_for_fingerprint)
+                        kwargs[fingerprint_name] = update_fingerprint(
+                            self._fingerprint, transform, kwargs_for_fingerprint
+                        )
 
             # Call actual function
 

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
+import nlp.arrow_dataset
 from nlp import concatenate_datasets
 from nlp.arrow_dataset import Dataset
 from nlp.features import ClassLabel, Features, Sequence, Value
@@ -29,6 +30,14 @@ def picklable_filter_function(x):
 
 
 class BaseDatasetTest(TestCase):
+    def setUp(self):
+        # google colab doesn't allow to pickle loggers
+        # so we want to make sure each tests passes without pickling the logger
+        def reduce_ex(self):
+            raise pickle.PicklingError()
+
+        nlp.arrow_dataset.logger.__reduce_ex__ = reduce_ex
+
     def _create_dummy_dataset(self, multiple_columns=False):
         if multiple_columns:
             data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}


### PR DESCRIPTION
A `logger` objects are not picklable in google colab, contrary to `logger` objects in jupyter notebooks or in python shells.
It creates some issues in google colab right now.

Indeed by calling any `Dataset` method, the fingerprint update pickles the transform function, and as the logger comes with it, it results in an error (full stacktrace [here](http://pastebin.fr/64330)):

```python
/usr/local/lib/python3.6/dist-packages/zmq/backend/cython/socket.cpython-36m-x86_64-linux-gnu.so in zmq.backend.cython.socket.Socket.__reduce_cython__()

TypeError: no default __reduce__ due to non-trivial __cinit__
```

To fix that I no longer dump the transform (`_map_single`, `select`, etc.), but the full name only (`nlp.arrow_dataset.Dataset._map_single`, `nlp.arrow_dataset.Dataset.select`, etc.)