### PR TITLE
Serialization

### DIFF
--- a/docs/source/package_reference/loading_methods.rst
+++ b/docs/source/package_reference/loading_methods.rst
@@ -10,6 +10,8 @@ Datasets
 
 .. autofunction:: nlp.load_dataset
 
+.. autofunction:: nlp.load_from_disk
+
 Metrics
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/package_reference/main_classes.rst
+++ b/docs/source/package_reference/main_classes.rst
@@ -21,6 +21,7 @@ The base class :class:`nlp.Dataset` implements a Dataset backed by an Apache Arr
         __len__, __iter__, formatted_as, set_format, reset_format,
         __getitem__, cleanup_cache_files,
         map, filter, select, sort, shuffle, train_test_split, shard, export,
+        save_to_disk, load_from_disk,
         add_faiss_index, add_faiss_index_from_external_arrays, save_faiss_index, load_faiss_index,
         add_elasticsearch_index,
         list_indexes, get_index, drop_index, search, search_batch, get_nearest_examples, get_nearest_examples_batch,
@@ -41,7 +42,8 @@ It also has dataset transform methods like map or filter, to process all the spl
         unique, flatten_,
         cleanup_cache_files,
         map, filter, sort, shuffle, set_format, reset_format, formatted_as,
-        cast_, remove_columns_, rename_column_
+        cast_, remove_columns_, rename_column_,
+        save_to_disk, load_from_disk,
 
 
 ``Features``

--- a/docs/source/processing.rst
+++ b/docs/source/processing.rst
@@ -464,6 +464,25 @@ When you have several :obj:`nlp.Dataset` objects that share the same column type
     >>> bert_dataset = concatenate_datasets([bookcorpus, wiki])
 
 
+Saving a processed dataset on disk and reload it
+------------------------------------------------
+
+Once you have your final dataset you can save it on your disk and reuse it later using :obj:`nlp.load_from_disk`.
+Saving a dataset creates a directory with various files:
+
+- arrow files: they contain your dataset's data
+- dataset_info.json: contains the description, citations, etc. of the dataset
+- state.json: contains the list of the arrow files and other informations like the dataset format type, if any (torch or tensorflow for example)
+
+.. code-block::
+
+    >>> encoded_dataset.save_to_disk("path/of/my/dataset/directory")
+    >>> ...
+    >>> from nlp import load_from_disk
+    >>> reloaded_encoded_dataset = load_from_disk("path/of/my/dataset/directory")
+
+Both :obj:`nlp.Dataset` and :obj:`nlp.DatasetDict` objects can be saved on disk, by using respectively :func:`nlp.Dataset.save_to_disk` and :func:`nlp.DatasetDict.save_to_disk`.
+
 Controling the cache behavior
 -----------------------------------
 

--- a/src/nlp/__init__.py
+++ b/src/nlp/__init__.py
@@ -43,7 +43,7 @@ from .features import (
 )
 from .info import DatasetInfo, MetricInfo
 from .inspect import inspect_dataset, inspect_metric, list_datasets, list_metrics
-from .load import import_main_class, load_dataset, load_metric, prepare_module
+from .load import import_main_class, load_dataset, load_from_disk, load_metric, prepare_module
 from .metric import Metric
 from .splits import NamedSplit, Split, SplitBase, SplitDict, SplitGenerator, SplitInfo, SubSplitInfo, percent
 from .utils import *

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -409,6 +409,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             data_file["filename"] = filename
         # Get state
         state = self.__getstate__()
+        state["_info"] = json.loads(state["_info"])
         assert state.get("_data") is None, "arrow table needs to be memory mapped"
         assert state.get("_indices") is None, "arrow table needs to be memory mapped"
         assert all(
@@ -424,6 +425,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         """Load the dataset from a dataset directory"""
         with open(os.path.join(dataset_path, "state.json"), "r") as state_file:
             state = json.load(state_file)
+        state["_info"] = json.dumps(state["_info"])
         dataset = Dataset.from_dict({})
         state = {k: state[k] for k in dataset.__dict__.keys()}  # in case we add new fields
         dataset.__setstate__(state, root_dir=dataset_path)

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -409,7 +409,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             data_file["filename"] = filename
         # Get state
         state = self.__getstate__()
-        state["_info"] = json.loads(state["_info"])
+        dataset_info = json.loads(state.pop("_info"))
         assert state.get("_data") is None, "arrow table needs to be memory mapped"
         assert state.get("_indices") is None, "arrow table needs to be memory mapped"
         assert all(
@@ -418,6 +418,8 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         # Serialize state
         with open(os.path.join(dataset_path, "state.json"), "w") as state_file:
             json.dump(state, state_file, indent=2, sort_keys=True)
+        with open(os.path.join(dataset_path, "dataset_info.json"), "w") as dataset_info_file:
+            json.dump(dataset_info, dataset_info_file, indent=2, sort_keys=True)
         logger.info("Dataset saved in {}".format(dataset_path))
 
     @staticmethod
@@ -425,7 +427,9 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         """Load the dataset from a dataset directory"""
         with open(os.path.join(dataset_path, "state.json"), "r") as state_file:
             state = json.load(state_file)
-        state["_info"] = json.dumps(state["_info"])
+        with open(os.path.join(dataset_path, "dataset_info.json"), "r") as dataset_info_file:
+            dataset_info = json.load(dataset_info_file)
+        state["_info"] = json.dumps(dataset_info)
         dataset = Dataset.from_dict({})
         state = {k: state[k] for k in dataset.__dict__.keys()}  # in case we add new fields
         dataset.__setstate__(state, root_dir=dataset_path)

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -416,7 +416,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         ), "in-place history needs to be empty"
         # Serialize state
         with open(os.path.join(dataset_path, "state.json"), "w") as state_file:
-            json.dump(state, state_file)
+            json.dump(state, state_file, indent=2, sort_keys=True)
         logger.info("Dataset saved in {}".format(dataset_path))
 
     @staticmethod

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -375,7 +375,12 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
             self._indices = reader._read_files(self._indices_data_files)
 
     def save_to_disk(self, dataset_path: str):
-        """Save the dataset in a dataset directory"""
+        """
+        Save the dataset in a dataset directory
+
+        Args:
+            dataset_path (``str``): path of the dataset directory where the dataset will be saved to
+        """
         assert (
             not self.list_indexes()
         ), "please remove all the indexes using `dataset.drop_index` before saving a dataset"
@@ -424,7 +429,11 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
 
     @staticmethod
     def load_from_disk(dataset_path: str) -> "Dataset":
-        """Load the dataset from a dataset directory"""
+        """Load the dataset from a dataset directory
+
+        Args:
+            dataset_path (``str``): path of the dataset directory where the dataset will be loaded from
+        """
         with open(os.path.join(dataset_path, "state.json"), "r") as state_file:
             state = json.load(state_file)
         with open(os.path.join(dataset_path, "dataset_info.json"), "r") as dataset_info_file:

--- a/src/nlp/arrow_dataset.py
+++ b/src/nlp/arrow_dataset.py
@@ -374,7 +374,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         if self._indices is None and self._indices_data_files:
             self._indices = reader._read_files(self._indices_data_files)
 
-    def save(self, dataset_path: str):
+    def save_to_disk(self, dataset_path: str):
         """Save the dataset in a dataset directory"""
         assert (
             not self.list_indexes()
@@ -423,7 +423,7 @@ class Dataset(DatasetInfoMixin, IndexableMixin):
         logger.info("Dataset saved in {}".format(dataset_path))
 
     @staticmethod
-    def load(dataset_path: str):
+    def load_from_disk(dataset_path: str) -> "Dataset":
         """Load the dataset from a dataset directory"""
         with open(os.path.join(dataset_path, "state.json"), "r") as state_file:
             state = json.load(state_file)

--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -160,6 +160,9 @@ class BaseReader:
         """
         assert len(files) > 0 and all(isinstance(f, dict) for f in files), "please provide valid file informations"
         pa_tables = []
+        files = copy.deepcopy(files)
+        for f in files:
+            f.update(filename=os.path.join(self._path, f["filename"]))
         for f_dict in files:
             pa_table: pa.Table = self._get_dataset_from_filename(f_dict)
             pa_tables.append(pa_table)
@@ -218,10 +221,10 @@ class BaseReader:
             kwargs to build a Dataset instance.
         """
         # Prepend path to filename
+        pa_table = self._read_files(files)
         files = copy.deepcopy(files)
         for f in files:
             f.update(filename=os.path.join(self._path, f["filename"]))
-        pa_table = self._read_files(files)
         dataset_kwargs = dict(arrow_table=pa_table, data_files=files, info=self._info, split=original_instructions)
         return dataset_kwargs
 

--- a/src/nlp/dataset_dict.py
+++ b/src/nlp/dataset_dict.py
@@ -460,17 +460,17 @@ class DatasetDict(dict):
             }
         )
 
-    def save(self, dataset_dict_path: str):
+    def save_to_disk(self, dataset_dict_path: str):
         """Save the dataset dict in a dataset dict directory"""
         os.makedirs(dataset_dict_path, exist_ok=True)
         json.dump({"splits": list(self)}, open(os.path.join(dataset_dict_path, "dataset_dict.json"), "w"))
         for k, dataset in self.items():
-            dataset.save(os.path.join(dataset_dict_path, k))
+            dataset.save_to_disk(os.path.join(dataset_dict_path, k))
 
     @staticmethod
-    def load(dataset_dict_path: str):
+    def load_from_disk(dataset_dict_path: str) -> "DatasetDict":
         """Load the dataset dict from a dataset dict directory"""
         dataset_dict = DatasetDict()
         for k in json.load(open(os.path.join(dataset_dict_path, "dataset_dict.json"), "r"))["splits"]:
-            dataset_dict[k] = Dataset.load(os.path.join(dataset_dict_path, k))
+            dataset_dict[k] = Dataset.load_from_disk(os.path.join(dataset_dict_path, k))
         return dataset_dict

--- a/src/nlp/dataset_dict.py
+++ b/src/nlp/dataset_dict.py
@@ -461,7 +461,12 @@ class DatasetDict(dict):
         )
 
     def save_to_disk(self, dataset_dict_path: str):
-        """Save the dataset dict in a dataset dict directory"""
+        """
+        Save the dataset dict in a dataset dict directory.
+
+        Args:
+            dataset_dict_path (``str``): path of the dataset dict directory where the dataset dict will be saved to
+        """
         os.makedirs(dataset_dict_path, exist_ok=True)
         json.dump({"splits": list(self)}, open(os.path.join(dataset_dict_path, "dataset_dict.json"), "w"))
         for k, dataset in self.items():
@@ -469,7 +474,12 @@ class DatasetDict(dict):
 
     @staticmethod
     def load_from_disk(dataset_dict_path: str) -> "DatasetDict":
-        """Load the dataset dict from a dataset dict directory"""
+        """
+        Load the dataset dict from a dataset dict directory
+
+        Args:
+            dataset_dict_path (``str``): path of the dataset dict directory where the dataset dict will be loaded from
+        """
         dataset_dict = DatasetDict()
         for k in json.load(open(os.path.join(dataset_dict_path, "dataset_dict.json"), "r"))["splits"]:
             dataset_dict[k] = Dataset.load_from_disk(os.path.join(dataset_dict_path, k))

--- a/src/nlp/dataset_dict.py
+++ b/src/nlp/dataset_dict.py
@@ -1,4 +1,6 @@
 import contextlib
+import json
+import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -457,3 +459,18 @@ class DatasetDict(dict):
                 for k, dataset in self.items()
             }
         )
+
+    def save(self, dataset_dict_path: str):
+        """Save the dataset dict in a dataset dict directory"""
+        os.makedirs(dataset_dict_path, exist_ok=True)
+        json.dump({"splits": list(self)}, open(os.path.join(dataset_dict_path, "dataset_dict.json"), "w"))
+        for k, dataset in self.items():
+            dataset.save(os.path.join(dataset_dict_path, k))
+
+    @staticmethod
+    def load(dataset_dict_path: str):
+        """Load the dataset dict from a dataset dict directory"""
+        dataset_dict = DatasetDict()
+        for k in json.load(open(os.path.join(dataset_dict_path, "dataset_dict.json"), "r"))["splits"]:
+            dataset_dict[k] = Dataset.load(os.path.join(dataset_dict_path, k))
+        return dataset_dict

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -564,12 +564,12 @@ def load_from_disk(dataset_path: str) -> Union[Dataset, DatasetDict]:
     Load a dataset that was previously saved using ``dataset.save_to_disk(dataset_path)``.
 
     Args:
-        dataset_path (``str``): path to a Dataset directory or a DatasetDict directory
+        dataset_path (``str``): path of a Dataset directory or a DatasetDict directory
 
     Returns:
         ``nlp.Dataset`` or ``nlp.DatasetDict``
-            if `dataset_path` is a path to a dataset directory: the dataset requested,
-            if `dataset_path` is a path to a dataset dict directory: a ``nlp.DatasetDict`` with each split.
+            if `dataset_path` is a path of a dataset directory: the dataset requested,
+            if `dataset_path` is a path of a dataset dict directory: a ``nlp.DatasetDict`` with each split.
     """
     if not os.path.isdir(dataset_path):
         raise FileNotFoundError("Directory {} not found".format(dataset_path))

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -578,4 +578,6 @@ def load_from_disk(dataset_path: str) -> Union[Dataset, DatasetDict]:
     elif os.path.exists(os.path.join(dataset_path, "dataset_dict.json")):
         return DatasetDict.load_from_disk(dataset_path)
     else:
-        raise FileNotFoundError("Directory {} is neither a dataset directory nor a dataset dict directory.".format(dataset_path))
+        raise FileNotFoundError(
+            "Directory {} is neither a dataset directory nor a dataset dict directory.".format(dataset_path)
+        )

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -557,3 +557,25 @@ def load_dataset(
         builder_instance._save_infos()
 
     return ds
+
+
+def load_from_disk(dataset_path: str) -> Union[Dataset, DatasetDict]:
+    """
+    Load a dataset that was previously saved using ``dataset.save_to_disk(dataset_path)``.
+
+    Args:
+        dataset_path (``str``): path to a Dataset directory or a DatasetDict directory
+
+    Returns:
+        ``nlp.Dataset`` or ``nlp.DatasetDict``
+            if `dataset_path` is a path to a dataset directory: the dataset requested,
+            if `dataset_path` is a path to a dataset dict directory: a ``nlp.DatasetDict`` with each split.
+    """
+    if not os.path.isdir(dataset_path):
+        raise FileNotFoundError("Directory {} not found".format(dataset_path))
+    if os.path.exists(os.path.join(dataset_path, "dataset_info.json")):
+        return Dataset.load_from_disk(dataset_path)
+    elif os.path.exists(os.path.join(dataset_path, "dataset_dict.json")):
+        return DatasetDict.load_from_disk(dataset_path)
+    else:
+        raise FileNotFoundError("Directory {} is neither a dataset directory nor a dataset dict directory.".format(dataset_path))

--- a/tests/test_arrow_dataset.py
+++ b/tests/test_arrow_dataset.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pyarrow as pa
 
 import nlp.arrow_dataset
-from nlp import concatenate_datasets
+from nlp import concatenate_datasets, load_from_disk
 from nlp.arrow_dataset import Dataset
 from nlp.features import ClassLabel, Features, Sequence, Value
 from nlp.info import DatasetInfo
@@ -121,8 +121,8 @@ class BaseDatasetTest(TestCase):
 
             dset = self._create_dummy_dataset().select(range(10))
             dataset_path = os.path.join(tmp_dir, "my_dataset")
-            dset.save(dataset_path)
-            dset = dset.load(dataset_path)
+            dset.save_to_disk(dataset_path)
+            dset = dset.load_from_disk(dataset_path)
 
         self.assertEqual(len(dset), 10)
         self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
@@ -138,8 +138,8 @@ class BaseDatasetTest(TestCase):
             dset._data = Unpicklable()  # check that we don't pickle the entire table
 
             dataset_path = os.path.join(tmp_dir, "my_dataset")
-            dset.save(dataset_path)
-            dset = dset.load(dataset_path)
+            dset.save_to_disk(dataset_path)
+            dset = dset.load_from_disk(dataset_path)
 
             self.assertEqual(len(dset), 10)
             self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
@@ -157,13 +157,26 @@ class BaseDatasetTest(TestCase):
             dset._indices = Unpicklable()
 
             dataset_path = os.path.join(tmp_dir, "my_dataset")
-            dset.save(dataset_path)
-            dset = dset.load(dataset_path)
+            dset.save_to_disk(dataset_path)
+            dset = dset.load_from_disk(dataset_path)
 
             self.assertEqual(len(dset), 10)
             self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
             self.assertEqual(dset[0]["filename"], "my_name-train_0")
             self.assertEqual(dset["filename"][0], "my_name-train_0")
+
+    def test_dummy_dataset_load_from_dick(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+
+            dset = self._create_dummy_dataset().select(range(10))
+            dataset_path = os.path.join(tmp_dir, "my_dataset")
+            dset.save_to_disk(dataset_path)
+            dset = load_from_disk(dataset_path)
+
+        self.assertEqual(len(dset), 10)
+        self.assertDictEqual(dset.features, Features({"filename": Value("string")}))
+        self.assertEqual(dset[0]["filename"], "my_name-train_0")
+        self.assertEqual(dset["filename"][0], "my_name-train_0")
 
     def test_from_pandas(self):
         data = {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]}

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import numpy as np
 import pandas as pd
 
-from nlp import Features, Sequence, Value
+from nlp import Features, Sequence, Value, load_from_disk
 from nlp.arrow_dataset import Dataset
 from nlp.dataset_dict import DatasetDict
 
@@ -280,8 +280,8 @@ class DatasetDictTest(TestCase):
     def test_serialization(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dsets = self._create_dummy_dataset_dict()
-            dsets.save(tmp_dir)
-            dsets = DatasetDict.load(tmp_dir)
+            dsets.save_to_disk(tmp_dir)
+            dsets = DatasetDict.load_from_disk(tmp_dir)
             self.assertListEqual(sorted(dsets), ["test", "train"])
             self.assertEqual(len(dsets["train"]), 30)
             self.assertListEqual(dsets["train"].column_names, ["filename"])
@@ -289,8 +289,19 @@ class DatasetDictTest(TestCase):
             self.assertListEqual(dsets["test"].column_names, ["filename"])
 
             del dsets["test"]
-            dsets.save(tmp_dir)
-            dsets = DatasetDict.load(tmp_dir)
+            dsets.save_to_disk(tmp_dir)
+            dsets = DatasetDict.load_from_disk(tmp_dir)
             self.assertListEqual(sorted(dsets), ["train"])
             self.assertEqual(len(dsets["train"]), 30)
             self.assertListEqual(dsets["train"].column_names, ["filename"])
+
+    def test_load_from_disk(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dsets = self._create_dummy_dataset_dict()
+            dsets.save_to_disk(tmp_dir)
+            dsets = load_from_disk(tmp_dir)
+            self.assertListEqual(sorted(dsets), ["test", "train"])
+            self.assertEqual(len(dsets["train"]), 30)
+            self.assertListEqual(dsets["train"].column_names, ["filename"])
+            self.assertEqual(len(dsets["test"]), 30)
+            self.assertListEqual(dsets["test"].column_names, ["filename"])

--- a/tests/test_dataset_dict.py
+++ b/tests/test_dataset_dict.py
@@ -276,3 +276,21 @@ class DatasetDictTest(TestCase):
         self.assertRaises(TypeError, dsets.filter, lambda x: True)
         self.assertRaises(TypeError, dsets.shuffle)
         self.assertRaises(TypeError, dsets.sort, "filename")
+
+    def test_serialization(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dsets = self._create_dummy_dataset_dict()
+            dsets.save(tmp_dir)
+            dsets = DatasetDict.load(tmp_dir)
+            self.assertListEqual(sorted(dsets), ["test", "train"])
+            self.assertEqual(len(dsets["train"]), 30)
+            self.assertListEqual(dsets["train"].column_names, ["filename"])
+            self.assertEqual(len(dsets["test"]), 30)
+            self.assertListEqual(dsets["test"].column_names, ["filename"])
+
+            del dsets["test"]
+            dsets.save(tmp_dir)
+            dsets = DatasetDict.load(tmp_dir)
+            self.assertListEqual(sorted(dsets), ["train"])
+            self.assertEqual(len(dsets["train"]), 30)
+            self.assertListEqual(dsets["train"].column_names, ["filename"])


### PR DESCRIPTION
I added `save` and `load` method to serialize/deserialize a dataset object in a folder.
It moves the arrow files there (or write them if the tables were in memory), and saves the pickle state in a json file `state.json`, except the info that are in a separate file `dataset_info.json`.

Example:

```python
import nlp

squad = nlp.load_dataset("squad", split="train")
squad.save("tmp/squad")
squad = nlp.Dataset.load("tmp/squad")
```

`ls tmp/squad`
```
dataset_info.json squad-train.arrow state.json
```

`cat tmp/squad/state.json`
```json
{
  "_data": null,
  "_data_files": [
    {
      "filename": "squad-train.arrow",
      "skip": 0,
      "take": 87599
    }
  ],
  "_fingerprint": "61f452797a686bc1",
  "_format_columns": null,
  "_format_kwargs": {},
  "_format_type": null,
  "_indexes": {},
  "_indices": null,
  "_indices_data_files": [],
  "_inplace_history": [
    {
      "transforms": []
    }
  ],
  "_output_all_columns": false,
  "_split": "train"
}
```

`cat tmp/squad/dataset_info.json`
```json
{
  "builder_name": "squad",
  "citation": "@article{2016arXiv160605250R,\n       author = {{Rajpurkar}, Pranav and {Zhang}, Jian and {Lopyrev},\n                 Konstantin and {Liang}, Percy},\n        title = \"{SQuAD: 100,000+ Questions for Machine Comprehension of Text}\",\n      journal = {arXiv e-prints},\n         year = 2016,\n          eid = {arXiv:1606.05250},\n        pages = {arXiv:1606.05250},\narchivePrefix = {arXiv},\n       eprint = {1606.05250},\n}\n",
  "config_name": "plain_text",
  "dataset_size": 89789763,
  "description": "Stanford Question Answering Dataset (SQuAD) is a reading comprehension dataset, consisting of questions posed by crowdworkers on a set of Wikipedia articles, where the answer to every question is a segment of text, or span, from the corresponding reading passage, or the question might be unanswerable.\n",
  "download_checksums": {
    "https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json": {
      "checksum": "95aa6a52d5d6a735563366753ca50492a658031da74f301ac5238b03966972c9",
      "num_bytes": 4854279
    },
    "https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json": {
      "checksum": "3527663986b8295af4f7fcdff1ba1ff3f72d07d61a20f487cb238a6ef92fd955",
      "num_bytes": 30288272
    }
  },
  "download_size": 35142551,
  "features": {
    "answers": {
      "_type": "Sequence",
      "feature": {
        "answer_start": {
          "_type": "Value",
          "dtype": "int32",
          "id": null
        },
        "text": {
          "_type": "Value",
          "dtype": "string",
          "id": null
        }
      },
      "id": null,
      "length": -1
    },
    "context": {
      "_type": "Value",
      "dtype": "string",
      "id": null
    },
    "id": {
      "_type": "Value",
      "dtype": "string",
      "id": null
    },
    "question": {
      "_type": "Value",
      "dtype": "string",
      "id": null
    },
    "title": {
      "_type": "Value",
      "dtype": "string",
      "id": null
    }
  },
  "homepage": "https://rajpurkar.github.io/SQuAD-explorer/",
  "license": "",
  "post_processed": {
    "features": null,
    "resources_checksums": {
      "train": {},
      "train[:10%]": {}
    }
  },
  "post_processing_size": 0,
  "size_in_bytes": 124932314,
  "splits": {
    "train": {
      "dataset_name": "squad",
      "name": "train",
      "num_bytes": 79317110,
      "num_examples": 87599
    },
    "validation": {
      "dataset_name": "squad",
      "name": "validation",
      "num_bytes": 10472653,
      "num_examples": 10570
    }
  },
  "supervised_keys": null,
  "version": {
    "description": "New split API (https://tensorflow.org/datasets/splits)",
    "major": 1,
    "minor": 0,
    "nlp_version_to_prepare": null,
    "patch": 0,
    "version_str": "1.0.0"
  }
}
```