### PR TITLE
Faster caching for text dataset

### DIFF
--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -199,7 +199,7 @@ class BaseReader:
         if not files:
             msg = 'Instruction "%s" corresponds to no data!' % instructions
             raise AssertionError(msg)
-        return self.read_files(files=tuple(files), original_instructions=instructions)
+        return self.read_files(files=files, original_instructions=instructions)
 
     def read_files(
         self,

--- a/src/nlp/fingerprint.py
+++ b/src/nlp/fingerprint.py
@@ -1,4 +1,5 @@
 import json
+import os
 from copy import deepcopy
 from dataclasses import asdict
 from functools import wraps
@@ -78,7 +79,7 @@ def _hash_pa_table(hasher, value):
 
 @hashregister(DatasetInfo)
 def _hash_dataset_info(hasher, value):
-    return hasher.hash_bytes(json.dumps(asdict(value)).encode("utf-8"))
+    return hasher.hash_bytes(json.dumps(asdict(value), sort_keys=True).encode("utf-8"))
 
 
 def generate_fingerprint(dataset):
@@ -89,6 +90,9 @@ def generate_fingerprint(dataset):
             continue
         hasher.update(key)
         hasher.update(state[key])
+    # hash data files last modification timestamps as well
+    for data_file in state.get("_data_files", []) + state.get("_indices_data_files", []):
+        hasher.update(os.path.getmtime(data_file["filename"]))
     return hasher.hexdigest()
 
 

--- a/tests/test_arrow_reader.py
+++ b/tests/test_arrow_reader.py
@@ -1,8 +1,8 @@
-from unittest import TestCase
 import os
+import tempfile
+from unittest import TestCase
 
 import pyarrow as pa
-import tempfile
 
 from nlp.arrow_dataset import Dataset
 from nlp.arrow_reader import BaseReader
@@ -71,7 +71,10 @@ class BaseReaderTest(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             reader = ReaderTest(tmp_dir, info)
 
-            files = [{"filename": os.path.join(tmp_dir, "train")}, {"filename": os.path.join(tmp_dir, "test"), "skip": 10, "take": 10}]
+            files = [
+                {"filename": os.path.join(tmp_dir, "train")},
+                {"filename": os.path.join(tmp_dir, "test"), "skip": 10, "take": 10},
+            ]
             dset = Dataset(**reader.read_files(files, original_instructions=""))
             self.assertEqual(dset.num_rows, 110)
             self.assertEqual(dset.num_columns, 1)

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -324,3 +324,21 @@ class AWSDatasetTest(parameterized.TestCase):
                 )
                 for split in dataset.keys():
                     self.assertTrue(len(dataset[split]) > 0)
+
+
+class TextTest(TestCase):
+
+    def test_caching(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            open(os.path.join(tmp_dir, "text.txt"), "w").write("\n".join("foo" for _ in range(10)))
+            ds = load_dataset("./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train")
+            data_file = ds._data_files[0]
+            fingerprint = ds._fingerprint
+            ds = load_dataset("./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train")
+            self.assertEqual(ds._data_files[0], data_file)
+            self.assertEqual(ds._fingerprint, fingerprint)
+
+            open(os.path.join(tmp_dir, "text.txt"), "w").write("\n".join("bar" for _ in range(10)))
+            ds = load_dataset("./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train")
+            self.assertNotEqual(ds._data_files[0], data_file)
+            self.assertNotEqual(ds._fingerprint, fingerprint)

--- a/tests/test_dataset_common.py
+++ b/tests/test_dataset_common.py
@@ -327,18 +327,23 @@ class AWSDatasetTest(parameterized.TestCase):
 
 
 class TextTest(TestCase):
-
     def test_caching(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             open(os.path.join(tmp_dir, "text.txt"), "w").write("\n".join("foo" for _ in range(10)))
-            ds = load_dataset("./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train")
+            ds = load_dataset(
+                "./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train"
+            )
             data_file = ds._data_files[0]
             fingerprint = ds._fingerprint
-            ds = load_dataset("./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train")
+            ds = load_dataset(
+                "./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train"
+            )
             self.assertEqual(ds._data_files[0], data_file)
             self.assertEqual(ds._fingerprint, fingerprint)
 
             open(os.path.join(tmp_dir, "text.txt"), "w").write("\n".join("bar" for _ in range(10)))
-            ds = load_dataset("./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train")
+            ds = load_dataset(
+                "./datasets/text", data_files=os.path.join(tmp_dir, "text.txt"), cache_dir=tmp_dir, split="train"
+            )
             self.assertNotEqual(ds._data_files[0], data_file)
             self.assertNotEqual(ds._fingerprint, fingerprint)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,37 +15,9 @@ from nlp.search import ElasticSearchIndex, FaissIndex, MissingIndex
 from nlp.splits import SplitDict, SplitInfo
 
 
-class ReaderTester(BaseReader):
-    """
-    Build a Dataset object out of Instruction instance(s).
-    This reader is made for testing. It mocks file reads.
-    """
-
-    def _get_dataset_from_filename(self, filename_skip_take):
-        """Returns a Dataset instance from given (filename, skip, take)."""
-        filename, skip, take = (
-            filename_skip_take["filename"],
-            filename_skip_take["skip"] if "skip" in filename_skip_take else None,
-            filename_skip_take["take"] if "take" in filename_skip_take else None,
-        )
-        pa_table = pa.Table.from_pydict({"filename": [filename + "_" + str(x) for x in np.arange(30).tolist()]})
-        if skip is not None and take is not None:
-            pa_table = pa_table.slice(skip, take)
-        return pa_table
-
-
 class IndexableDatasetTest(TestCase):
     def _create_dummy_dataset(self):
-        name = "my_name"
-        train_info = SplitInfo(name="train", num_examples=30)
-        test_info = SplitInfo(name="test", num_examples=30)
-        split_infos = [train_info, test_info]
-        split_dict = SplitDict()
-        split_dict.add(train_info)
-        split_dict.add(test_info)
-        info = DatasetInfo(splits=split_dict)
-        reader = ReaderTester("", info)
-        dset = Dataset(**reader.read(name, "train", split_infos))
+        dset = Dataset.from_dict({"filename": ["my_name-train" + "_" + str(x) for x in np.arange(30).tolist()]})
         return dset
 
     def test_add_faiss_index(self):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,14 +5,10 @@ from unittest.mock import patch
 
 import faiss
 import numpy as np
-import pyarrow as pa
 from elasticsearch import Elasticsearch
 
 from nlp.arrow_dataset import Dataset
-from nlp.arrow_reader import BaseReader
-from nlp.info import DatasetInfo
 from nlp.search import ElasticSearchIndex, FaissIndex, MissingIndex
-from nlp.splits import SplitDict, SplitInfo
 
 
 class IndexableDatasetTest(TestCase):


### PR DESCRIPTION
As mentioned in #546 and #548 , hashing `data_files` contents to get the cache directory name for a text dataset can take a long time.

To make it faster I changed the hashing so that it takes into account the `path` and the `last modified timestamp` of each data file, instead of iterating through the content of each file to get a hash.