### PR TITLE
Add modules cache

### DIFF
--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -37,17 +37,24 @@ from .info import DATASET_INFOS_DICT_FILE_NAME
 from .metric import Metric
 from .splits import Split
 from .utils.download_manager import GenerateMode
-from .utils.file_utils import DownloadConfig, cached_path, hf_bucket_url
+from .utils.file_utils import DownloadConfig, cached_path, hf_bucket_url, HF_MODULES_CACHE
 from .utils.logging import get_logger
 
 
 logger = get_logger(__name__)
 
-CURRENT_FILE_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
-DATASETS_PATH = os.path.join(CURRENT_FILE_DIRECTORY, "datasets")
-DATASETS_MODULE = "nlp.datasets"
-METRICS_PATH = os.path.join(CURRENT_FILE_DIRECTORY, "metrics")
-METRICS_MODULE = "nlp.metrics"
+DYNAMIC_MODULES_PATH = os.path.join(HF_MODULES_CACHE, "nlp_modules")
+DATASETS_PATH = os.path.join(DYNAMIC_MODULES_PATH, "datasets")
+DATASETS_MODULE = "nlp_modules.datasets"
+METRICS_PATH = os.path.join(DYNAMIC_MODULES_PATH, "metrics")
+METRICS_MODULE = "nlp_modules.metrics"
+
+
+def init_dynamic_modules():
+    os.makedirs(DYNAMIC_MODULES_PATH, exist_ok=True)
+    if not os.path.exists(os.path.join(DYNAMIC_MODULES_PATH, "__init__.py")):
+        with open(os.path.join(DYNAMIC_MODULES_PATH, "__init__.py"), "w"):
+            pass
 
 
 def import_main_class(module_path, dataset=True) -> Union[DatasetBuilder, Metric]:
@@ -221,6 +228,7 @@ def prepare_module(
             - the local path to the dataset/metric file if force_local_path is True: e.g. '/User/huggingface/nlp/datasets/squad/squad.py'
         2. A hash string computed from the content of the dataset loading script.
     """
+    init_dynamic_modules()
     if download_config is None:
         download_config = DownloadConfig(**download_kwargs)
     download_config.extract_compressed_file = True

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -37,7 +37,7 @@ from .info import DATASET_INFOS_DICT_FILE_NAME
 from .metric import Metric
 from .splits import Split
 from .utils.download_manager import GenerateMode
-from .utils.file_utils import DownloadConfig, cached_path, hf_bucket_url, HF_MODULES_CACHE
+from .utils.file_utils import HF_MODULES_CACHE, DownloadConfig, cached_path, hf_bucket_url
 from .utils.logging import get_logger
 
 

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -113,6 +113,11 @@ except (AttributeError, ImportError):
     HF_MODULES_CACHE = os.getenv(os.getenv("HF_MODULES_CACHE", default_modules_cache_path))
 sys.path.append(str(HF_MODULES_CACHE))
 
+os.makedirs(HF_MODULES_CACHE, exist_ok=True)
+if not os.path.exists(os.path.join(HF_MODULES_CACHE, "__init__.py")):
+    with open(os.path.join(HF_MODULES_CACHE, "__init__.py"), "w"):
+        pass
+
 INCOMPLETE_SUFFIX = ".incomplete"
 
 

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -103,6 +103,16 @@ except (AttributeError, ImportError):
 S3_METRICS_BUCKET_PREFIX = "https://s3.amazonaws.com/datasets.huggingface.co/nlp/metrics"
 CLOUDFRONT_METRICS_DISTRIB_PREFIX = "https://cdn-datasets.huggingface.co/nlp/metric"
 
+
+default_modules_cache_path = os.path.join(hf_cache_home, "modules")
+try:
+    from pathlib import Path
+
+    HF_MODULES_CACHE = Path(os.getenv("HF_MODULES_CACHE", default_modules_cache_path))
+except (AttributeError, ImportError):
+    HF_MODULES_CACHE = os.getenv(os.getenv("HF_MODULES_CACHE", default_modules_cache_path))
+sys.path.append(str(HF_MODULES_CACHE))
+
 INCOMPLETE_SUFFIX = ".incomplete"
 
 


### PR DESCRIPTION
As discusses in #554 , we should use a module cache directory outside of the python packages directory since we may not have write permissions.

I added a new HF_MODULES_PATH directory that is added to the python path when doing `import nlp`.
In this directory, a module `nlp_modules` is created so that datasets can be added to `nlp_modules.datasets` and metrics to `nlp_modules.metrics`. `nlp_modules` doesn't exist on Pypi.

If someone using cloudpickle still wants to have the downloaded dataset/metrics scripts to be inside the nlp directory, it is still possible to change the environment variable HF_MODULES_PATH to be a path inside the nlp lib.