### PR TITLE
Use github versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install pyarrow==0.17.1
-            - run: python -m pytest -sv ./tests/
+            - run: HF_NLP_VERSION=master python -m pytest -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:
         working_directory: ~/nlp
@@ -24,7 +24,7 @@ jobs:
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install pyarrow==1.0.0
-            - run: python -m pytest -sv ./tests/
+            - run: HF_NLP_VERSION=master python -m pytest -sv ./tests/
 
     check_code_quality:
         working_directory: ~/nlp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install pyarrow==0.17.1
-            - run: HF_NLP_VERSION=master python -m pytest -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
     run_dataset_script_tests_pyarrow_1:
         working_directory: ~/nlp
@@ -24,7 +24,7 @@ jobs:
             - run: source venv/bin/activate
             - run: pip install .[tests]
             - run: pip install pyarrow==1.0.0
-            - run: HF_NLP_VERSION=master python -m pytest -sv ./tests/
+            - run: HF_SCRIPTS_VERSION=master python -m pytest -sv ./tests/
 
     check_code_quality:
         working_directory: ~/nlp

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 # Lint as: python3
 """ HuggingFace/NLP is an open library of NLP datasets.
 
+Note:
+
+   VERSION needs to be formatted following the MAJOR.MINOR.PATCH convention
+   (we need to follow this convention to be able to retrieve versioned scripts)
+
 Simple check list for release from AllenNLP repo: https://github.com/allenai/allennlp/blob/master/setup.py
 
 To create the package for pypi.

--- a/src/nlp/arrow_reader.py
+++ b/src/nlp/arrow_reader.py
@@ -245,7 +245,7 @@ class BaseReader:
             shutil.move(downloaded_dataset_info, os.path.join(cache_dir, "dataset_info.json"))
             if self._info is not None:
                 self._info.update(self._info.from_directory(cache_dir))
-        except ConnectionError:
+        except FileNotFoundError:
             raise DatasetNotOnHfGcs()
         try:
             for split in self._info.splits:
@@ -258,7 +258,7 @@ class BaseReader:
                     remote_prepared_filename = os.path.join(remote_cache_dir, file_instruction["filename"])
                     downloaded_prepared_filename = cached_path(remote_prepared_filename)
                     shutil.move(downloaded_prepared_filename, os.path.join(cache_dir, file_instruction["filename"]))
-        except ConnectionError:
+        except FileNotFoundError:
             raise MissingFilesOnHfGcs()
 
 

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -218,11 +218,13 @@ def prepare_module(
             path to the dataset or metric script, can be either:
                 - a path to a local directory containing the dataset processing python script
                 - an url to a S3 directory with a dataset processing python script
-            download_config (Optional ``nlp.DownloadConfig``: specific download configuration parameters.
-            dataset (bool): True if the script to load is a dataset, False if the script is a metric.
-            force_local_path (Optional str): Optional path to a local path to download and prepare the script to.
-                Used to inspect or modify the script folder.
-            **download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied.
+        version (Optional ``Union[str, nlp.Version]``): if specified, the module will be loaded from the nlp repository
+            at this version. By default it is set to the local version fo the lib
+        download_config (Optional ``nlp.DownloadConfig``: specific download configuration parameters.
+        dataset (bool): True if the script to load is a dataset, False if the script is a metric.
+        force_local_path (Optional str): Optional path to a local path to download and prepare the script to.
+            Used to inspect or modify the script folder.
+        download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied.
 
     Return: Tuple[``str``, ``str``] with
         1. The module path being
@@ -460,6 +462,8 @@ def load_metric(
                 - a dataset identifier on HuggingFace AWS bucket (list all available datasets and ids with ``nlp.list_datasets()``)
                     e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``
         config_name (Optional ``str``): selecting a configuration for the metric (e.g. the GLUE metric has a configuration for each subset)
+        version (Optional ``Union[str, nlp.Version]``): if specified, the module will be loaded from the nlp repository
+            at this version. By default it is set to the local version fo the lib
         process_id (Optional ``int``): for distributed evaluation: id of the process
         num_process (Optional ``int``): for distributed evaluation: total number of processes
         data_dir (Optional str): path to store the temporary predictions and references (default to `~/.nlp/`)
@@ -532,7 +536,8 @@ def load_dataset(
                 - a dataset identifier on HuggingFace AWS bucket (list all available datasets and ids with ``nlp.list_datasets()``)
                     e.g. ``'squad'``, ``'glue'`` or ``'openai/webtext'``
         name (Optional ``str``): defining the name of the dataset configuration
-        version (Optional ``str``): defining the version of the dataset configuration
+        version (Optional ``Union[str, nlp.Version]``): if specified, the module will be loaded from the nlp repository
+            at this version. By default it is set to the local version fo the lib
         data_files (Optional ``str``): defining the data_files of the dataset configuration
         data_dir (Optional ``str``): defining the data_dir of the dataset configuration
         split (`nlp.Split` or `str`): which split of the data to load.

--- a/src/nlp/load.py
+++ b/src/nlp/load.py
@@ -265,6 +265,12 @@ def prepare_module(
         try:
             local_path = cached_path(file_path, download_config=download_config)
         except FileNotFoundError:
+            if version is not None:
+                raise ValueError(
+                    "Couldn't find remote file with version {} at {}\nPlease provide a valid version and a valid {} name".format(
+                        version, file_path, "dataset" if dataset else "metric"
+                    )
+                )
             github_file_path = file_path
             file_path = hf_bucket_url(path, filename=name, dataset=dataset)
             try:

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -203,7 +203,7 @@ def head_hf_s3(identifier: str, filename: str, use_cdn=False, dataset=True) -> r
 def hf_github_url(path: str, name: str, dataset=True, version: Optional[str] = None) -> str:
     from .. import __version__
 
-    version = version or os.getenv("HF_NLP_VERSION", None) or __version__
+    version = version or os.getenv("HF_SCRIPTS_VERSION", __version__)
     if dataset:
         return REPO_DATASETS_URL.format(version=version, path=path, name=name)
     else:

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -90,6 +90,7 @@ except (AttributeError, ImportError):
 
 S3_DATASETS_BUCKET_PREFIX = "https://s3.amazonaws.com/datasets.huggingface.co/nlp/datasets"
 CLOUDFRONT_DATASETS_DISTRIB_PREFIX = "https://cdn-datasets.huggingface.co/nlp/datasets"
+REPO_DATASETS_URL = "https://raw.githubusercontent.com/huggingface/nlp/{version}/datasets/{path}/{name}"
 
 
 default_metrics_cache_path = os.path.join(hf_cache_home, "metrics")
@@ -102,6 +103,7 @@ except (AttributeError, ImportError):
 
 S3_METRICS_BUCKET_PREFIX = "https://s3.amazonaws.com/datasets.huggingface.co/nlp/metrics"
 CLOUDFRONT_METRICS_DISTRIB_PREFIX = "https://cdn-datasets.huggingface.co/nlp/metric"
+REPO_METRICS_URL = "https://raw.githubusercontent.com/huggingface/nlp/{version}/metrics/{path}/{name}"
 
 
 default_modules_cache_path = os.path.join(hf_cache_home, "modules")
@@ -192,6 +194,20 @@ def hf_bucket_url(identifier: str, filename: str, use_cdn=False, dataset=True) -
     else:
         endpoint = CLOUDFRONT_METRICS_DISTRIB_PREFIX if use_cdn else S3_METRICS_BUCKET_PREFIX
     return "/".join((endpoint, identifier, filename))
+
+
+def head_hf_s3(identifier: str, filename: str, use_cdn=False, dataset=True) -> requests.models.Response:
+    return requests.head(hf_bucket_url(identifier=identifier, filename=filename, use_cdn=use_cdn, dataset=dataset))
+
+
+def hf_github_url(path: str, name: str, dataset=True, version: Optional[str] = None) -> str:
+    from .. import __version__
+
+    version = version or os.getenv("HF_NLP_VERSION", None) or __version__
+    if dataset:
+        return REPO_DATASETS_URL.format(version=version, path=path, name=name)
+    else:
+        return REPO_METRICS_URL.format(version=version, path=path, name=name)
 
 
 def hash_url_to_filename(url, etag=None):

--- a/src/nlp/utils/version.py
+++ b/src/nlp/utils/version.py
@@ -32,15 +32,10 @@ class Version:
     Args:
         version_str: string. Eg: "1.2.3".
         description: string, a description of what is new in this version.
-        nlp_version_to_prepare: string, defaults to None. If set, indicates that
-            current version cannot be used to `download_and_prepare` the
-            dataset, but that at version {nlp_version_to_prepare} should be
-            used instead.
     """
 
     version_str: str
     description: str = None
-    nlp_version_to_prepare: str = None
     major: str = None
     minor: str = None
     patch: str = None


### PR DESCRIPTION
Right now dataset scripts and metrics are downloaded from S3 which is in sync with master. It means that it's not currently possible to pin the dataset/metric script version.

To fix that I changed the download url from S3 to github, and adding a `version` parameter in `load_dataset` and `load_metric` to pin a certain version of the lib, as in #562 