### PR TITLE
[style/quality] Moving to isort 5.0.0 + style/quality on datasets and metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,7 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            # we need a version of isort with https://github.com/timothycrosley/isort/pull/1000
-            - run: sudo pip install git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
+            - run: sudo pip install isort
             - run: sudo pip install .[quality]
             - run: black --check --line-length 119 --target-version py36 src tests benchmarks
             - run: isort --check-only --recursive src tests benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,10 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: sudo pip install isort
             - run: sudo pip install .[quality]
-            - run: black --check --line-length 119 --target-version py36 src tests benchmarks
-            - run: isort --check-only --recursive src tests benchmarks
-            - run: flake8 src tests benchmarks
+            - run: black --check --line-length 119 --target-version py36 tests src benchmarks datasets metrics
+            - run: isort --check-only tests src benchmarks datasets metrics
+            - run: flake8 tests src benchmarks datasets metrics
     build_doc:
         working_directory: ~/nlp
         docker:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,6 @@
    it with `pip uninstall nlp` before reinstalling it in editable
    mode with the `-e` flag.)
 
-   Right now, we need an unreleased version of `isort` to avoid a
-   [bug](https://github.com/timothycrosley/isort/pull/1000):
-
-   ```bash
-   $ pip install -U git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
-   ```
-
 5. Develop the features on your branch. If you want to add a dataset see more in-detail intsructions in the section [*How to add a dataset*](#how-to-add-a-dataset). Alternatively, you can follow the steps to [add a dataset](https://huggingface.co/nlp/add_dataset.html) and [share a dataset](https://huggingface.co/nlp/share_dataset.html) in the documentation.
 
 6. Format your code. Run black and isort so that your newly added files look nice with the following command:

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@
 # Check that source code meets quality standards
 
 quality:
-	black --check --line-length 119 --target-version py36 tests src benchmarks
-	isort --check-only --recursive tests src benchmarks datasets
-	flake8 tests src benchmarks
+	black --check --line-length 119 --target-version py36 tests src benchmarks datasets metrics
+	isort --check-only tests src benchmarks datasets metrics
+	flake8 tests src benchmarks datasets metrics
 
 # Format source code automatically
 
 style:
-	black --line-length 119 --target-version py36 tests src benchmarks
-	isort --recursive tests src datasets benchmarks
+	black --line-length 119 --target-version py36 tests src benchmarks datasets metrics
+	isort tests src benchmarks datasets metrics

--- a/benchmarks/benchmark_array_xd.py
+++ b/benchmarks/benchmark_array_xd.py
@@ -2,10 +2,11 @@ import json
 import os
 import tempfile
 
+from utils import generate_examples, get_duration
+
 import nlp
 from nlp.arrow_writer import ArrowWriter
 from nlp.features import Array2D
-from utils import generate_examples, get_duration
 
 
 SHAPE_TEST_1 = (30, 487)

--- a/benchmarks/benchmark_indices_mapping.py
+++ b/benchmarks/benchmark_indices_mapping.py
@@ -2,8 +2,9 @@ import json
 import os
 import tempfile
 
-import nlp
 from utils import generate_example_dataset, get_duration
+
+import nlp
 
 
 SPEED_TEST_N_EXAMPLES = 500_000

--- a/benchmarks/benchmark_iterating.py
+++ b/benchmarks/benchmark_iterating.py
@@ -2,8 +2,9 @@ import json
 import os
 import tempfile
 
-import nlp
 from utils import generate_example_dataset, get_duration
+
+import nlp
 
 
 SPEED_TEST_N_EXAMPLES = 50_000

--- a/benchmarks/benchmark_map_filter.py
+++ b/benchmarks/benchmark_map_filter.py
@@ -3,9 +3,9 @@ import os
 import tempfile
 
 import transformers
+from utils import generate_example_dataset, get_duration
 
 import nlp
-from utils import generate_example_dataset, get_duration
 
 
 SPEED_TEST_N_EXAMPLES = 500_000

--- a/datasets/aeslc/aeslc.py
+++ b/datasets/aeslc/aeslc.py
@@ -69,13 +69,16 @@ class Aeslc(nlp.GeneratorBasedBuilder):
         input_path = os.path.join(dl_path, "AESLC-master", "enron_subject_line")
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={"pattern": os.path.join(input_path, "train", "*.subject")},
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"pattern": os.path.join(input_path, "train", "*.subject")},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={"pattern": os.path.join(input_path, "dev", "*.subject")},
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"pattern": os.path.join(input_path, "dev", "*.subject")},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.TEST, gen_kwargs={"pattern": os.path.join(input_path, "test", "*.subject")},
+                name=nlp.Split.TEST,
+                gen_kwargs={"pattern": os.path.join(input_path, "test", "*.subject")},
             ),
         ]
 

--- a/datasets/ag_news/ag_news.py
+++ b/datasets/ag_news/ag_news.py
@@ -19,25 +19,24 @@
 from __future__ import absolute_import, division, print_function
 
 import csv
-import os
 
 import nlp
 
 
 _DESCRIPTION = """\
-AG is a collection of more than 1 million news articles. News articles have been 
-gathered from more than 2000 news sources by ComeToMyHead in more than 1 year of 
-activity. ComeToMyHead is an academic news search engine which has been running 
-since July, 2004. The dataset is provided by the academic comunity for research 
-purposes in data mining (clustering, classification, etc), information retrieval 
-(ranking, search, etc), xml, data compression, data streaming, and any other 
-non-commercial activity. For more information, please refer to the link 
+AG is a collection of more than 1 million news articles. News articles have been
+gathered from more than 2000 news sources by ComeToMyHead in more than 1 year of
+activity. ComeToMyHead is an academic news search engine which has been running
+since July, 2004. The dataset is provided by the academic comunity for research
+purposes in data mining (clustering, classification, etc), information retrieval
+(ranking, search, etc), xml, data compression, data streaming, and any other
+non-commercial activity. For more information, please refer to the link
 http://www.di.unipi.it/~gulli/AG_corpus_of_news_articles.html .
 
-The AG's news topic classification dataset is constructed by Xiang Zhang 
-(xiang.zhang@nyu.edu) from the dataset above. It is used as a text 
-classification benchmark in the following paper: Xiang Zhang, Junbo Zhao, Yann 
-LeCun. Character-level Convolutional Networks for Text Classification. Advances 
+The AG's news topic classification dataset is constructed by Xiang Zhang
+(xiang.zhang@nyu.edu) from the dataset above. It is used as a text
+classification benchmark in the following paper: Xiang Zhang, Junbo Zhao, Yann
+LeCun. Character-level Convolutional Networks for Text Classification. Advances
 in Neural Information Processing Systems 28 (NIPS 2015).
 """
 

--- a/datasets/allocine/allocine.py
+++ b/datasets/allocine/allocine.py
@@ -32,9 +32,9 @@ class AllocineConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for Allocine.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(AllocineConfig, self).__init__(**kwargs)
 
 
@@ -58,7 +58,10 @@ class AllocineDataset(nlp.GeneratorBasedBuilder):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
             features=nlp.Features(
-                {"review": nlp.Value("string"), "label": nlp.features.ClassLabel(names=["neg", "pos"]),}
+                {
+                    "review": nlp.Value("string"),
+                    "label": nlp.features.ClassLabel(names=["neg", "pos"]),
+                }
             ),
             supervised_keys=None,
             homepage="https://github.com/TheophileBlard/french-sentiment-analysis-with-bert",

--- a/datasets/anli/anli.py
+++ b/datasets/anli/anli.py
@@ -27,11 +27,11 @@ import nlp
 _CITATION = """\
 @InProceedings{nie2019adversarial,
     title={Adversarial NLI: A New Benchmark for Natural Language Understanding},
-    author={Nie, Yixin 
-                and Williams, Adina 
-                and Dinan, Emily 
-                and Bansal, Mohit 
-                and Weston, Jason 
+    author={Nie, Yixin
+                and Williams, Adina
+                and Dinan, Emily
+                and Bansal, Mohit
+                and Weston, Jason
                 and Kiela, Douwe},
     booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
     year = "2020",
@@ -40,7 +40,7 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-The Adversarial Natural Language Inference (ANLI) is a new large-scale NLI benchmark dataset, 
+The Adversarial Natural Language Inference (ANLI) is a new large-scale NLI benchmark dataset,
 The dataset is collected via an iterative, adversarial human-and-model-in-the-loop procedure.
 ANLI is much more difficult than its predecessors including SNLI and MNLI.
 It contains three rounds. Each round has train/dev/test splits.
@@ -59,10 +59,10 @@ class ANLIConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for ANLI.
 
-    Args:
-.
-      **kwargs: keyword arguments forwarded to super.
-    """
+            Args:
+        .
+              **kwargs: keyword arguments forwarded to super.
+        """
         super(ANLIConfig, self).__init__(
             version=nlp.Version("0.1.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -72,7 +72,10 @@ class ANLI(nlp.GeneratorBasedBuilder):
     """ANLI: The ANLI Dataset."""
 
     BUILDER_CONFIGS = [
-        ANLIConfig(name="plain_text", description="Plain text",),
+        ANLIConfig(
+            name="plain_text",
+            description="Plain text",
+        ),
     ]
 
     def _info(self):
@@ -128,12 +131,12 @@ class ANLI(nlp.GeneratorBasedBuilder):
     def _generate_examples(self, filepath):
         """Generate mnli examples.
 
-    Args:
-      filepath: a string
+        Args:
+          filepath: a string
 
-    Yields:
-      dictionaries containing "premise", "hypothesis" and "label" strings
-    """
+        Yields:
+          dictionaries containing "premise", "hypothesis" and "label" strings
+        """
         for idx, line in enumerate(open(filepath, "rb")):
             if line is not None:
                 line = line.strip().decode("utf-8")

--- a/datasets/arcd/arcd.py
+++ b/datasets/arcd/arcd.py
@@ -37,9 +37,9 @@ class ArcdConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for ARCD.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(ArcdConfig, self).__init__(**kwargs)
 
 

--- a/datasets/billsum/billsum.py
+++ b/datasets/billsum/billsum.py
@@ -65,7 +65,11 @@ class Billsum(nlp.GeneratorBasedBuilder):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
             features=nlp.Features(
-                {_DOCUMENT: nlp.Value("string"), _SUMMARY: nlp.Value("string"), "title": nlp.Value("string"),}
+                {
+                    _DOCUMENT: nlp.Value("string"),
+                    _SUMMARY: nlp.Value("string"),
+                    "title": nlp.Value("string"),
+                }
             ),
             supervised_keys=(_DOCUMENT, _SUMMARY),
             homepage="https://github.com/FiscalNote/BillSum",

--- a/datasets/biomrc/biomrc.py
+++ b/datasets/biomrc/biomrc.py
@@ -53,9 +53,9 @@ class BiomrcConfig(nlp.BuilderConfig):
 
     def __init__(self, biomrc_setting="A", biomrc_version="large", **kwargs):
         """BuilderConfig for BioMRC.
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         if biomrc_setting.lower() == "b":
             self.biomrc_setting = "B"
         else:

--- a/datasets/biomrc/biomrc.py
+++ b/datasets/biomrc/biomrc.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import logging
-import os
 
 import nlp
 

--- a/datasets/blimp/blimp.py
+++ b/datasets/blimp/blimp.py
@@ -51,10 +51,10 @@ class BlimpConfig(nlp.BuilderConfig):
     def __init__(self, paradigm_uid, **kwargs):
         """BuilderConfig for Blimp.
 
-    Args:
-      paradigm_uid: string, UID of the linguistic paradigm
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          paradigm_uid: string, UID of the linguistic paradigm
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = paradigm_uid
 
         description = _DESCRIPTION

--- a/datasets/blog_authorship_corpus/blog_authorship_corpus.py
+++ b/datasets/blog_authorship_corpus/blog_authorship_corpus.py
@@ -51,7 +51,12 @@ class BlogAuthorshipCorpusConfig(nlp.BuilderConfig):
           data_url: `string`, url to the dataset (word or raw level)
           **kwargs: keyword arguments forwarded to super.
         """
-        super(BlogAuthorshipCorpusConfig, self).__init__(version=nlp.Version("1.0.0",), **kwargs)
+        super(BlogAuthorshipCorpusConfig, self).__init__(
+            version=nlp.Version(
+                "1.0.0",
+            ),
+            **kwargs,
+        )
         self.data_url = data_url
 
 
@@ -108,9 +113,13 @@ class BlogAuthorshipCorpus(nlp.GeneratorBasedBuilder):
                     train_files.append(file_path)
 
             return [
-                nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"files": train_files, "split": "train"},),
                 nlp.SplitGenerator(
-                    name=nlp.Split.VALIDATION, gen_kwargs={"files": validation_files, "split": "validation"},
+                    name=nlp.Split.TRAIN,
+                    gen_kwargs={"files": train_files, "split": "train"},
+                ),
+                nlp.SplitGenerator(
+                    name=nlp.Split.VALIDATION,
+                    gen_kwargs={"files": validation_files, "split": "validation"},
                 ),
             ]
         else:

--- a/datasets/bookcorpus/bookcorpus.py
+++ b/datasets/bookcorpus/bookcorpus.py
@@ -63,12 +63,21 @@ class BookcorpusConfig(nlp.BuilderConfig):
 class Bookcorpus(nlp.GeneratorBasedBuilder):
     """BookCorpus dataset."""
 
-    BUILDER_CONFIGS = [BookcorpusConfig(name="plain_text", description="Plain text",)]
+    BUILDER_CONFIGS = [
+        BookcorpusConfig(
+            name="plain_text",
+            description="Plain text",
+        )
+    ]
 
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({"text": nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    "text": nlp.Value("string"),
+                }
+            ),
             supervised_keys=None,
             homepage="https://yknzhu.wixsite.com/mbweb",
             citation=_CITATION,

--- a/datasets/bookcorpus/bookcorpus.py
+++ b/datasets/bookcorpus/bookcorpus.py
@@ -18,9 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import glob
 import os
-import re
 
 import nlp
 

--- a/datasets/boolq/boolq.py
+++ b/datasets/boolq/boolq.py
@@ -75,7 +75,10 @@ class Boolq(nlp.GeneratorBasedBuilder):
 
         return [
             nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepath": downloaded_files["train"]}),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"filepath": downloaded_files["dev"]},),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"filepath": downloaded_files["dev"]},
+            ),
         ]
 
     def _generate_examples(self, filepath):

--- a/datasets/boolq/boolq.py
+++ b/datasets/boolq/boolq.py
@@ -22,9 +22,9 @@ _CITATION = """\
 
 # TODO(boolq):
 _DESCRIPTION = """\
-BoolQ is a question answering dataset for yes/no questions containing 15942 examples. These questions are naturally 
-occurring ---they are generated in unprompted and unconstrained settings. 
-Each example is a triplet of (question, passage, answer), with the title of the page as optional additional context. 
+BoolQ is a question answering dataset for yes/no questions containing 15942 examples. These questions are naturally
+occurring ---they are generated in unprompted and unconstrained settings.
+Each example is a triplet of (question, passage, answer), with the title of the page as optional additional context.
 The text-pair classification setup is similar to existing natural language inference tasks.
 """
 

--- a/datasets/break_data/break_data.py
+++ b/datasets/break_data/break_data.py
@@ -80,7 +80,10 @@ class BreakData(nlp.GeneratorBasedBuilder):
                Contains questions annotated with the high-level variant of QDMR. These decomposition are exclusive to Reading 
                Comprehension tasks (Section 2). lexicon_tokens files are also provided."""
             ),
-            text_features={"source": "source", "allowed_tokens": "allowed_tokens",},
+            text_features={
+                "source": "source",
+                "allowed_tokens": "allowed_tokens",
+            },
             lexicon_tokens=True,
         ),
         BreakDataConfig(
@@ -110,7 +113,10 @@ class BreakData(nlp.GeneratorBasedBuilder):
                each question, the lexicon file contains the set of valid tokens that could potentially appear in its 
                decomposition """
             ),
-            text_features={"source": "source", "allowed_tokens": "allowed_tokens",},
+            text_features={
+                "source": "source",
+                "allowed_tokens": "allowed_tokens",
+            },
             lexicon_tokens=True,
         ),
         BreakDataConfig(

--- a/datasets/break_data/break_data.py
+++ b/datasets/break_data/break_data.py
@@ -25,7 +25,7 @@ _CITATION = """\
 # TODO(break):
 _DESCRIPTION = """\
 Break is a human annotated dataset of natural language questions and their Question Decomposition Meaning Representations
-(QDMRs). Break consists of 83,978 examples sampled from 10 question answering datasets over text, images and databases. 
+(QDMRs). Break consists of 83,978 examples sampled from 10 question answering datasets over text, images and databases.
 This repository contains the Break dataset along with information on the exact data format.
 """
 _URL = "https://github.com/allenai/Break/raw/master/break_dataset/Break-dataset.zip"
@@ -61,7 +61,7 @@ class BreakData(nlp.GeneratorBasedBuilder):
             name="QDMR-high-level",
             description=textwrap.dedent(
                 """
-             Contains questions annotated with the high-level variant of QDMR. These decomposition are exclusive to Reading 
+             Contains questions annotated with the high-level variant of QDMR. These decomposition are exclusive to Reading
              Comprehension tasks (Section 2). lexicon_tokens files are also provided."""
             ),
             text_features={
@@ -77,7 +77,7 @@ class BreakData(nlp.GeneratorBasedBuilder):
             name="QDMR-high-level-lexicon",
             description=textwrap.dedent(
                 """
-               Contains questions annotated with the high-level variant of QDMR. These decomposition are exclusive to Reading 
+               Contains questions annotated with the high-level variant of QDMR. These decomposition are exclusive to Reading
                Comprehension tasks (Section 2). lexicon_tokens files are also provided."""
             ),
             text_features={
@@ -90,9 +90,9 @@ class BreakData(nlp.GeneratorBasedBuilder):
             name="QDMR",
             description=textwrap.dedent(
                 """
-               Contains questions over text, images and databases annotated with their Question Decomposition Meaning 
-               Representation. In addition to the train, dev and (hidden) test sets we provide lexicon_tokens files. For 
-               each question, the lexicon file contains the set of valid tokens that could potentially appear in its 
+               Contains questions over text, images and databases annotated with their Question Decomposition Meaning
+               Representation. In addition to the train, dev and (hidden) test sets we provide lexicon_tokens files. For
+               each question, the lexicon file contains the set of valid tokens that could potentially appear in its
                decomposition """
             ),
             text_features={
@@ -108,9 +108,9 @@ class BreakData(nlp.GeneratorBasedBuilder):
             name="QDMR-lexicon",
             description=textwrap.dedent(
                 """
-                 Contains questions over text, images and databases annotated with their Question Decomposition Meaning 
-               Representation. In addition to the train, dev and (hidden) test sets we provide lexicon_tokens files. For 
-               each question, the lexicon file contains the set of valid tokens that could potentially appear in its 
+                 Contains questions over text, images and databases annotated with their Question Decomposition Meaning
+               Representation. In addition to the train, dev and (hidden) test sets we provide lexicon_tokens files. For
+               each question, the lexicon file contains the set of valid tokens that could potentially appear in its
                decomposition """
             ),
             text_features={
@@ -123,7 +123,7 @@ class BreakData(nlp.GeneratorBasedBuilder):
             name="logical-forms",
             description=textwrap.dedent(
                 """
-               Contains questions and QDMRs annotated with full logical-forms of QDMR operators + arguments. Full logical-forms 
+               Contains questions and QDMRs annotated with full logical-forms of QDMR operators + arguments. Full logical-forms
                were inferred by the annotation-consistency algorithm described in """
             ),
             lexicon_tokens=False,

--- a/datasets/cfq/cfq.py
+++ b/datasets/cfq/cfq.py
@@ -59,11 +59,11 @@ class CfqConfig(nlp.BuilderConfig):
     def __init__(self, name, directory="splits", **kwargs):
         """BuilderConfig for CFQ.
 
-    Args:
-      name: Unique name of the split.
-      directory: Which subdirectory to read the split from.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          name: Unique name of the split.
+          directory: Which subdirectory to read the split from.
+          **kwargs: keyword arguments forwarded to super.
+        """
         # Version history:
         super(CfqConfig, self).__init__(name=name, version=nlp.Version("1.0.1"), description=_DESCRIPTION, **kwargs)
         self.split_file = os.path.join(directory, name + ".json")
@@ -92,7 +92,12 @@ class Cfq(nlp.GeneratorBasedBuilder):
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({_QUESTION: nlp.Value("string"), _QUERY: nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    _QUESTION: nlp.Value("string"),
+                    _QUERY: nlp.Value("string"),
+                }
+            ),
             supervised_keys=(_QUESTION, _QUERY),
             homepage="https://github.com/google-research/google-research/tree/master/cfq",
             citation=_CITATION,

--- a/datasets/civil_comments/civil_comments.py
+++ b/datasets/civil_comments/civil_comments.py
@@ -66,16 +66,16 @@ _DOWNLOAD_URL = "https://storage.googleapis.com/jigsaw-unintended-bias-in-toxici
 class CivilComments(nlp.GeneratorBasedBuilder):
     """Classification and tagging of 2M comments on news sites.
 
-  This version of the CivilComments Dataset provides access to the primary
-  seven labels that were annotated by crowd workers, the toxicity and other
-  tags are a value between 0 and 1 indicating the fraction of annotators that
-  assigned these attributes to the comment text.
+    This version of the CivilComments Dataset provides access to the primary
+    seven labels that were annotated by crowd workers, the toxicity and other
+    tags are a value between 0 and 1 indicating the fraction of annotators that
+    assigned these attributes to the comment text.
 
-  The other tags, which are only available for a fraction of the input examples
-  are currently ignored, as are all of the attributes that were part of the
-  original civil comments release. See the Kaggle documentation for more
-  details about the available features.
-  """
+    The other tags, which are only available for a fraction of the input examples
+    are currently ignored, as are all of the attributes that were part of the
+    original civil comments release. See the Kaggle documentation for more
+    details about the available features.
+    """
 
     VERSION = nlp.Version("0.9.0")
 
@@ -128,16 +128,16 @@ class CivilComments(nlp.GeneratorBasedBuilder):
     def _generate_examples(self, filename, toxicity_label):
         """Yields examples.
 
-    Each example contains a text input and then seven annotation labels.
+        Each example contains a text input and then seven annotation labels.
 
-    Args:
-      filename: the path of the file to be read for this split.
-      toxicity_label: indicates 'target' or 'toxicity' to capture the variation
-        in the released labels for this dataset.
+        Args:
+          filename: the path of the file to be read for this split.
+          toxicity_label: indicates 'target' or 'toxicity' to capture the variation
+            in the released labels for this dataset.
 
-    Yields:
-      A dictionary of features, all floating point except the input text.
-    """
+        Yields:
+          A dictionary of features, all floating point except the input text.
+        """
         with open(filename, encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:

--- a/datasets/clue/clue.py
+++ b/datasets/clue/clue.py
@@ -64,23 +64,23 @@ class ClueConfig(nlp.BuilderConfig):
     ):
         """BuilderConfig for CLUE.
 
-    Args:
-      text_features: `dict[string, string]`, map from the name of the feature
-        dict for each text field to the name of the column in the tsv file
-      label_column: `string`, name of the column in the tsv file corresponding
-        to the label
-      data_url: `string`, url to download the zip file from
-      data_dir: `string`, the path to the folder containing the tsv files in the
-        downloaded zip
-      citation: `string`, citation for the data set
-      url: `string`, url for information about the data set
-      label_classes: `list[string]`, the list of classes if the label is
-        categorical. If not provided, then the label will be of type
-        `nlp.Value('float32')`.
-      process_label: `Function[string, any]`, function  taking in the raw value
-        of the label and processing it to the form required by the label feature
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          text_features: `dict[string, string]`, map from the name of the feature
+            dict for each text field to the name of the column in the tsv file
+          label_column: `string`, name of the column in the tsv file corresponding
+            to the label
+          data_url: `string`, url to download the zip file from
+          data_dir: `string`, the path to the folder containing the tsv files in the
+            downloaded zip
+          citation: `string`, citation for the data set
+          url: `string`, url for information about the data set
+          label_classes: `list[string]`, the list of classes if the label is
+            categorical. If not provided, then the label will be of type
+            `nlp.Value('float32')`.
+          process_label: `Function[string, any]`, function  taking in the raw value
+            of the label and processing it to the form required by the label feature
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(ClueConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -121,8 +121,23 @@ class Clue(nlp.GeneratorBasedBuilder):
             """
             ),
             text_features={"sentence": "sentence"},
-            label_classes=["100", "101", "102", "103", "104", "106", "107", "108", "109", "110", "112", "113", "114",
-                           "115", "116"],
+            label_classes=[
+                "100",
+                "101",
+                "102",
+                "103",
+                "104",
+                "106",
+                "107",
+                "108",
+                "109",
+                "110",
+                "112",
+                "113",
+                "114",
+                "115",
+                "116",
+            ],
             label_column="label",
             data_url="https://storage.googleapis.com/cluebenchmark/tasks/tnews_public.zip",
             url="https://github.com/skdjfla/toutiao-text-classfication-dataset",
@@ -174,7 +189,7 @@ class Clue(nlp.GeneratorBasedBuilder):
             description=textwrap.dedent(
                 """\
             Chinese Scientific Literature Dataset (CSL) is taken from the abstracts of
-            Chinese papers and their keywords. The papers are selected from some core 
+            Chinese papers and their keywords. The papers are selected from some core
             journals of Chinese social sciences and natural sciences. TF-IDF is used to
             generate a mixture of fake keywords and real keywords in the paper to construct
             abstract-keyword pairs. The task goal is to judge whether the keywords are
@@ -206,8 +221,8 @@ class Clue(nlp.GeneratorBasedBuilder):
                   author={Cui, Yiming and Liu, Ting and Xiao, Li and Chen, Zhipeng and Ma, Wentao and Che, Wanxiang and Wang, Shijin and Hu, Guoping},
                   journal={arXiv preprint arXiv:1810.07366},
                   year={2018}
-                }"""),
-
+                }"""
+            ),
         ),
         ClueConfig(
             name="drcd",
@@ -242,14 +257,15 @@ class Clue(nlp.GeneratorBasedBuilder):
                    publisher={Association for Computational Linguistics},
                    author={Zheng, Chujie and Huang, Minlie and Sun, Aixin},
                    year={2019}
-                }"""),
+                }"""
+            ),
         ),
         ClueConfig(
             name="c3",
             description=textwrap.dedent(
                 """\
-            Multiple-Choice Chinese Machine Reading Comprehension (C3, or C^3) is a Chinese 
-            multi-choice reading comprehension data set, including mixed type data sets 
+            Multiple-Choice Chinese Machine Reading Comprehension (C3, or C^3) is a Chinese
+            multi-choice reading comprehension data set, including mixed type data sets
             such as dialogue and long text. Both the training and validation sets are 
             the concatenation of the dialogue and long-text subsets.
             """
@@ -271,7 +287,8 @@ class Clue(nlp.GeneratorBasedBuilder):
                       pages     = {141--155},
                       year      = {2020},
                       url       = {https://transacl.org/ojs/index.php/tacl/article/view/1882}
-                    }"""),
+                    }"""
+            ),
         ),
         ClueConfig(
             name="diagnostics",
@@ -291,14 +308,14 @@ class Clue(nlp.GeneratorBasedBuilder):
     ]
 
     def _info(self):
-        if self.config.name in ['afqmc', 'tnews', 'iflytek', 'cmnli', 'diagnostics']:
+        if self.config.name in ["afqmc", "tnews", "iflytek", "cmnli", "diagnostics"]:
             features = {text_feature: nlp.Value("string") for text_feature in six.iterkeys(self.config.text_features)}
             if self.config.label_classes:
                 features["label"] = nlp.features.ClassLabel(names=self.config.label_classes)
             else:
                 features["label"] = nlp.Value("float32")
             features["idx"] = nlp.Value("int32")
-        elif self.config.name == 'cluewsc2020':
+        elif self.config.name == "cluewsc2020":
             features = {
                 "idx": nlp.Value("int32"),
                 "text": nlp.Value("string"),
@@ -308,35 +325,41 @@ class Clue(nlp.GeneratorBasedBuilder):
                     "span2_text": nlp.Value("string"),
                     "span1_index": nlp.Value("int32"),
                     "span2_index": nlp.Value("int32"),
-                }
+                },
             }
-        elif self.config.name == 'csl':
+        elif self.config.name == "csl":
             features = {
                 "idx": nlp.Value("int32"),
                 "corpus_id": nlp.Value("int32"),
                 "abst": nlp.Value("string"),
                 "label": nlp.features.ClassLabel(names=self.config.label_classes),
-                "keyword": nlp.Sequence(nlp.Value("string"))
+                "keyword": nlp.Sequence(nlp.Value("string")),
             }
-        elif self.config.name in ['cmrc2018', 'drcd']:
+        elif self.config.name in ["cmrc2018", "drcd"]:
             features = {
                 "id": nlp.Value("string"),
                 "context": nlp.Value("string"),
                 "question": nlp.Value("string"),
                 "answers": nlp.Sequence(
-                    {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"), }
+                    {
+                        "text": nlp.Value("string"),
+                        "answer_start": nlp.Value("int32"),
+                    }
                 ),
             }
-        elif self.config.name == 'chid':
+        elif self.config.name == "chid":
             features = {
                 "idx": nlp.Value("int32"),
                 "candidates": nlp.Sequence(nlp.Value("string")),
                 "content": nlp.Sequence(nlp.Value("string")),
                 "answers": nlp.features.Sequence(
-                    {"text": nlp.Value("string"), "candidate_id": nlp.Value("int32"), }
+                    {
+                        "text": nlp.Value("string"),
+                        "candidate_id": nlp.Value("int32"),
+                    }
                 ),
             }
-        elif self.config.name == 'c3':
+        elif self.config.name == "c3":
             features = {
                 "id": nlp.Value("int32"),
                 "context": nlp.Sequence(nlp.Value("string")),
@@ -345,9 +368,11 @@ class Clue(nlp.GeneratorBasedBuilder):
                 "answer": nlp.Value("string"),
             }
         else:
-            raise NotImplementedError("This task is not implemented. If you believe"
-                                      " this task was recently added to the CLUE benchmark, "
-                                      "please open a GitHub issue and we will add it.")
+            raise NotImplementedError(
+                "This task is not implemented. If you believe"
+                " this task was recently added to the CLUE benchmark, "
+                "please open a GitHub issue and we will add it."
+            )
 
         return nlp.DatasetInfo(
             description=_CLUE_DESCRIPTION,
@@ -362,39 +387,46 @@ class Clue(nlp.GeneratorBasedBuilder):
         test_split = nlp.SplitGenerator(
             name=nlp.Split.TEST,
             gen_kwargs={
-                "data_file": os.path.join(data_dir, "test.json" if self.config.name != "diagnostics" else "diagnostics_test.json"),
+                "data_file": os.path.join(
+                    data_dir, "test.json" if self.config.name != "diagnostics" else "diagnostics_test.json"
+                ),
                 "split": "test",
             },
         )
 
         split_list = [test_split]
 
-        if self.config.name != 'diagnostics':
+        if self.config.name != "diagnostics":
             train_split = nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
                 gen_kwargs={
-                    "data_file": os.path.join(data_dir or "",
-                                              "train.json" if self.config.name != "c3" else "d-train.json"),
+                    "data_file": os.path.join(
+                        data_dir or "", "train.json" if self.config.name != "c3" else "d-train.json"
+                    ),
                     "split": "train",
                 },
             )
             val_split = nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION,
                 gen_kwargs={
-                    "data_file": os.path.join(data_dir or "", "dev.json" if self.config.name != "c3" else "d-dev.json"),
+                    "data_file": os.path.join(
+                        data_dir or "", "dev.json" if self.config.name != "c3" else "d-dev.json"
+                    ),
                     "split": "dev",
                 },
             )
             split_list += [train_split, val_split]
 
-        if self.config.name == 'cmrc2018':
-            split_list.append(nlp.SplitGenerator(
-                name=nlp.Split('trial'),
-                gen_kwargs={
-                    "data_file": os.path.join(data_dir or "", "trial.json"),
-                    "split": "trial",
-                },
-            ))
+        if self.config.name == "cmrc2018":
+            split_list.append(
+                nlp.SplitGenerator(
+                    name=nlp.Split("trial"),
+                    gen_kwargs={
+                        "data_file": os.path.join(data_dir or "", "trial.json"),
+                        "split": "trial",
+                    },
+                )
+            )
 
         return split_list
 
@@ -411,7 +443,7 @@ class Clue(nlp.GeneratorBasedBuilder):
                 files = [data_file]
             else:
                 data_dir = os.path.dirname(data_file)
-                files = [os.path.join(data_dir, "{}-{}.json".format(typ, split)) for typ in ['d', 'm']]
+                files = [os.path.join(data_dir, "{}-{}.json".format(typ, split)) for typ in ["d", "m"]]
             data = []
             for f in files:
                 data_subset = json.load(open(f, encoding="utf8"))
@@ -423,13 +455,13 @@ class Clue(nlp.GeneratorBasedBuilder):
                         "context": entry[0],
                         "question": question["question"],
                         "choice": question["choice"],
-                        "answer": question["answer"] if split != "test" else ""
+                        "answer": question["answer"] if split != "test" else "",
                     }
                     yield example["id"], example
 
         else:
             with open(data_file, encoding="utf8") as f:
-                if self.config.name in ['cmrc2018', 'drcd']:
+                if self.config.name in ["cmrc2018", "drcd"]:
                     data = json.load(f)
                     for example in data["data"]:
                         for paragraph in example["paragraphs"]:
@@ -445,7 +477,10 @@ class Clue(nlp.GeneratorBasedBuilder):
                                     "context": context,
                                     "question": question,
                                     "id": id_,
-                                    "answers": {"answer_start": answer_starts, "text": answers, },
+                                    "answers": {
+                                        "answer_start": answer_starts,
+                                        "text": answers,
+                                    },
                                 }
 
                 else:
@@ -461,13 +496,18 @@ class Clue(nlp.GeneratorBasedBuilder):
                                 for content in contents:
                                     idioms = re.findall(r"#idiom\d+#", content)
                                     for idiom in idioms:
-                                        idiom_list.append({"candidate_id": answer_dict[idiom], "text": candidates[answer_dict[idiom]]})
+                                        idiom_list.append(
+                                            {
+                                                "candidate_id": answer_dict[idiom],
+                                                "text": candidates[answer_dict[idiom]],
+                                            }
+                                        )
                             example["answers"] = idiom_list
 
                         elif self.config.label_column in row:
                             label = row[self.config.label_column]
                             # Notice: some labels in CMNLI are missing. We drop these data.
-                            if self.config.name == 'cmnli' and label == '-':
+                            if self.config.name == "cmnli" and label == "-":
                                 continue
                             # For some tasks, the label is represented as 0 and 1 in the tsv
                             # files and needs to be cast to integer to work with the feature.

--- a/datasets/clue/clue.py
+++ b/datasets/clue/clue.py
@@ -266,7 +266,7 @@ class Clue(nlp.GeneratorBasedBuilder):
                 """\
             Multiple-Choice Chinese Machine Reading Comprehension (C3, or C^3) is a Chinese
             multi-choice reading comprehension data set, including mixed type data sets
-            such as dialogue and long text. Both the training and validation sets are 
+            such as dialogue and long text. Both the training and validation sets are
             the concatenation of the dialogue and long-text subsets.
             """
             ),

--- a/datasets/cmrc2018/cmrc2018.py
+++ b/datasets/cmrc2018/cmrc2018.py
@@ -62,7 +62,10 @@ class Cmrc2018(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                     # These are the features of your dataset like images, labels ...
                 }
@@ -109,5 +112,8 @@ class Cmrc2018(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/cmrc2018/cmrc2018.py
+++ b/datasets/cmrc2018/cmrc2018.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import nlp
 

--- a/datasets/cnn_dailymail/cnn_dailymail.py
+++ b/datasets/cnn_dailymail/cnn_dailymail.py
@@ -94,10 +94,10 @@ class CnnDailymailConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for CnnDailymail.
 
-    Args:
+        Args:
 
-      **kwargs: keyword arguments forwarded to super.
-    """
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(CnnDailymailConfig, self).__init__(**kwargs)
 
 
@@ -234,7 +234,11 @@ class CnnDailymail(nlp.GeneratorBasedBuilder):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
             features=nlp.Features(
-                {_ARTICLE: nlp.Value("string"), _HIGHLIGHTS: nlp.Value("string"), "id": nlp.Value("string"),}
+                {
+                    _ARTICLE: nlp.Value("string"),
+                    _HIGHLIGHTS: nlp.Value("string"),
+                    "id": nlp.Value("string"),
+                }
             ),
             supervised_keys=None,
             homepage="https://github.com/abisee/cnn-dailymail",

--- a/datasets/com_qa/com_qa.py
+++ b/datasets/com_qa/com_qa.py
@@ -29,15 +29,15 @@ _CITATION = """\
 
 # TODO(com_qa):
 _DESCRIPTION = """\
-ComQA is a dataset of 11,214 questions, which were collected from WikiAnswers, a community question answering website. 
-By collecting questions from such a site we ensure that the information needs are ones of interest to actual users. 
-Moreover, questions posed there are often cannot be answered by commercial search engines or QA technology, making them 
-more interesting for driving future research compared to those collected from an engine's query log. The dataset contains 
-questions with various challenging phenomena such as the need for temporal reasoning, comparison (e.g., comparatives, 
-superlatives, ordinals), compositionality (multiple, possibly nested, subquestions with multiple entities), and 
-unanswerable questions (e.g., Who was the first human being on Mars?). Through a large crowdsourcing effort, questions 
-in ComQA are grouped into 4,834 paraphrase clusters that express the same information need. Each cluster is annotated 
-with its answer(s). ComQA answers come in the form of Wikipedia entities wherever possible. Wherever the answers are 
+ComQA is a dataset of 11,214 questions, which were collected from WikiAnswers, a community question answering website.
+By collecting questions from such a site we ensure that the information needs are ones of interest to actual users.
+Moreover, questions posed there are often cannot be answered by commercial search engines or QA technology, making them
+more interesting for driving future research compared to those collected from an engine's query log. The dataset contains
+questions with various challenging phenomena such as the need for temporal reasoning, comparison (e.g., comparatives,
+superlatives, ordinals), compositionality (multiple, possibly nested, subquestions with multiple entities), and
+unanswerable questions (e.g., Who was the first human being on Mars?). Through a large crowdsourcing effort, questions
+in ComQA are grouped into 4,834 paraphrase clusters that express the same information need. Each cluster is annotated
+with its answer(s). ComQA answers come in the form of Wikipedia entities wherever possible. Wherever the answers are
 temporal or measurable quantities, TIMEX3 and the International System of Units (SI) are used for normalization.
 """
 _URL = "https://qa.mpi-inf.mpg.de/comqa"

--- a/datasets/common_gen/common_gen.py
+++ b/datasets/common_gen/common_gen.py
@@ -60,22 +60,16 @@ class CommonGen(nlp.GeneratorBasedBuilder):
 
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={
-                    "filepath": os.path.join(dl_dir, "commongen.train.jsonl"),
-                    "split": "train"
-                }
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"filepath": os.path.join(dl_dir, "commongen.train.jsonl"), "split": "train"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={
-                    "filepath": os.path.join(dl_dir, "commongen.dev.jsonl"),
-                    "split": "dev"
-                }
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"filepath": os.path.join(dl_dir, "commongen.dev.jsonl"), "split": "dev"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.TEST, gen_kwargs={
-                    "filepath": os.path.join(dl_dir, "commongen.test_noref.jsonl"),
-                    "split": "test"
-                }
+                name=nlp.Split.TEST,
+                gen_kwargs={"filepath": os.path.join(dl_dir, "commongen.test_noref.jsonl"), "split": "test"},
             ),
         ]
 
@@ -87,7 +81,7 @@ class CommonGen(nlp.GeneratorBasedBuilder):
                 row = row.replace(", }", "}")  # Fix possible JSON format error
                 data = json.loads(row)
 
-                rand_order = [word for word in data["concept_set"].split('#')]
+                rand_order = [word for word in data["concept_set"].split("#")]
                 random.shuffle(rand_order)
 
                 if split == "test":

--- a/datasets/common_gen/common_gen.py
+++ b/datasets/common_gen/common_gen.py
@@ -20,15 +20,15 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-CommonGen is a constrained text generation task, associated with a benchmark dataset, 
-to explicitly test machines for the ability of generative commonsense reasoning. Given 
-a set of common concepts; the task is to generate a coherent sentence describing an 
+CommonGen is a constrained text generation task, associated with a benchmark dataset,
+to explicitly test machines for the ability of generative commonsense reasoning. Given
+a set of common concepts; the task is to generate a coherent sentence describing an
 everyday scenario using these concepts.
 
-CommonGen is challenging because it inherently requires 1) relational reasoning using 
-background commonsense knowledge, and 2) compositional generalization ability to work 
-on unseen concept combinations. Our dataset, constructed through a combination of 
-crowd-sourcing from AMT and existing caption corpora, consists of 30k concept-sets and 
+CommonGen is challenging because it inherently requires 1) relational reasoning using
+background commonsense knowledge, and 2) compositional generalization ability to work
+on unseen concept combinations. Our dataset, constructed through a combination of
+crowd-sourcing from AMT and existing caption corpora, consists of 30k concept-sets and
 50k sentences in total.
 """
 _URL = "https://storage.googleapis.com/huggingface-nlp/datasets/common_gen/commongen_data.zip"

--- a/datasets/commonsense_qa/commonsense_qa.py
+++ b/datasets/commonsense_qa/commonsense_qa.py
@@ -43,7 +43,12 @@ class CommonsenseQa(nlp.GeneratorBasedBuilder):
             {
                 "answerKey": nlp.Value("string"),
                 "question": nlp.Value("string"),
-                "choices": nlp.features.Sequence({"label": nlp.Value("string"), "text": nlp.Value("string"),}),
+                "choices": nlp.features.Sequence(
+                    {
+                        "label": nlp.Value("string"),
+                        "text": nlp.Value("string"),
+                    }
+                ),
             }
         )
         return nlp.DatasetInfo(
@@ -76,10 +81,18 @@ class CommonsenseQa(nlp.GeneratorBasedBuilder):
                 name=nlp.Split.TRAIN, gen_kwargs={"filepath": downloaded_files["train"], "split": "train"}
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={"filepath": downloaded_files["dev"], "split": "dev",}
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={
+                    "filepath": downloaded_files["dev"],
+                    "split": "dev",
+                },
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.TEST, gen_kwargs={"filepath": downloaded_files["test"], "split": "test",}
+                name=nlp.Split.TEST,
+                gen_kwargs={
+                    "filepath": downloaded_files["test"],
+                    "split": "test",
+                },
             ),
         ]
 

--- a/datasets/coqa/coqa.py
+++ b/datasets/coqa/coqa.py
@@ -2,9 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import csv
 import json
-import os
 
 import nlp
 
@@ -28,60 +26,13 @@ CoQA: A Conversational Question Answering Challenge
 _TRAIN_DATA_URL = "https://nlp.stanford.edu/data/coqa/coqa-train-v1.0.json"
 _DEV_DATA_URL = "https://nlp.stanford.edu/data/coqa/coqa-dev-v1.0.json"
 
-#
-# class CoqaConfig(nlp.BuilderConfig):
-#   """BuilderConfig for Coqa."""
-#
-#   def __init__(self,
-#                story,
-#                source,
-#                questions,
-#                answers,
-#                citation,
-#                description,
-#                additional_answers=None,
-#                **kwargs):
-#     """BuilderConfig for Coca.
-#
-#     Args:
-#       story: `text`,  context
-#       source: `text`, source of the story
-#       questions `Sequence` set of questions
-#       answers: `Sequence` set of answers to the questions
-#       data_url: `string`, url to download the  file from
-#       citation: `string`, citation for the data set
-#      additional_answers: `Sequence`, in the dev set questions have also set of additional answers
-#       **kwargs: keyword arguments forwarded to super.
-#     """
-#     super(CoqaConfig, self).__init__(
-#         version=nlp.Version(
-#             "1.0.0",
-#             "New split API (https://tensorflow.org/datasets/splits)"),
-#         **kwargs)
-#     self.story = story
-#     self.source = source
-#     self.questions = questions
-#     self.answers = answers
-#     self.additional_answers = additional_answers
-#     self.citation = citation
-#     self.description = description
-
 
 class Coqa(nlp.GeneratorBasedBuilder):
     """TODO(coqa): Short description of my dataset."""
 
     # TODO(coqa): Set up version.
     VERSION = nlp.Version("1.0.0")
-    # BUILDER_CONFIGS = CoqaConfig(
-    #     story= 'story',
-    #     source='source',
-    #     questions='questions',
-    #     answers='answers',
-    #     additional_answers='additional_answers',
-    #     description= _DESCRIPTION,
-    #     citation= _CITATION
-    #
-    # )
+
     def _info(self):
         # TODO(coqa): Specifies the nlp.DatasetInfo object
         return nlp.DatasetInfo(

--- a/datasets/cornell_movie_dialog/cornell_movie_dialog.py
+++ b/datasets/cornell_movie_dialog/cornell_movie_dialog.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import ast
-import csv
 import os
 
 import nlp
@@ -15,10 +14,10 @@ _CITATION = """\
 
   author={Cristian Danescu-Niculescu-Mizil and Lillian Lee},
 
-  title={Chameleons in imagined conversations: 
+  title={Chameleons in imagined conversations:
   A new approach to understanding coordination of linguistic style in dialogs.},
 
-  booktitle={Proceedings of the 
+  booktitle={Proceedings of the
 
         Workshop on Cognitive Modeling and Computational Linguistics, ACL 2011},
 
@@ -29,7 +28,6 @@ _CITATION = """\
 
 # TODO(cornell_movie_dialog):
 _DESCRIPTION = """\
-     
 This corpus contains a large metadata-rich collection of fictional conversations extracted from raw movie scripts:
 - 220,579 conversational exchanges between 10,292 pairs of movie characters
 - involves 9,035 characters from 617 movies
@@ -118,7 +116,7 @@ class CornellMovieDialog(nlp.GeneratorBasedBuilder):
 
         with open(movie_titles_file, "rb") as f:
             movie_titles_data = [x.decode("latin").split("+++$+++") for x in f.readlines()]
-        ## looping over movie conversation file
+        # looping over movie conversation file
         for id_, conv in enumerate(movie_conv_data):
             char_id_1 = conv[0]
             char_id_2 = conv[1]
@@ -126,13 +124,13 @@ class CornellMovieDialog(nlp.GeneratorBasedBuilder):
             line_ids = conv[-1].replace("\n", "")
             line_ids = ast.literal_eval(line_ids.strip())
             lines_texts = []
-            ## searching text corresponding to each lineID in line_ids in movie lines file
+            # searching text corresponding to each lineID in line_ids in movie lines file
             for line_id in line_ids:
                 i = 0
                 while i < len(movie_lines_data) and movie_lines_data[i][0].strip() != line_id:
                     i += 1
                 lines_texts.append(movie_lines_data[i][0])  # if i < len(movie_lines_data) else '')
-            ## look for char names in movie character file
+            # look for char names in movie character file
             j = 0
             while j < len(movie_char_data) and movie_char_data[j][0].strip() != char_id_1.strip():
                 j += 1
@@ -144,14 +142,14 @@ class CornellMovieDialog(nlp.GeneratorBasedBuilder):
                 k += 1
             char_name_2 = movie_char_data[k][1]
 
-            ##look for movie year, IMDBRating, genre, no_imdb_voting in movie tiles file
-            l = 0
-            while l < len(movie_titles_data) and movie_titles_data[l][0].strip() != movie_id.strip():
-                l += 1
-            movie_year = movie_titles_data[l][2]
-            imdb_rating = movie_titles_data[l][3]
-            no_imdb_vote = movie_titles_data[l][4]
-            genre = movie_titles_data[l][5].replace("\n", "").strip()
+            # look for movie year, IMDBRating, genre, no_imdb_voting in movie tiles file
+            li = 0
+            while li < len(movie_titles_data) and movie_titles_data[li][0].strip() != movie_id.strip():
+                li += 1
+            movie_year = movie_titles_data[li][2]
+            imdb_rating = movie_titles_data[li][3]
+            no_imdb_vote = movie_titles_data[li][4]
+            genre = movie_titles_data[li][5].replace("\n", "").strip()
             movie_genres = ast.literal_eval(genre)
 
             yield id_, {

--- a/datasets/cos_e/cos_e.py
+++ b/datasets/cos_e/cos_e.py
@@ -168,10 +168,12 @@ class CosE(nlp.GeneratorBasedBuilder):
         # We use the CoS-E/CQA dev set as our validation set.
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={"files": files["train"], "cqa_indexed": cqa_indexed},
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"files": files["train"], "cqa_indexed": cqa_indexed},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={"files": files["dev"], "cqa_indexed": cqa_indexed},
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"files": files["dev"], "cqa_indexed": cqa_indexed},
             ),
         ]
 

--- a/datasets/crd3/crd3.py
+++ b/datasets/crd3/crd3.py
@@ -74,7 +74,12 @@ class CRD3(nlp.GeneratorBasedBuilder):
                     "turn_end": nlp.Value("int32"),
                     "alignment_score": nlp.Value("float32"),
                     "turn_num": nlp.Value("int32"),
-                    "turns": nlp.features.Sequence({"names": nlp.Value("string"), "utterances": nlp.Value("string"),}),
+                    "turns": nlp.features.Sequence(
+                        {
+                            "names": nlp.Value("string"),
+                            "utterances": nlp.Value("string"),
+                        }
+                    ),
                 }
             ),
             homepage="https://github.com/RevanthRameshkumar/CRD3",
@@ -103,9 +108,18 @@ class CRD3(nlp.GeneratorBasedBuilder):
         test_files, train_files, dev_files = get_train_test_dev_files(files, test_splits, train_splits, dev_splits)
 
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"files_path": train_files},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"files_path": test_files},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"files_path": dev_files},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"files_path": train_files},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"files_path": test_files},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"files_path": dev_files},
+            ),
         ]
 
     def _generate_examples(self, files_path):
@@ -131,5 +145,8 @@ class CRD3(nlp.GeneratorBasedBuilder):
                             "turn_end": turn_end,
                             "alignment_score": score,
                             "turn_num": turn_num,
-                            "turns": {"names": turn_names, "utterances": turn_utterances,},
+                            "turns": {
+                                "names": turn_names,
+                                "utterances": turn_utterances,
+                            },
                         }

--- a/datasets/crd3/crd3.py
+++ b/datasets/crd3/crd3.py
@@ -37,10 +37,10 @@ conference = {ACL}
 
 _DESCRIPTION = """
 Storytelling with Dialogue: A Critical Role Dungeons and Dragons Dataset.
-Critical Role is an unscripted, live-streamed show where a fixed group of people play Dungeons and Dragons, an open-ended role-playing game. 
-The dataset is collected from 159 Critical Role episodes transcribed to text dialogues, consisting of 398,682 turns. It also includes corresponding 
-abstractive summaries collected from the Fandom wiki. The dataset is linguistically unique in that the narratives are generated entirely through player 
-collaboration and spoken interaction. For each dialogue, there are a large number of turns, multiple abstractive summaries with varying levels of detail, 
+Critical Role is an unscripted, live-streamed show where a fixed group of people play Dungeons and Dragons, an open-ended role-playing game.
+The dataset is collected from 159 Critical Role episodes transcribed to text dialogues, consisting of 398,682 turns. It also includes corresponding
+abstractive summaries collected from the Fandom wiki. The dataset is linguistically unique in that the narratives are generated entirely through player
+collaboration and spoken interaction. For each dialogue, there are a large number of turns, multiple abstractive summaries with varying levels of detail,
 and semantic ties to the previous dialogues.
 """
 

--- a/datasets/crime_and_punish/crime_and_punish.py
+++ b/datasets/crime_and_punish/crime_and_punish.py
@@ -20,7 +20,12 @@ class CrimeAndPunishConfig(nlp.BuilderConfig):
           data_url: `string`, url to the dataset (word or raw level)
           **kwargs: keyword arguments forwarded to super.
         """
-        super(CrimeAndPunishConfig, self).__init__(version=nlp.Version("1.0.0",), **kwargs)
+        super(CrimeAndPunishConfig, self).__init__(
+            version=nlp.Version(
+                "1.0.0",
+            ),
+            **kwargs,
+        )
         self.data_url = data_url
 
 
@@ -40,7 +45,11 @@ class CrimeAndPunish(nlp.GeneratorBasedBuilder):
             # This is the description that will appear on the datasets page.
             description=_DESCRIPTION,
             # nlp.features.FeatureConnectors
-            features=nlp.Features({"line": nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    "line": nlp.Value("string"),
+                }
+            ),
             # If there's a common (input, target) tuple from the features,
             # specify them here. They'll be used if as_supervised=True in
             # builder.as_dataset.
@@ -55,7 +64,10 @@ class CrimeAndPunish(nlp.GeneratorBasedBuilder):
             data = dl_manager.download_and_extract(self.config.data_url)
 
             return [
-                nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"data_file": data, "split": "train"},),
+                nlp.SplitGenerator(
+                    name=nlp.Split.TRAIN,
+                    gen_kwargs={"data_file": data, "split": "train"},
+                ),
             ]
         else:
             raise ValueError("{} does not exist".format(self.config.name))

--- a/datasets/csv/csv.py
+++ b/datasets/csv/csv.py
@@ -54,8 +54,7 @@ class Csv(nlp.ArrowBasedBuilder):
         return nlp.DatasetInfo()
 
     def _split_generators(self, dl_manager):
-        """ We handle string, list and dicts in datafiles
-        """
+        """We handle string, list and dicts in datafiles"""
         if not self.config.data_files:
             raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
         data_files = dl_manager.download_and_extract(self.config.data_files)

--- a/datasets/daily_dialog/daily_dialog.py
+++ b/datasets/daily_dialog/daily_dialog.py
@@ -72,15 +72,9 @@ class DailyDialog(nlp.GeneratorBasedBuilder):
             description=_DESCRIPTION,
             features=nlp.Features(
                 {
-                    "dialog": nlp.features.Sequence(
-                        nlp.Value("string")
-                    ),
-                    "act": nlp.features.Sequence(
-                        nlp.ClassLabel(names=list(act_label.values()))
-                    ),
-                    "emotion": nlp.features.Sequence(
-                        nlp.ClassLabel(names=list(emotion_label.values()))
-                    ),
+                    "dialog": nlp.features.Sequence(nlp.Value("string")),
+                    "act": nlp.features.Sequence(nlp.ClassLabel(names=list(act_label.values()))),
+                    "emotion": nlp.features.Sequence(nlp.ClassLabel(names=list(emotion_label.values()))),
                 }
             ),
             supervised_keys=None,

--- a/datasets/daily_dialog/daily_dialog.py
+++ b/datasets/daily_dialog/daily_dialog.py
@@ -32,10 +32,10 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-We develop a high-quality multi-turn dialog dataset, DailyDialog, which is intriguing in several aspects. 
-The language is human-written and less noisy. The dialogues in the dataset reflect our daily communication way 
-and cover various topics about our daily life. We also manually label the developed dataset with communication 
-intention and emotion information. Then, we evaluate existing approaches on DailyDialog dataset and hope it 
+We develop a high-quality multi-turn dialog dataset, DailyDialog, which is intriguing in several aspects.
+The language is human-written and less noisy. The dialogues in the dataset reflect our daily communication way
+and cover various topics about our daily life. We also manually label the developed dataset with communication
+intention and emotion information. Then, we evaluate existing approaches on DailyDialog dataset and hope it
 benefit the research field of dialog systems.
 """
 

--- a/datasets/definite_pronoun_resolution/definite_pronoun_resolution.py
+++ b/datasets/definite_pronoun_resolution/definite_pronoun_resolution.py
@@ -75,7 +75,10 @@ class DefinitePronounResolution(nlp.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
         files = dl_manager.download_and_extract(
-            {"train": _DATA_URL_PATTERN.format("train"), "test": _DATA_URL_PATTERN.format("test"),}
+            {
+                "train": _DATA_URL_PATTERN.format("train"),
+                "test": _DATA_URL_PATTERN.format("test"),
+            }
         )
         return [
             nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"filepath": files["test"]}),

--- a/datasets/discofuse/discofuse.py
+++ b/datasets/discofuse/discofuse.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import, division, print_function
 import csv
 import os
 
-import tensorflow as tf
-
 import nlp
 
 
@@ -26,7 +24,7 @@ _CITATION = """\
 
 # TODO(discofuse):
 _DESCRIPTION = """\
- DISCOFUSE is a large scale dataset for discourse-based sentence fusion. 
+ DISCOFUSE is a large scale dataset for discourse-based sentence fusion.
 """
 
 

--- a/datasets/doqa/doqa.py
+++ b/datasets/doqa/doqa.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import logging
 import os
 
 import nlp
@@ -37,14 +36,14 @@ _CITATION = """
  """
 
 _DESCRIPTION = """
-DoQA is a dataset for accessing Domain Specific FAQs via conversational QA that contains 2,437 information-seeking question/answer dialogues 
-(10,917 questions in total) on three different domains: cooking, travel and movies. Note that we include in the generic concept of FAQs also 
-Community Question Answering sites, as well as corporate information in intranets which is maintained in textual form similar to FAQs, often 
+DoQA is a dataset for accessing Domain Specific FAQs via conversational QA that contains 2,437 information-seeking question/answer dialogues
+(10,917 questions in total) on three different domains: cooking, travel and movies. Note that we include in the generic concept of FAQs also
+Community Question Answering sites, as well as corporate information in intranets which is maintained in textual form similar to FAQs, often
 referred to as internal “knowledge bases”.
 
-These dialogues are created by crowd workers that play the following two roles: the user who asks questions about a given topic posted in Stack 
-Exchange (https://stackexchange.com/), and the domain expert who replies to the questions by selecting a short span of text from the long textual 
-reply in the original post. The expert can rephrase the selected span, in order to make it look more natural. The dataset covers unanswerable 
+These dialogues are created by crowd workers that play the following two roles: the user who asks questions about a given topic posted in Stack
+Exchange (https://stackexchange.com/), and the domain expert who replies to the questions by selecting a short span of text from the long textual
+reply in the original post. The expert can rephrase the selected span, in order to make it look more natural. The dataset covers unanswerable
 questions and some relevant dialogue acts.
 
 DoQA enables the development and evaluation of conversational QA systems that help users access the knowledge buried in domain specific FAQs.
@@ -167,7 +166,6 @@ class Doqa(nlp.GeneratorBasedBuilder):
                 paragraphs = row["paragraphs"]
                 for p in paragraphs:
                     context = p["context"]
-                    id_ = p["id"]
                     qas = p["qas"]
                     for qa in qas:
                         question = qa["question"]

--- a/datasets/doqa/doqa.py
+++ b/datasets/doqa/doqa.py
@@ -51,21 +51,25 @@ DoQA enables the development and evaluation of conversational QA systems that he
 """
 
 _URL = "https://ixa2.si.ehu.es/convai/doqa-v2.1.zip"
+
+
 class DoqaConfig(nlp.BuilderConfig):
     """BuilderConfig for DoQA."""
 
-    def __init__(self,  **kwargs):
+    def __init__(self, **kwargs):
         """Constructs a DoQA.
 
         Args:
         **kwargs: keyword arguments forwarded to super.
         """
 
-        super(DoqaConfig, self).__init__(version=nlp.Version("2.1.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs)
+        super(DoqaConfig, self).__init__(
+            version=nlp.Version("2.1.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
+        )
 
 
 class Doqa(nlp.GeneratorBasedBuilder):
-    
+
     BUILDER_CONFIGS = [
         DoqaConfig(
             name="cooking",
@@ -75,62 +79,78 @@ class Doqa(nlp.GeneratorBasedBuilder):
         ),
         DoqaConfig(
             name="travel",
-        )
+        ),
     ]
-    
+
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({
-                "title": nlp.Value("string"),
-                "background": nlp.Value("string"),
-                "context": nlp.Value("string"),
-                "question": nlp.Value("string"),
-                "id": nlp.Value("string"),
-                "answers":nlp.features.Sequence({
-                    "text": nlp.Value("string"),
-                    "answer_start": nlp.Value("int32"),
-            }),
-                "followup": nlp.Value("string"),
-                "yesno": nlp.Value("string"),
-                "orig_answer": nlp.features.Sequence({
-                    "text": nlp.Value("string"),
-                    "answer_start": nlp.Value("int32"),
-            }),
-            }),
+            features=nlp.Features(
+                {
+                    "title": nlp.Value("string"),
+                    "background": nlp.Value("string"),
+                    "context": nlp.Value("string"),
+                    "question": nlp.Value("string"),
+                    "id": nlp.Value("string"),
+                    "answers": nlp.features.Sequence(
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
+                    ),
+                    "followup": nlp.Value("string"),
+                    "yesno": nlp.Value("string"),
+                    "orig_answer": nlp.features.Sequence(
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
+                    ),
+                }
+            ),
             homepage="http://ixa.eus/node/12931",
             citation=_CITATION,
         )
 
     def _split_generators(self, dl_manager):
         path = dl_manager.download_and_extract(_URL)
-        if self.config.name == 'cooking':
+        if self.config.name == "cooking":
             return [
                 nlp.SplitGenerator(
                     name=nlp.Split.TEST,
-                    gen_kwargs={"filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset",  "doqa-cooking-test-v2.1.json")},
+                    gen_kwargs={
+                        "filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset", "doqa-cooking-test-v2.1.json")
+                    },
                 ),
                 nlp.SplitGenerator(
                     name=nlp.Split.VALIDATION,
-                    gen_kwargs={"filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset", "doqa-cooking-dev-v2.1.json")},
+                    gen_kwargs={
+                        "filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset", "doqa-cooking-dev-v2.1.json")
+                    },
                 ),
                 nlp.SplitGenerator(
                     name=nlp.Split.TRAIN,
-                    gen_kwargs={"filepath": os.path.join(path, "doqa-v2.1","doqa_dataset",  "doqa-cooking-train-v2.1.json")},
-                )
+                    gen_kwargs={
+                        "filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset", "doqa-cooking-train-v2.1.json")
+                    },
+                ),
             ]
         elif self.config.name == "movies":
             return [
                 nlp.SplitGenerator(
                     name=nlp.Split.TEST,
-                    gen_kwargs={"filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset",  "doqa-movies-test-v2.1.json")},
+                    gen_kwargs={
+                        "filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset", "doqa-movies-test-v2.1.json")
+                    },
                 )
             ]
         elif self.config.name == "travel":
             return [
                 nlp.SplitGenerator(
                     name=nlp.Split.TEST,
-                    gen_kwargs={"filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset", "doqa-travel-test-v2.1.json")},
+                    gen_kwargs={
+                        "filepath": os.path.join(path, "doqa-v2.1", "doqa_dataset", "doqa-travel-test-v2.1.json")
+                    },
                 )
             ]
         else:
@@ -138,7 +158,7 @@ class Doqa(nlp.GeneratorBasedBuilder):
 
     def _generate_examples(self, filepath):
         """Yields examples."""
-        
+
         with open(filepath, encoding="utf-8") as f:
             data = json.load(f)
             for row in data["data"]:
@@ -157,7 +177,7 @@ class Doqa(nlp.GeneratorBasedBuilder):
                         followup = qa["followup"]
                         answer_text = [answer["text"] for answer in answers]
                         answer_start = [answer["answer_start"] for answer in answers]
-                        
+
                         orig_answer_start = [qa["orig_answer"]["answer_start"]]
                         orig_answer_text = [qa["orig_answer"]["text"]]
                         yield id1, {
@@ -171,9 +191,9 @@ class Doqa(nlp.GeneratorBasedBuilder):
                                 "answer_start": answer_start,
                             },
                             "followup": followup,
-                            "yesno":yesno,
-                            "orig_answer":{
+                            "yesno": yesno,
+                            "orig_answer": {
                                 "text": orig_answer_text,
                                 "answer_start": orig_answer_start,
-                        },
+                            },
                         }

--- a/datasets/drop/drop.py
+++ b/datasets/drop/drop.py
@@ -21,9 +21,9 @@ _CITATION = """\
 # TODO(drop):
 _DESCRIPTION = """\
 DROP: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Paragraphs.
-. DROP is a crowdsourced, adversarially-created, 96k-question benchmark, in which a system must resolve references in a 
+. DROP is a crowdsourced, adversarially-created, 96k-question benchmark, in which a system must resolve references in a
 question, perhaps to multiple input positions, and perform discrete operations over them (such as addition, counting, or
- sorting). These operations require a much more comprehensive understanding of the content of paragraphs than what was 
+ sorting). These operations require a much more comprehensive understanding of the content of paragraphs than what was
  necessary for prior datasets.
 """
 _URl = "https://s3-us-west-2.amazonaws.com/allennlp/datasets/drop/drop_dataset.zip"

--- a/datasets/eli5/eli5.py
+++ b/datasets/eli5/eli5.py
@@ -250,9 +250,9 @@ class Eli5Config(nlp.BuilderConfig):
 
     def __init__(self, **kwargs):
         """BuilderConfig for ExplainLikeImFive.
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(Eli5Config, self).__init__(**kwargs)
 
 
@@ -309,33 +309,40 @@ class Eli5(nlp.GeneratorBasedBuilder):
         self.data_split = json.load(open(fpath_splits))
         return [
             nlp.SplitGenerator(
-                name=nlp.Split("train_eli5"), gen_kwargs={"split": "train", "subreddit_name": "explainlikeimfive"},
+                name=nlp.Split("train_eli5"),
+                gen_kwargs={"split": "train", "subreddit_name": "explainlikeimfive"},
             ),
             nlp.SplitGenerator(
                 name=nlp.Split("validation_eli5"),
                 gen_kwargs={"split": "validation", "subreddit_name": "explainlikeimfive"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split("test_eli5"), gen_kwargs={"split": "test", "subreddit_name": "explainlikeimfive"},
+                name=nlp.Split("test_eli5"),
+                gen_kwargs={"split": "test", "subreddit_name": "explainlikeimfive"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split("train_asks"), gen_kwargs={"split": "train", "subreddit_name": "askscience"},
+                name=nlp.Split("train_asks"),
+                gen_kwargs={"split": "train", "subreddit_name": "askscience"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split("validation_asks"), gen_kwargs={"split": "validation", "subreddit_name": "askscience"},
+                name=nlp.Split("validation_asks"),
+                gen_kwargs={"split": "validation", "subreddit_name": "askscience"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split("test_asks"), gen_kwargs={"split": "test", "subreddit_name": "askscience"},
+                name=nlp.Split("test_asks"),
+                gen_kwargs={"split": "test", "subreddit_name": "askscience"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split("train_askh"), gen_kwargs={"split": "train", "subreddit_name": "AskHistorians"},
+                name=nlp.Split("train_askh"),
+                gen_kwargs={"split": "train", "subreddit_name": "AskHistorians"},
             ),
             nlp.SplitGenerator(
                 name=nlp.Split("validation_askh"),
                 gen_kwargs={"split": "validation", "subreddit_name": "AskHistorians"},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split("test_askh"), gen_kwargs={"split": "test", "subreddit_name": "AskHistorians"},
+                name=nlp.Split("test_askh"),
+                gen_kwargs={"split": "test", "subreddit_name": "AskHistorians"},
             ),
         ]
 

--- a/datasets/emo/emo.py
+++ b/datasets/emo/emo.py
@@ -37,7 +37,7 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-In this dataset, given a textual dialogue i.e. an utterance along with two previous turns of context, the goal was to infer the underlying emotion of the utterance by choosing from four emotion classes - Happy, Sad, Angry and Others. 
+In this dataset, given a textual dialogue i.e. an utterance along with two previous turns of context, the goal was to infer the underlying emotion of the utterance by choosing from four emotion classes - Happy, Sad, Angry and Others.
 """
 
 
@@ -46,9 +46,9 @@ class EmoConfig(nlp.BuilderConfig):
 
     def __init__(self, **kwargs):
         """BuilderConfig for EmoContext.
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(EmoConfig, self).__init__(**kwargs)
 
 
@@ -62,7 +62,11 @@ class Emo(nlp.GeneratorBasedBuilder):
     VERSION = nlp.Version("1.0.0")
 
     BUILDER_CONFIGS = [
-        EmoConfig(name="emo2019", version=nlp.Version("1.0.0"), description="Plain text",),
+        EmoConfig(
+            name="emo2019",
+            version=nlp.Version("1.0.0"),
+            description="Plain text",
+        ),
     ]
 
     def _info(self):
@@ -89,8 +93,17 @@ class Emo(nlp.GeneratorBasedBuilder):
         dl_train = dl_manager.download_and_extract(self._get_drive_url(_TRAIN_URL))
         dl_test = dl_manager.download_and_extract(self._get_drive_url(_TEST_URL))
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepath": dl_train, "split": "train",},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"filepath": dl_test, "split": "test"},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={
+                    "filepath": dl_train,
+                    "split": "train",
+                },
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"filepath": dl_test, "split": "test"},
+            ),
         ]
 
     def _generate_examples(self, filepath, split):

--- a/datasets/emotion/emotion.py
+++ b/datasets/emotion/emotion.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import csv
-import os
 
 import nlp
 

--- a/datasets/esnli/esnli.py
+++ b/datasets/esnli/esnli.py
@@ -53,7 +53,11 @@ class Esnli(nlp.GeneratorBasedBuilder):
     # splits only.
     # 0.0.1 Initial version
     BUILDER_CONFIGS = [
-        nlp.BuilderConfig(name="plain_text", version=nlp.Version("0.0.2"), description="Plain text import of e-SNLI",)
+        nlp.BuilderConfig(
+            name="plain_text",
+            version=nlp.Version("0.0.2"),
+            description="Plain text import of e-SNLI",
+        )
     ]
 
     def _info(self):
@@ -86,9 +90,18 @@ class Esnli(nlp.GeneratorBasedBuilder):
         )
 
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"files": files["train"]},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"files": files["validation"]},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"files": files["test"]},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"files": files["train"]},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"files": files["validation"]},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"files": files["test"]},
+            ),
         ]
 
     def _generate_examples(self, files):

--- a/datasets/fever/fever.py
+++ b/datasets/fever/fever.py
@@ -105,7 +105,14 @@ class Fever(nlp.GeneratorBasedBuilder):
         if self.config.name == "v2.0":
             urls = "https://s3-eu-west-1.amazonaws.com/fever.public/fever2-fixers-dev.jsonl"
             dl_path = dl_manager.download_and_extract(urls)
-            return [nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"filepath": dl_path,},)]
+            return [
+                nlp.SplitGenerator(
+                    name=nlp.Split.VALIDATION,
+                    gen_kwargs={
+                        "filepath": dl_path,
+                    },
+                )
+            ]
         elif self.config.name == "v1.0":
             urls = {
                 "train": "https://s3-eu-west-1.amazonaws.com/fever.public/train.jsonl",
@@ -117,12 +124,42 @@ class Fever(nlp.GeneratorBasedBuilder):
             }
             dl_path = dl_manager.download_and_extract(urls)
             return [
-                nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepath": dl_path["train"],},),
-                nlp.SplitGenerator(name="unlabelled_test", gen_kwargs={"filepath": dl_path["unlabelled_test"],},),
-                nlp.SplitGenerator(name="unlabelled_dev", gen_kwargs={"filepath": dl_path["unlabelled_dev"],},),
-                nlp.SplitGenerator(name="labelled_dev", gen_kwargs={"filepath": dl_path["labelled_dev"],},),
-                nlp.SplitGenerator(name="paper_dev", gen_kwargs={"filepath": dl_path["paper_dev"],},),
-                nlp.SplitGenerator(name="paper_test", gen_kwargs={"filepath": dl_path["paper_test"],},),
+                nlp.SplitGenerator(
+                    name=nlp.Split.TRAIN,
+                    gen_kwargs={
+                        "filepath": dl_path["train"],
+                    },
+                ),
+                nlp.SplitGenerator(
+                    name="unlabelled_test",
+                    gen_kwargs={
+                        "filepath": dl_path["unlabelled_test"],
+                    },
+                ),
+                nlp.SplitGenerator(
+                    name="unlabelled_dev",
+                    gen_kwargs={
+                        "filepath": dl_path["unlabelled_dev"],
+                    },
+                ),
+                nlp.SplitGenerator(
+                    name="labelled_dev",
+                    gen_kwargs={
+                        "filepath": dl_path["labelled_dev"],
+                    },
+                ),
+                nlp.SplitGenerator(
+                    name="paper_dev",
+                    gen_kwargs={
+                        "filepath": dl_path["paper_dev"],
+                    },
+                ),
+                nlp.SplitGenerator(
+                    name="paper_test",
+                    gen_kwargs={
+                        "filepath": dl_path["paper_test"],
+                    },
+                ),
             ]
         elif self.config.name == "wiki_pages":
             urls = "https://s3-eu-west-1.amazonaws.com/fever.public/wiki-pages.zip"
@@ -130,7 +167,12 @@ class Fever(nlp.GeneratorBasedBuilder):
             files = sorted(os.listdir(os.path.join(dl_path, "wiki-pages")))
             file_paths = [os.path.join(dl_path, "wiki-pages", file) for file in files]
             return [
-                nlp.SplitGenerator(name="wikipedia_pages", gen_kwargs={"filepath": file_paths,},),
+                nlp.SplitGenerator(
+                    name="wikipedia_pages",
+                    gen_kwargs={
+                        "filepath": file_paths,
+                    },
+                ),
             ]
         else:
             raise ValueError("config name not found")

--- a/datasets/fever/fever.py
+++ b/datasets/fever/fever.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import logging
 import os
 
 import nlp

--- a/datasets/flores/flores.py
+++ b/datasets/flores/flores.py
@@ -52,13 +52,13 @@ class FloresConfig(nlp.BuilderConfig):
     def __init__(self, language_pair=(None, None), **kwargs):
         """BuilderConfig for FLoRes.
 
-    Args:
-        for the `nlp.features.text.TextEncoder` used for the features feature.
-      language_pair: pair of languages that will be used for translation. Should
-        contain 2-letter coded strings. First will be used at source and second
-        as target in supervised mode. For example: ("se", "en").
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+            for the `nlp.features.text.TextEncoder` used for the features feature.
+          language_pair: pair of languages that will be used for translation. Should
+            contain 2-letter coded strings. First will be used at source and second
+            as target in supervised mode. For example: ("se", "en").
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s%s" % (language_pair[0], language_pair[1])
 
         description = ("Translation dataset from %s to %s") % (language_pair[0], language_pair[1])
@@ -82,8 +82,12 @@ class Flores(nlp.GeneratorBasedBuilder):
     """FLoRes machine translation dataset."""
 
     BUILDER_CONFIGS = [
-        FloresConfig(language_pair=("ne", "en"),),
-        FloresConfig(language_pair=("si", "en"),),
+        FloresConfig(
+            language_pair=("ne", "en"),
+        ),
+        FloresConfig(
+            language_pair=("si", "en"),
+        ),
     ]
 
     def _info(self):

--- a/datasets/gap/gap.py
+++ b/datasets/gap/gap.py
@@ -57,9 +57,9 @@ _TESTURL = "https://raw.githubusercontent.com/google-research-datasets/gap-coref
 class Gap(nlp.GeneratorBasedBuilder):
     """GAP is a gender-balanced dataset.
 
-  It contains 8,908 coreference-labeled pairs
-  of (ambiguous pronoun, antecedent name), sampled from Wikipedia.
-  """
+    It contains 8,908 coreference-labeled pairs
+    of (ambiguous pronoun, antecedent name), sampled from Wikipedia.
+    """
 
     VERSION = nlp.Version("0.1.0")
 
@@ -92,9 +92,18 @@ class Gap(nlp.GeneratorBasedBuilder):
             {"train": _TRAINURL, "validation": _VALIDATIONURL, "test": _TESTURL}
         )
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepath": directory["train"]},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"filepath": directory["validation"]},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"filepath": directory["test"]},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"filepath": directory["train"]},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"filepath": directory["validation"]},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"filepath": directory["test"]},
+            ),
         ]
 
     def _generate_examples(self, filepath):

--- a/datasets/gap/gap.py
+++ b/datasets/gap/gap.py
@@ -43,9 +43,9 @@ _CITATION = """
 """
 
 _DESCRIPTION = """
-GAP is a gender-balanced dataset containing 8,908 coreference-labeled pairs of 
-(ambiguous pronoun, antecedent name), sampled from Wikipedia and released by 
-Google AI Language for the evaluation of coreference resolution in practical 
+GAP is a gender-balanced dataset containing 8,908 coreference-labeled pairs of
+(ambiguous pronoun, antecedent name), sampled from Wikipedia and released by
+Google AI Language for the evaluation of coreference resolution in practical
 applications.
 """
 

--- a/datasets/germeval_14/germeval_14.py
+++ b/datasets/germeval_14/germeval_14.py
@@ -62,9 +62,9 @@ class GermEval14Config(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for GermEval 2014.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(GermEval14Config, self).__init__(**kwargs)
 
 

--- a/datasets/glue/glue.py
+++ b/datasets/glue/glue.py
@@ -49,7 +49,10 @@ _MRPC_TRAIN = "https://dl.fbaipublicfiles.com/senteval/senteval_data/msr_paraphr
 _MRPC_TEST = "https://dl.fbaipublicfiles.com/senteval/senteval_data/msr_paraphrase_test.txt"
 
 _MNLI_BASE_KWARGS = dict(
-    text_features={"premise": "sentence1", "hypothesis": "sentence2",},
+    text_features={
+        "premise": "sentence1",
+        "hypothesis": "sentence2",
+    },
     label_classes=["entailment", "neutral", "contradiction"],
     label_column="gold_label",
     data_url="https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FMNLI.zip?alt=media&token=50329ea1-e339-40e2-809c-10c40afff3ce",
@@ -101,23 +104,23 @@ class GlueConfig(nlp.BuilderConfig):
     ):
         """BuilderConfig for GLUE.
 
-    Args:
-      text_features: `dict[string, string]`, map from the name of the feature
-        dict for each text field to the name of the column in the tsv file
-      label_column: `string`, name of the column in the tsv file corresponding
-        to the label
-      data_url: `string`, url to download the zip file from
-      data_dir: `string`, the path to the folder containing the tsv files in the
-        downloaded zip
-      citation: `string`, citation for the data set
-      url: `string`, url for information about the data set
-      label_classes: `list[string]`, the list of classes if the label is
-        categorical. If not provided, then the label will be of type
-        `nlp.Value('float32')`.
-      process_label: `Function[string, any]`, function  taking in the raw value
-        of the label and processing it to the form required by the label feature
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          text_features: `dict[string, string]`, map from the name of the feature
+            dict for each text field to the name of the column in the tsv file
+          label_column: `string`, name of the column in the tsv file corresponding
+            to the label
+          data_url: `string`, url to download the zip file from
+          data_dir: `string`, the path to the folder containing the tsv files in the
+            downloaded zip
+          citation: `string`, citation for the data set
+          url: `string`, url for information about the data set
+          label_classes: `list[string]`, the list of classes if the label is
+            categorical. If not provided, then the label will be of type
+            `nlp.Value('float32')`.
+          process_label: `Function[string, any]`, function  taking in the raw value
+            of the label and processing it to the form required by the label feature
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(GlueConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -218,7 +221,10 @@ class Glue(nlp.GeneratorBasedBuilder):
             community question-answering website Quora. The task is to determine whether a
             pair of questions are semantically equivalent."""
             ),
-            text_features={"question1": "question1", "question2": "question2",},
+            text_features={
+                "question1": "question1",
+                "question2": "question2",
+            },
             label_classes=["not_duplicate", "duplicate"],
             label_column="is_duplicate",
             data_url="https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FQQP.zip?alt=media&token=700c6acf-160d-4d89-81d1-de4191d02cb5",
@@ -244,7 +250,10 @@ class Glue(nlp.GeneratorBasedBuilder):
             language inference data. Each pair is human-annotated with a similarity score
             from 1 to 5."""
             ),
-            text_features={"sentence1": "sentence1", "sentence2": "sentence2",},
+            text_features={
+                "sentence1": "sentence1",
+                "sentence2": "sentence2",
+            },
             label_column="score",
             data_url="https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FSTS-B.zip?alt=media&token=bddb94a7-8706-4e0d-a694-1109e12273b5",
             data_dir="STS-B",
@@ -307,7 +316,10 @@ class Glue(nlp.GeneratorBasedBuilder):
             the model select the exact answer, but also removes the simplifying assumptions that the answer
             is always present in the input and that lexical overlap is a reliable cue."""
             ),  # pylint: disable=line-too-long
-            text_features={"question": "question", "sentence": "sentence",},
+            text_features={
+                "question": "question",
+                "sentence": "sentence",
+            },
             label_classes=["entailment", "not_entailment"],
             label_column="label",
             data_url="https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FQNLIv2.zip?alt=media&token=6fdcf570-0fc5-4631-8456-9505272d1601",
@@ -333,7 +345,10 @@ class Glue(nlp.GeneratorBasedBuilder):
             constructed based on news and Wikipedia text. We convert all datasets to a two-class split, where
             for three-class datasets we collapse neutral and contradiction into not entailment, for consistency."""
             ),  # pylint: disable=line-too-long
-            text_features={"sentence1": "sentence1", "sentence2": "sentence2",},
+            text_features={
+                "sentence1": "sentence1",
+                "sentence2": "sentence2",
+            },
             label_classes=["entailment", "not_entailment"],
             label_column="label",
             data_url="https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FRTE.zip?alt=media&token=5efa7e85-a0bb-4f19-8ea2-9e1840f077fb",
@@ -395,7 +410,10 @@ class Glue(nlp.GeneratorBasedBuilder):
             between a model's score on this task and its score on the unconverted original task. We
             call converted dataset WNLI (Winograd NLI)."""
             ),
-            text_features={"sentence1": "sentence1", "sentence2": "sentence2",},
+            text_features={
+                "sentence1": "sentence1",
+                "sentence2": "sentence2",
+            },
             label_classes=["not_entailment", "entailment"],
             label_column="label",
             data_url="https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FWNLI.zip?alt=media&token=068ad0a0-ded7-4bd7-99a5-5e00222e0faf",
@@ -421,7 +439,10 @@ class Glue(nlp.GeneratorBasedBuilder):
             Inference (NLI) problems. Use a model trained on MulitNLI to produce
             predictions for this dataset."""
             ),
-            text_features={"premise": "sentence1", "hypothesis": "sentence2",},
+            text_features={
+                "premise": "sentence1",
+                "hypothesis": "sentence2",
+            },
             label_classes=["entailment", "neutral", "contradiction"],
             label_column="",  # No label since we only have test set.
             # We must use a URL shortener since the URL from GLUE is very long and
@@ -450,11 +471,25 @@ class Glue(nlp.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         if self.config.name == "ax":
             data_file = dl_manager.download(self.config.data_url)
-            return [nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"data_file": data_file, "split": "test",})]
+            return [
+                nlp.SplitGenerator(
+                    name=nlp.Split.TEST,
+                    gen_kwargs={
+                        "data_file": data_file,
+                        "split": "test",
+                    },
+                )
+            ]
 
         if self.config.name == "mrpc":
             data_dir = None
-            mrpc_files = dl_manager.download({"dev_ids": _MRPC_DEV_IDS, "train": _MRPC_TRAIN, "test": _MRPC_TEST,})
+            mrpc_files = dl_manager.download(
+                {
+                    "dev_ids": _MRPC_DEV_IDS,
+                    "train": _MRPC_TRAIN,
+                    "test": _MRPC_TEST,
+                }
+            )
         else:
             dl_dir = dl_manager.download_and_extract(self.config.data_url)
             data_dir = os.path.join(dl_dir, self.config.data_dir)

--- a/datasets/guardian_authorship/guardian_authorship.py
+++ b/datasets/guardian_authorship/guardian_authorship.py
@@ -43,20 +43,20 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-A dataset cross-topic authorship attribution. The dataset is provided by Stamatatos 2013. 
+A dataset cross-topic authorship attribution. The dataset is provided by Stamatatos 2013.
 1- The cross-topic scenarios are based on Table-4 in Stamatatos 2017 (Ex. cross_topic_1 => row 1:P S U&W ).
 2- The cross-genre scenarios are based on Table-5 in the same paper. (Ex. cross_genre_1 => row 1:B P S&U&W).
 
-3- The same-topic/genre scenario is created by grouping all the datasts as follows. 
+3- The same-topic/genre scenario is created by grouping all the datasts as follows.
 For ex., to use same_topic and split the data 60-40 use:
-train_ds = load_dataset('guardian_authorship', name="cross_topic_<<#>>", 
+train_ds = load_dataset('guardian_authorship', name="cross_topic_<<#>>",
                         split='train[:60%]+validation[:60%]+test[:60%]')
-tests_ds = load_dataset('guardian_authorship', name="cross_topic_<<#>>", 
-                        split='train[-40%:]+validation[-40%:]+test[-40%:]')            
+tests_ds = load_dataset('guardian_authorship', name="cross_topic_<<#>>",
+                        split='train[-40%:]+validation[-40%:]+test[-40%:]')
 
 IMPORTANT: train+validation+test[:60%] will generate the wrong splits becasue the data is imbalanced
 
-* See https://huggingface.co/nlp/splits.html for detailed/more examples 
+* See https://huggingface.co/nlp/splits.html for detailed/more examples
 """
 
 _URL = "https://www.dropbox.com/s/lc5mje0owl9shms/Guardian.zip?dl=1"

--- a/datasets/hyperpartisan_news_detection/hyperpartisan_news_detection.py
+++ b/datasets/hyperpartisan_news_detection/hyperpartisan_news_detection.py
@@ -18,7 +18,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import glob
 import os
 import textwrap
 import xml.etree.ElementTree as ET

--- a/datasets/imdb/imdb.py
+++ b/datasets/imdb/imdb.py
@@ -54,9 +54,9 @@ class IMDBReviewsConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for IMDBReviews.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(IMDBReviewsConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -65,7 +65,12 @@ class IMDBReviewsConfig(nlp.BuilderConfig):
 class Imdb(nlp.GeneratorBasedBuilder):
     """IMDB movie reviews dataset."""
 
-    BUILDER_CONFIGS = [IMDBReviewsConfig(name="plain_text", description="Plain text",)]
+    BUILDER_CONFIGS = [
+        IMDBReviewsConfig(
+            name="plain_text",
+            description="Plain text",
+        )
+    ]
 
     def _info(self):
         return nlp.DatasetInfo(

--- a/datasets/iwslt2017/iwslt2017.py
+++ b/datasets/iwslt2017/iwslt2017.py
@@ -126,8 +126,18 @@ class IWSLT217(nlp.GeneratorBasedBuilder):
                 name=nlp.Split.TRAIN,
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "source_files": [os.path.join(data_dir, "train.tags.{}.{}".format(self.config.pair, source),)],
-                    "target_files": [os.path.join(data_dir, "train.tags.{}.{}".format(self.config.pair, target),)],
+                    "source_files": [
+                        os.path.join(
+                            data_dir,
+                            "train.tags.{}.{}".format(self.config.pair, source),
+                        )
+                    ],
+                    "target_files": [
+                        os.path.join(
+                            data_dir,
+                            "train.tags.{}.{}".format(self.config.pair, target),
+                        )
+                    ],
                     "split": "train",
                 },
             ),
@@ -136,11 +146,17 @@ class IWSLT217(nlp.GeneratorBasedBuilder):
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
                     "source_files": [
-                        os.path.join(data_dir, "IWSLT17.TED.tst{}.{}.{}.xml".format(year, self.config.pair, source),)
+                        os.path.join(
+                            data_dir,
+                            "IWSLT17.TED.tst{}.{}.{}.xml".format(year, self.config.pair, source),
+                        )
                         for year in years
                     ],
                     "target_files": [
-                        os.path.join(data_dir, "IWSLT17.TED.tst{}.{}.{}.xml".format(year, self.config.pair, target),)
+                        os.path.join(
+                            data_dir,
+                            "IWSLT17.TED.tst{}.{}.{}.xml".format(year, self.config.pair, target),
+                        )
                         for year in years
                     ],
                     "split": "test",
@@ -151,10 +167,16 @@ class IWSLT217(nlp.GeneratorBasedBuilder):
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
                     "source_files": [
-                        os.path.join(data_dir, "IWSLT17.TED.dev2010.{}.{}.xml".format(self.config.pair, source),)
+                        os.path.join(
+                            data_dir,
+                            "IWSLT17.TED.dev2010.{}.{}.xml".format(self.config.pair, source),
+                        )
                     ],
                     "target_files": [
-                        os.path.join(data_dir, "IWSLT17.TED.dev2010.{}.{}.xml".format(self.config.pair, target),)
+                        os.path.join(
+                            data_dir,
+                            "IWSLT17.TED.dev2010.{}.{}.xml".format(self.config.pair, target),
+                        )
                     ],
                     "split": "dev",
                 },

--- a/datasets/jeopardy/jeopardy.py
+++ b/datasets/jeopardy/jeopardy.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import os
 
 import nlp
 
@@ -53,7 +52,6 @@ class Jeopardy(nlp.GeneratorBasedBuilder):
                     "value": nlp.Value("int32"),
                     "answer": nlp.Value("string"),
                     "round": nlp.Value("string"),
-                    "category": nlp.Value("string"),
                     "show_number": nlp.Value("int32"),
                     # These are the features of your dataset like images, labels ...
                 }

--- a/datasets/json/json.py
+++ b/datasets/json/json.py
@@ -41,8 +41,7 @@ class Json(nlp.ArrowBasedBuilder):
         return nlp.DatasetInfo(features=self.config.features)
 
     def _split_generators(self, dl_manager):
-        """ We handle string, list and dicts in datafiles
-        """
+        """We handle string, list and dicts in datafiles"""
         if not self.config.data_files:
             raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
         data_files = dl_manager.download_and_extract(self.config.data_files)
@@ -81,7 +80,9 @@ class Json(nlp.ArrowBasedBuilder):
             else:
                 try:
                     pa_table = paj.read_json(
-                        file, read_options=self.config.pa_read_options, parse_options=self.config.pa_parse_options,
+                        file,
+                        read_options=self.config.pa_read_options,
+                        parse_options=self.config.pa_parse_options,
                     )
                 except pa.ArrowInvalid:
                     with open(file, encoding="utf-8") as f:

--- a/datasets/json/json.py
+++ b/datasets/json/json.py
@@ -3,7 +3,6 @@
 import json
 from dataclasses import dataclass
 from io import BytesIO
-from typing import List, Union
 
 import pyarrow as pa
 import pyarrow.json as paj

--- a/datasets/kor_nli/kor_nli.py
+++ b/datasets/kor_nli/kor_nli.py
@@ -30,10 +30,10 @@ class KorNLIConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for KorNLI.
 
-    Args:
+        Args:
 
-      **kwargs: keyword arguments forwarded to super.
-    """
+          **kwargs: keyword arguments forwarded to super.
+        """
         # Version 1.1.0 remove empty document and summary strings.
         super(KorNLIConfig, self).__init__(version=nlp.Version("1.0.0"), **kwargs)
 

--- a/datasets/librispeech_lm/librispeech_lm.py
+++ b/datasets/librispeech_lm/librispeech_lm.py
@@ -49,7 +49,11 @@ class LibrispeechLm(nlp.GeneratorBasedBuilder):
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({"text": nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    "text": nlp.Value("string"),
+                }
+            ),
             supervised_keys=("text", "text"),
             homepage=_URL,
             citation=_CITATION,

--- a/datasets/lince/lince.py
+++ b/datasets/lince/lince.py
@@ -293,7 +293,9 @@ class Lince(nlp.GeneratorBasedBuilder):
             name="lid_msaea",
             data_dir="lid_msaea",
             colnames={"tokens": 0, "lid": 1},
-            classes={"lid": ["ambiguous", "lang1", "lang2", "mixed", "ne", "other"],},
+            classes={
+                "lid": ["ambiguous", "lang1", "lang2", "mixed", "ne", "other"],
+            },
             label_column="lid",
             description="Modern Standard Arabic-Egyptian Arabic language identification dataset (Persian script)",
         ),
@@ -301,7 +303,9 @@ class Lince(nlp.GeneratorBasedBuilder):
             name="lid_nepeng",
             data_dir="lid_nepeng",
             colnames={"tokens": 0, "lid": 1},
-            classes={"lid": ["ambiguous", "lang1", "lang2", "mixed", "ne", "other"],},
+            classes={
+                "lid": ["ambiguous", "lang1", "lang2", "mixed", "ne", "other"],
+            },
             label_column="lid",
             description="Nepali-English language identification dataset (Latin script)",
         ),
@@ -481,11 +485,17 @@ class Lince(nlp.GeneratorBasedBuilder):
         return [
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
-                gen_kwargs={"filepath": os.path.join(data_dir, "train.conll"), "colnames": self.config.colnames,},
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "train.conll"),
+                    "colnames": self.config.colnames,
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION,
-                gen_kwargs={"filepath": os.path.join(data_dir, "dev.conll"), "colnames": self.config.colnames,},
+                gen_kwargs={
+                    "filepath": os.path.join(data_dir, "dev.conll"),
+                    "colnames": self.config.colnames,
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.TEST,

--- a/datasets/lince/lince.py
+++ b/datasets/lince/lince.py
@@ -8,7 +8,6 @@ import re
 import textwrap
 from itertools import groupby
 
-import numpy as np
 import six
 
 import nlp
@@ -35,7 +34,7 @@ Note that each LinCE dataset has its own citation. Please see the source to see
 the correct citation for each contained dataset."""
 
 _DESCRIPTION = """\
-LinCE is a centralized Linguistic Code-switching Evaluation benchmark 
+LinCE is a centralized Linguistic Code-switching Evaluation benchmark
 (https://ritual.uh.edu/lince/) that contains data for training and evaluating
 NLP systems on code-switching tasks.
 """
@@ -187,7 +186,7 @@ _DATASET_CITATIONS = {
            publisher = "Association for Computational Linguistics",
            url = "https://www.aclweb.org/anthology/W18-3219",
            pages = "138--147"
-        }  
+        }
         """
     ),
     "ner_msaea": textwrap.dedent(
@@ -207,7 +206,7 @@ _DATASET_CITATIONS = {
            publisher = "Association for Computational Linguistics",
            url = "https://www.aclweb.org/anthology/W18-3219",
            pages = "138--147"
-        }  
+        }
         """
     ),
     "ner_hineng": textwrap.dedent(
@@ -240,7 +239,7 @@ _DATASET_CITATIONS = {
                   Garrette, Dan and
                   Gamb{\"a}ck, Bj{\"o}rn and
                   Chakraborty, Tanmoy and
-                  Solorio, Thamar and  
+                  Solorio, Thamar and
                   Das, Amitava",
           booktitle = "Proceedings of the 14th International Workshop on Semantic Evaluation ({S}em{E}val-2020)",
           year = 2020,

--- a/datasets/lm1b/lm1b.py
+++ b/datasets/lm1b/lm1b.py
@@ -64,9 +64,9 @@ class Lm1bConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for Lm1b.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(Lm1bConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -84,7 +84,10 @@ class Lm1b(nlp.GeneratorBasedBuilder):
     """1 Billion Word Language Model Benchmark dataset."""
 
     BUILDER_CONFIGS = [
-        Lm1bConfig(name="plain_text", description="Plain text",),
+        Lm1bConfig(
+            name="plain_text",
+            description="Plain text",
+        ),
     ]
 
     def _info(self):

--- a/datasets/math_dataset/math_dataset.py
+++ b/datasets/math_dataset/math_dataset.py
@@ -192,7 +192,13 @@ def _generate_builder_configs():
     """Generate configs with different subsets of mathematics dataset."""
     configs = []
     for module in sorted(set(_MODULES)):
-        configs.append(nlp.BuilderConfig(name=module, version=nlp.Version("1.0.0"), description=_DESCRIPTION,))
+        configs.append(
+            nlp.BuilderConfig(
+                name=module,
+                version=nlp.Version("1.0.0"),
+                description=_DESCRIPTION,
+            )
+        )
 
     return configs
 
@@ -205,7 +211,12 @@ class MathDataset(nlp.GeneratorBasedBuilder):
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({_QUESTION: nlp.Value("string"), _ANSWER: nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    _QUESTION: nlp.Value("string"),
+                    _ANSWER: nlp.Value("string"),
+                }
+            ),
             supervised_keys=(_QUESTION, _ANSWER),
             homepage="https://github.com/deepmind/mathematics_dataset",
             citation=_CITATION,
@@ -236,11 +247,19 @@ class MathDataset(nlp.GeneratorBasedBuilder):
         return [
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
-                gen_kwargs={"directory": directory, "config": config, "categories": _TRAIN_CATEGORY,},
+                gen_kwargs={
+                    "directory": directory,
+                    "config": config,
+                    "categories": _TRAIN_CATEGORY,
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.TEST,
-                gen_kwargs={"directory": directory, "config": config, "categories": _INTERPOLATE_CATEGORY,},
+                gen_kwargs={
+                    "directory": directory,
+                    "config": config,
+                    "categories": _INTERPOLATE_CATEGORY,
+                },
             ),
         ]
 

--- a/datasets/mlqa/mlqa.py
+++ b/datasets/mlqa/mlqa.py
@@ -41,7 +41,12 @@ class MlqaConfig(nlp.BuilderConfig):
           data_url: `string`, url to the dataset
           **kwargs: keyword arguments forwarded to super.
         """
-        super(MlqaConfig, self).__init__(version=nlp.Version("1.0.0",), **kwargs)
+        super(MlqaConfig, self).__init__(
+            version=nlp.Version(
+                "1.0.0",
+            ),
+            **kwargs,
+        )
         self.data_url = data_url
 
 

--- a/datasets/mlqa/mlqa.py
+++ b/datasets/mlqa/mlqa.py
@@ -22,7 +22,7 @@ _CITATION = """\
 _DESCRIPTION = """\
     MLQA (MultiLingual Question Answering) is a benchmark dataset for evaluating cross-lingual question answering performance.
     MLQA consists of over 5K extractive QA instances (12K in English) in SQuAD format in seven languages - English, Arabic,
-    German, Spanish, Hindi, Vietnamese and Simplified Chinese. MLQA is highly parallel, with QA instances parallel between 
+    German, Spanish, Hindi, Vietnamese and Simplified Chinese. MLQA is highly parallel, with QA instances parallel between
     4 different languages on average.
 """
 _URL = "https://dl.fbaipublicfiles.com/MLQA/"

--- a/datasets/mlsum/mlsum.py
+++ b/datasets/mlsum/mlsum.py
@@ -16,11 +16,11 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-We present MLSUM, the first large-scale MultiLingual SUMmarization dataset. 
-Obtained from online newspapers, it contains 1.5M+ article/summary pairs in five different languages -- namely, French, German, Spanish, Russian, Turkish. 
-Together with English newspapers from the popular CNN/Daily mail dataset, the collected data form a large scale multilingual dataset which can enable new research directions for the text summarization community. 
-We report cross-lingual comparative analyses based on state-of-the-art systems. 
-These highlight existing biases which motivate the use of a multi-lingual dataset. 
+We present MLSUM, the first large-scale MultiLingual SUMmarization dataset.
+Obtained from online newspapers, it contains 1.5M+ article/summary pairs in five different languages -- namely, French, German, Spanish, Russian, Turkish.
+Together with English newspapers from the popular CNN/Daily mail dataset, the collected data form a large scale multilingual dataset which can enable new research directions for the text summarization community.
+We report cross-lingual comparative analyses based on state-of-the-art systems.
+These highlight existing biases which motivate the use of a multi-lingual dataset.
 """
 _URL = "https://gitlab.lip6.fr/scialom/mlsum_data/-/raw/master/MLSUM/"
 _LANG = ["de", "es", "fr", "ru", "tu"]

--- a/datasets/mlsum/mlsum.py
+++ b/datasets/mlsum/mlsum.py
@@ -28,23 +28,20 @@ _LANG = ["de", "es", "fr", "ru", "tu"]
 
 class Mlsum(nlp.GeneratorBasedBuilder):
 
-    BUILDER_CONFIGS = (
-        [
-            nlp.BuilderConfig(
-                name=lang,
-                version=nlp.Version("1.0.0"),
-                description="",
-            )
-            for lang in _LANG
-        ]
-    )
+    BUILDER_CONFIGS = [
+        nlp.BuilderConfig(
+            name=lang,
+            version=nlp.Version("1.0.0"),
+            description="",
+        )
+        for lang in _LANG
+    ]
 
     def _info(self):
         return nlp.DatasetInfo(
             # This is the description that will appear on the datasets page.
             description=_DESCRIPTION,
             # nlp.features.FeatureConnectors
-
             features=nlp.Features(
                 {
                     "text": nlp.Value("string"),
@@ -52,7 +49,7 @@ class Mlsum(nlp.GeneratorBasedBuilder):
                     "topic": nlp.Value("string"),
                     "url": nlp.Value("string"),
                     "title": nlp.Value("string"),
-                    "date":nlp.Value("string")
+                    "date": nlp.Value("string")
                     # These are the features of your dataset like images, labels ...
                 }
             ),
@@ -69,54 +66,54 @@ class Mlsum(nlp.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
         # dl_manager is a nlp.download.DownloadManager that can be used to
         # download and extract URLs
-        
+
         lang = str(self.config.name)
         urls_to_download = {
-            "test": os.path.join(_URL, lang+"_test.zip"),
-            "train": os.path.join(_URL, lang+"_train.zip"),
-            "validation": os.path.join(_URL, lang+"_val.zip")
+            "test": os.path.join(_URL, lang + "_test.zip"),
+            "train": os.path.join(_URL, lang + "_train.zip"),
+            "validation": os.path.join(_URL, lang + "_val.zip"),
         }
         downloaded_files = dl_manager.download_and_extract(urls_to_download)
 
         return [
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
-                    # These kwargs will be passed to _generate_examples
+                # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(downloaded_files["train"], lang+'_train.jsonl'),
+                    "filepath": os.path.join(downloaded_files["train"], lang + "_train.jsonl"),
                     "lang": lang,
                 },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION,
-                    # These kwargs will be passed to _generate_examples
+                # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(downloaded_files["validation"], lang+'_val.jsonl'),
+                    "filepath": os.path.join(downloaded_files["validation"], lang + "_val.jsonl"),
                     "lang": lang,
                 },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.TEST,
-                    # These kwargs will be passed to _generate_examples
+                # These kwargs will be passed to _generate_examples
                 gen_kwargs={
-                    "filepath": os.path.join(downloaded_files["test"], lang+'_test.jsonl'),
+                    "filepath": os.path.join(downloaded_files["test"], lang + "_test.jsonl"),
                     "lang": lang,
                 },
-            )
+            ),
         ]
 
     def _generate_examples(self, filepath, lang):
         """Yields examples."""
         with open(filepath, encoding="utf-8") as f:
             i = 0
-            for line in f: 
+            for line in f:
                 data = json.loads(line)
-                i +=1
+                i += 1
                 yield i, {
                     "text": data["text"],
                     "summary": data["summary"],
                     "topic": data["topic"],
-                    "url":data['url'],
-                    "title":data["title"],
-                    "date":data["date"]
+                    "url": data["url"],
+                    "title": data["title"],
+                    "date": data["date"],
                 }

--- a/datasets/ms_marco/ms_marco.py
+++ b/datasets/ms_marco/ms_marco.py
@@ -135,9 +135,18 @@ class MsMarco(nlp.GeneratorBasedBuilder):
         else:
             dl_path = dl_manager.download_and_extract(_V1_URLS)
         return [
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"filepath": dl_path["dev"]},),
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepath": dl_path["train"]},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"filepath": dl_path["test"]},),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"filepath": dl_path["dev"]},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"filepath": dl_path["train"]},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"filepath": dl_path["test"]},
+            ),
         ]
 
     def _generate_examples(self, filepath):

--- a/datasets/multi_news/multi_news.py
+++ b/datasets/multi_news/multi_news.py
@@ -69,9 +69,18 @@ class MultiNews(nlp.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
         extract_path = os.path.join(dl_manager.download_and_extract(_URL), "multi-news-original")
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"path": os.path.join(extract_path, "train")},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"path": os.path.join(extract_path, "val")},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"path": os.path.join(extract_path, "test")},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"path": os.path.join(extract_path, "train")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"path": os.path.join(extract_path, "val")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"path": os.path.join(extract_path, "test")},
+            ),
         ]
 
     def _generate_examples(self, path=None):

--- a/datasets/multi_nli/multi_nli.py
+++ b/datasets/multi_nli/multi_nli.py
@@ -59,10 +59,10 @@ class MultiNLIConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for MultiNLI.
 
-    Args:
-.
-      **kwargs: keyword arguments forwarded to super.
-    """
+            Args:
+        .
+              **kwargs: keyword arguments forwarded to super.
+        """
         super(MultiNLIConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -72,7 +72,10 @@ class MultiNli(nlp.GeneratorBasedBuilder):
     """MultiNLI: The Stanford Question Answering Dataset. Version 1.1."""
 
     BUILDER_CONFIGS = [
-        MultiNLIConfig(name="plain_text", description="Plain text",),
+        MultiNLIConfig(
+            name="plain_text",
+            description="Plain text",
+        ),
     ]
 
     def _info(self):
@@ -115,12 +118,12 @@ class MultiNli(nlp.GeneratorBasedBuilder):
     def _generate_examples(self, filepath):
         """Generate mnli examples.
 
-    Args:
-      filepath: a string
+        Args:
+          filepath: a string
 
-    Yields:
-      dictionaries containing "premise", "hypothesis" and "label" strings
-    """
+        Yields:
+          dictionaries containing "premise", "hypothesis" and "label" strings
+        """
         for idx, line in enumerate(open(filepath, "rb")):
             if idx == 0:
                 continue  # skip header

--- a/datasets/multi_nli_mismatch/multi_nli_mismatch.py
+++ b/datasets/multi_nli_mismatch/multi_nli_mismatch.py
@@ -61,10 +61,10 @@ class MultiNLIMismatchConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for MultiNLI Mismatch.
 
-    Args:
+        Args:
 
-      **kwargs: keyword arguments forwarded to super.
-    """
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(MultiNLIMismatchConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -74,14 +74,21 @@ class MultiNliMismatch(nlp.GeneratorBasedBuilder):
     """MultiNLI: The Stanford Question Answering Dataset. Version 1.1."""
 
     BUILDER_CONFIGS = [
-        MultiNLIMismatchConfig(name="plain_text", description="Plain text",),
+        MultiNLIMismatchConfig(
+            name="plain_text",
+            description="Plain text",
+        ),
     ]
 
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
             features=nlp.Features(
-                {"premise": nlp.Value("string"), "hypothesis": nlp.Value("string"), "label": nlp.Value("string"),}
+                {
+                    "premise": nlp.Value("string"),
+                    "hypothesis": nlp.Value("string"),
+                    "label": nlp.Value("string"),
+                }
             ),
             # No default supervised_keys (as we have to pass both premise
             # and hypothesis as input).
@@ -110,12 +117,12 @@ class MultiNliMismatch(nlp.GeneratorBasedBuilder):
     def _generate_examples(self, filepath):
         """Generate mnli mismatch examples.
 
-    Args:
-      filepath: a string
+        Args:
+          filepath: a string
 
-    Yields:
-      dictionaries containing "premise", "hypothesis" and "label" strings
-    """
+        Yields:
+          dictionaries containing "premise", "hypothesis" and "label" strings
+        """
         for idx, line in enumerate(open(filepath, "rb")):
             if idx == 0:
                 continue

--- a/datasets/mwsc/mwsc.py
+++ b/datasets/mwsc/mwsc.py
@@ -59,9 +59,18 @@ class MWSC(nlp.GeneratorBasedBuilder):
             schemas_file = os.path.join(schemas_file, "schema.txt")
 
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepath": schemas_file, "split": "train"},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"filepath": schemas_file, "split": "test"},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"filepath": schemas_file, "split": "dev"},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"filepath": schemas_file, "split": "train"},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"filepath": schemas_file, "split": "test"},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"filepath": schemas_file, "split": "dev"},
+            ),
         ]
 
     def _get_both_schema(self, context):

--- a/datasets/mwsc/mwsc.py
+++ b/datasets/mwsc/mwsc.py
@@ -76,7 +76,7 @@ class MWSC(nlp.GeneratorBasedBuilder):
     def _get_both_schema(self, context):
         """Split [option1/option2] into 2 sentences.
         From https://github.com/salesforce/decaNLP/blob/1e9605f246b9e05199b28bde2a2093bc49feeeaa/text/torchtext/datasets/generic.py#L815-L827"""
-        pattern = "\[.*\]"
+        pattern = r"\[.*\]"
         variations = [x[1:-1].split("/") for x in re.findall(pattern, context)]
         splits = re.split(pattern, context)
         results = []

--- a/datasets/natural_questions/natural_questions.py
+++ b/datasets/natural_questions/natural_questions.py
@@ -117,8 +117,14 @@ class NaturalQuestions(nlp.BeamBasedBuilder):
             files = dl_manager.ship_files_with_pipeline(files, pipeline)
 
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepaths": files["train"]},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"filepaths": files["validation"]},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"filepaths": files["train"]},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"filepaths": files["validation"]},
+            ),
         ]
 
     def _build_pcollection(self, pipeline, filepaths):

--- a/datasets/newsgroup/newsgroup.py
+++ b/datasets/newsgroup/newsgroup.py
@@ -112,7 +112,11 @@ class Newsgroups(nlp.GeneratorBasedBuilder):
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION + "\n" + self.config.description,
-            features=nlp.Features({"text": nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    "text": nlp.Value("string"),
+                }
+            ),
             homepage="http://qwone.com/~jason/20Newsgroups/",
             citation=_CITATION,
         )

--- a/datasets/newsgroup/newsgroup.py
+++ b/datasets/newsgroup/newsgroup.py
@@ -18,7 +18,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import csv
 import os
 
 import nlp
@@ -35,8 +34,8 @@ _CITATION = """
  """
 
 _DESCRIPTION = """
-The 20 Newsgroups data set is a collection of approximately 20,000 newsgroup documents, partitioned (nearly) evenly across 
-20 different newsgroups. The 20 newsgroups collection has become a popular data set for experiments in text applications of 
+The 20 Newsgroups data set is a collection of approximately 20,000 newsgroup documents, partitioned (nearly) evenly across
+20 different newsgroups. The 20 newsgroups collection has become a popular data set for experiments in text applications of
 machine learning techniques, such as text classification and text clustering.
 """
 

--- a/datasets/newsroom/newsroom.py
+++ b/datasets/newsroom/newsroom.py
@@ -118,12 +118,17 @@ class Newsroom(nlp.GeneratorBasedBuilder):
             )
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={"input_file": os.path.join(data_dir, "train.jsonl")},
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"input_file": os.path.join(data_dir, "train.jsonl")},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={"input_file": os.path.join(data_dir, "dev.jsonl")},
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"input_file": os.path.join(data_dir, "dev.jsonl")},
             ),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"input_file": os.path.join(data_dir, "test.jsonl")},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"input_file": os.path.join(data_dir, "test.jsonl")},
+            ),
         ]
 
     def _generate_examples(self, input_file=None):

--- a/datasets/openbookqa/openbookqa.py
+++ b/datasets/openbookqa/openbookqa.py
@@ -35,13 +35,13 @@ _URL = "https://s3-us-west-2.amazonaws.com/ai2-website/data/OpenBookQA-V1-Sep201
 
 class OpenbookqaConfig(nlp.BuilderConfig):
     def __init__(self, data_dir, **kwargs):
-        """ BuilderConfig for openBookQA dataset 
+        """BuilderConfig for openBookQA dataset
 
-      Args:
-        data_dir: directory for the given dataset name
-        **kwargs: keyword arguments forwarded to super.
+        Args:
+          data_dir: directory for the given dataset name
+          **kwargs: keyword arguments forwarded to super.
 
-      """
+        """
 
         super(OpenbookqaConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs

--- a/datasets/openbookqa/openbookqa.py
+++ b/datasets/openbookqa/openbookqa.py
@@ -22,12 +22,12 @@ _CITATION = """\
 # TODO(openBookQA):
 _DESCRIPTION = textwrap.dedent(
     """\
-OpenBookQA aims to promote research in advanced question-answering, probing a deeper understanding of both the topic 
-(with salient facts summarized as an open book, also provided with the dataset) and the language it is expressed in. In 
-particular, it contains questions that require multi-step reasoning, use of additional common and commonsense knowledge, 
+OpenBookQA aims to promote research in advanced question-answering, probing a deeper understanding of both the topic
+(with salient facts summarized as an open book, also provided with the dataset) and the language it is expressed in. In
+particular, it contains questions that require multi-step reasoning, use of additional common and commonsense knowledge,
 and rich text comprehension.
 OpenBookQA is a new kind of question-answering dataset modeled after open book exams for assessing human understanding of
-a subject. 
+a subject.
 """
 )
 _URL = "https://s3-us-west-2.amazonaws.com/ai2-website/data/OpenBookQA-V1-Sep2018.zip"
@@ -60,9 +60,9 @@ class Openbookqa(nlp.GeneratorBasedBuilder):
             name="main",
             description=textwrap.dedent(
                 """
-                                  It consists of 5,957 multiple-choice elementary-level science questions (4,957 train, 500 dev, 500 test), 
-                                  which probe the understanding of a small “book” of 1,326 core science facts and the application of these facts to novel 
-                                  situations. For training, the dataset includes a mapping from each question to the core science fact it was designed to 
+                                  It consists of 5,957 multiple-choice elementary-level science questions (4,957 train, 500 dev, 500 test),
+                                  which probe the understanding of a small “book” of 1,326 core science facts and the application of these facts to novel
+                                  situations. For training, the dataset includes a mapping from each question to the core science fact it was designed to
                                   probe. Answering OpenBookQA questions requires additional broad common knowledge, not contained in the book. The questions,
                                   by design, are answered incorrectly by both a retrieval-based algorithm and a word co-occurrence algorithm. Strong neural
                                   baselines achieve around 50% on OpenBookQA, leaving a large gap to the 92% accuracy of crowd-workers.
@@ -74,8 +74,8 @@ class Openbookqa(nlp.GeneratorBasedBuilder):
             name="additional",
             description=textwrap.dedent(
                 """
-                                  Additionally, we provide 5,167 crowd-sourced common knowledge facts, and an expanded version of the train/dev/test questions where 
-                                  each question is associated with its originating core fact, a human accuracy score, a clarity score, and an anonymized crowd-worker 
+                                  Additionally, we provide 5,167 crowd-sourced common knowledge facts, and an expanded version of the train/dev/test questions where
+                                  each question is associated with its originating core fact, a human accuracy score, a clarity score, and an anonymized crowd-worker
                                   ID (in the “Additional” folder).
                                 """
             ),

--- a/datasets/opinosis/opinosis.py
+++ b/datasets/opinosis/opinosis.py
@@ -65,7 +65,10 @@ class Opinosis(nlp.GeneratorBasedBuilder):
         """Returns SplitGenerators."""
         extract_path = dl_manager.download_and_extract(_URL)
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"path": extract_path},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"path": extract_path},
+            ),
         ]
 
     def _generate_examples(self, path=None):

--- a/datasets/pandas/pandas.py
+++ b/datasets/pandas/pandas.py
@@ -11,8 +11,7 @@ class Pandas(nlp.ArrowBasedBuilder):
         return nlp.DatasetInfo()
 
     def _split_generators(self, dl_manager):
-        """ We handle string, list and dicts in datafiles
-        """
+        """We handle string, list and dicts in datafiles"""
         if not self.config.data_files:
             raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")
         data_files = dl_manager.download_and_extract(self.config.data_files)

--- a/datasets/para_crawl/para_crawl.py
+++ b/datasets/para_crawl/para_crawl.py
@@ -43,9 +43,9 @@ _BASE_DATA_URL_FORMAT_STR = (
 def _target_languages():
     """Create the sorted dictionary of language codes, and language names.
 
-  Returns:
-    The sorted dictionary as an instance of `collections.OrderedDict`.
-  """
+    Returns:
+      The sorted dictionary as an instance of `collections.OrderedDict`.
+    """
     langs = {
         "bg": "Bulgarian",
         "cs": "Czech",
@@ -80,13 +80,13 @@ class ParaCrawlConfig(nlp.BuilderConfig):
     def __init__(self, target_language=None, **kwargs):
         """BuilderConfig for ParaCrawl.
 
-    Args:
-        for the `nlp.features.text.TextEncoder` used for the features feature.
-      target_language: Target language that will be used to translate to from
-        English which is always the source language. It has to contain 2-letter
-        coded strings. For example: "se", "hu".
-      **kwargs: Keyword arguments forwarded to super.
-    """
+        Args:
+            for the `nlp.features.text.TextEncoder` used for the features feature.
+          target_language: Target language that will be used to translate to from
+            English which is always the source language. It has to contain 2-letter
+            coded strings. For example: "se", "hu".
+          **kwargs: Keyword arguments forwarded to super.
+        """
         # Validate the target language.
         if target_language not in _target_languages():
             raise ValueError("Invalid target language: %s " % target_language)
@@ -113,7 +113,8 @@ class ParaCrawl(nlp.GeneratorBasedBuilder):
         # The version below does not refer to the version of the released
         # database. It only indicates the version of the TFDS integration.
         ParaCrawlConfig(  # pylint: disable=g-complex-comprehension
-            target_language=target_language, version=nlp.Version("1.0.0"),
+            target_language=target_language,
+            version=nlp.Version("1.0.0"),
         )
         for target_language in _target_languages()
     ]

--- a/datasets/pg19/pg19.py
+++ b/datasets/pg19/pg19.py
@@ -44,7 +44,9 @@ _STORAGE_API_ROOT_URL = "https://storage.googleapis.com/storage/v1/b/deepmind-gu
 
 _METADATA_URL = os.path.join(_ASSET_ROOT_URL, "metadata.csv")
 
-flat_map = lambda fn, arr: [el for sub_arr in map(fn, arr) for el in sub_arr]
+
+def flat_map(fn, arr):
+    return [el for sub_arr in map(fn, arr) for el in sub_arr]
 
 
 class Pg19(nlp.GeneratorBasedBuilder):

--- a/datasets/piaf/piaf.py
+++ b/datasets/piaf/piaf.py
@@ -52,9 +52,9 @@ class PiafConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for PIAF.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(PiafConfig, self).__init__(**kwargs)
 
 
@@ -82,7 +82,10 @@ class Piaf(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                 }
             ),
@@ -124,5 +127,8 @@ class Piaf(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/qa4mre/qa4mre.py
+++ b/datasets/qa4mre/qa4mre.py
@@ -80,18 +80,18 @@ PATHS = {
 def _get_question(topic_id, topic_name, test_id, document_id, document_str, question):
     """Gets instance ID and features for every question.
 
-  Args:
-    topic_id: string
-    topic_name: string
-    test_id: string
-    document_id: string
-    document_str: string
-    question: XML element for question
+    Args:
+      topic_id: string
+      topic_name: string
+      test_id: string
+      document_id: string
+      document_str: string
+      question: XML element for question
 
-  Returns:
-    id_: string. Unique ID for instance.
-    feats: dict of instance features
-  """
+    Returns:
+      id_: string. Unique ID for instance.
+      feats: dict of instance features
+    """
 
     question_id = question.attrib["q_id"]
     for q_text in question.iter("q_str"):
@@ -130,12 +130,12 @@ class Qa4mreConfig(nlp.BuilderConfig):
     def __init__(self, year, track="main", language="EN", **kwargs):
         """BuilderConfig for Qa4Mre.
 
-    Args:
-      year: string, year of dataset
-      track: string, the task track from PATHS[year]['_TRACKS'].
-      language: string, Acronym for language in the main task.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          year: string, year of dataset
+          track: string, the task track from PATHS[year]['_TRACKS'].
+          language: string, Acronym for language in the main task.
+          **kwargs: keyword arguments forwarded to super.
+        """
         if track.lower() not in PATHS[year]["_TRACKS"]:
             raise ValueError("Incorrect track. Track should be one of the following: ", PATHS[year]["_TRACKS"])
 

--- a/datasets/qa4mre/qa4mre.py
+++ b/datasets/qa4mre/qa4mre.py
@@ -44,12 +44,12 @@ _CITATION = r"""
 """
 
 _DESCRIPTION = """
-QA4MRE dataset was created for the CLEF 2011/2012/2013 shared tasks to promote research in 
-question answering and reading comprehension. The dataset contains a supporting 
-passage and a set of questions corresponding to the passage. Multiple options 
-for answers are provided for each question, of which only one is correct. The 
+QA4MRE dataset was created for the CLEF 2011/2012/2013 shared tasks to promote research in
+question answering and reading comprehension. The dataset contains a supporting
+passage and a set of questions corresponding to the passage. Multiple options
+for answers are provided for each question, of which only one is correct. The
 training and test datasets are available for the main track.
-Additional gold standard documents are available for two pilot studies: one on 
+Additional gold standard documents are available for two pilot studies: one on
 alzheimers data, and the other on entrance exams data.
 """
 

--- a/datasets/qa_zre/qa_zre.py
+++ b/datasets/qa_zre/qa_zre.py
@@ -66,15 +66,21 @@ class QaZre(nlp.GeneratorBasedBuilder):
         return [
             nlp.SplitGenerator(
                 name=nlp.Split.TEST,
-                gen_kwargs={"filepaths": [os.path.join(dl_dir, "test." + str(i)) for i in range(10)],},
+                gen_kwargs={
+                    "filepaths": [os.path.join(dl_dir, "test." + str(i)) for i in range(10)],
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION,
-                gen_kwargs={"filepaths": [os.path.join(dl_dir, "dev." + str(i)) for i in range(10)],},
+                gen_kwargs={
+                    "filepaths": [os.path.join(dl_dir, "dev." + str(i)) for i in range(10)],
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
-                gen_kwargs={"filepaths": [os.path.join(dl_dir, "train." + str(i)) for i in range(10)],},
+                gen_kwargs={
+                    "filepaths": [os.path.join(dl_dir, "train." + str(i)) for i in range(10)],
+                },
             ),
         ]
 

--- a/datasets/qangaroo/qangaroo.py
+++ b/datasets/qangaroo/qangaroo.py
@@ -38,7 +38,7 @@ _URL = "https://drive.google.com/uc?export=download&id=1ytVZ4AhubFDOEL7o7XrIRIyh
 
 class QangarooConfig(nlp.BuilderConfig):
     def __init__(self, data_dir, **kwargs):
-        """ BuilderConfig for qangaroo dataset
+        """BuilderConfig for qangaroo dataset
 
         Args:
           data_dir: directory for the given dataset name

--- a/datasets/qangaroo/qangaroo.py
+++ b/datasets/qangaroo/qangaroo.py
@@ -25,7 +25,7 @@ The two QAngaroo datasets provide a training and evaluation resource for such me
 """
 
 _MEDHOP_DESCRIPTION = """\
-  With the same format as WikiHop, this dataset is based on research paper abstracts from PubMed, and the queries are about interactions between pairs of drugs. 
+  With the same format as WikiHop, this dataset is based on research paper abstracts from PubMed, and the queries are about interactions between pairs of drugs.
   The correct answer has to be inferred by combining information from a chain of reactions of drugs and proteins.
   """
 _WIKIHOP_DESCRIPTION = """\

--- a/datasets/qanta/qanta.py
+++ b/datasets/qanta/qanta.py
@@ -161,8 +161,7 @@ _FEATURES = {
 
 
 class Qanta(nlp.GeneratorBasedBuilder):
-    """The Qanta dataset is a question answering dataset based on the academic trivia game Quizbowl.
-  """
+    """The Qanta dataset is a question answering dataset based on the academic trivia game Quizbowl."""
 
     VERSION = _VERSION
     BUILDER_CONFIGS = [
@@ -268,7 +267,12 @@ class Qanta(nlp.GeneratorBasedBuilder):
         ]
 
     def _generate_examples(
-        self, qanta_filepath: str, trick_filepath: str, fold: str, mode: str, char_skip: int,
+        self,
+        qanta_filepath: str,
+        trick_filepath: str,
+        fold: str,
+        mode: str,
+        char_skip: int,
     ):
         """Yields examples."""
         if mode not in _MODES:

--- a/datasets/qasc/qasc.py
+++ b/datasets/qasc/qasc.py
@@ -20,7 +20,7 @@ _CITATION = """\
 
 # TODO(qasc):
 _DESCRIPTION = """
-QASC is a question-answering dataset with a focus on sentence composition. It consists of 9,980 8-way multiple-choice 
+QASC is a question-answering dataset with a focus on sentence composition. It consists of 9,980 8-way multiple-choice
 questions about grade school science (8,134 train, 926 dev, 920 test), and comes with a corpus of 17M sentences.
 """
 _URl = "http://data.allenai.org/downloads/qasc/qasc_dataset.tar.gz"

--- a/datasets/quartz/quartz.py
+++ b/datasets/quartz/quartz.py
@@ -14,18 +14,16 @@ _CITATION = """\
   author = {Oyvind Tafjord and Matt Gardner and Kevin Lin and Peter Clark},
   title = {"QUARTZ: An Open-Domain Dataset of Qualitative Relationship
 Questions"},
- 
   year = {"2019"},
 }
 """
 
 # TODO(quartz):
 _DESCRIPTION = """\
-QuaRTz is a crowdsourced dataset of 3864 multiple-choice questions about open domain qualitative relationships. Each 
+QuaRTz is a crowdsourced dataset of 3864 multiple-choice questions about open domain qualitative relationships. Each
 question is paired with one of 405 different background sentences (sometimes short paragraphs).
-The QuaRTz dataset V1 contains 3864 questions about open domain qualitative relationships. Each question is paired with 
+The QuaRTz dataset V1 contains 3864 questions about open domain qualitative relationships. Each question is paired with
 one of 405 different background sentences (sometimes short paragraphs).
-
 The dataset is split into train (2696), dev (384) and test (784). A background sentence will only appear in a single split.
 """
 

--- a/datasets/quora/quora.py
+++ b/datasets/quora/quora.py
@@ -37,7 +37,12 @@ class Quora(nlp.GeneratorBasedBuilder):
             description=_DESCRIPTION,
             features=nlp.Features(
                 {
-                    "questions": nlp.features.Sequence({"id": nlp.Value("int32"), "text": nlp.Value("string"),}),
+                    "questions": nlp.features.Sequence(
+                        {
+                            "id": nlp.Value("int32"),
+                            "text": nlp.Value("string"),
+                        }
+                    ),
                     "is_duplicate": nlp.Value("bool"),
                 }
             ),

--- a/datasets/quora/quora.py
+++ b/datasets/quora/quora.py
@@ -18,7 +18,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import collections
 import csv
 
 import nlp

--- a/datasets/quoref/quoref.py
+++ b/datasets/quoref/quoref.py
@@ -48,7 +48,10 @@ class Quoref(nlp.GeneratorBasedBuilder):
                     "title": nlp.Value("string"),
                     "url": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"answer_start": nlp.Value("int32"), "text": nlp.Value("string"),}
+                        {
+                            "answer_start": nlp.Value("int32"),
+                            "text": nlp.Value("string"),
+                        }
                     )
                     # These are the features of your dataset like images, labels ...
                 }
@@ -106,6 +109,9 @@ class Quoref(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                             "url": url,
                         }

--- a/datasets/quoref/quoref.py
+++ b/datasets/quoref/quoref.py
@@ -20,8 +20,8 @@ _CITATION = """\
 
 # TODO(quoref):
 _DESCRIPTION = """\
-Quoref is a QA dataset which tests the coreferential reasoning capability of reading comprehension systems. In this 
-span-selection benchmark containing 24K questions over 4.7K paragraphs from Wikipedia, a system must resolve hard 
+Quoref is a QA dataset which tests the coreferential reasoning capability of reading comprehension systems. In this
+span-selection benchmark containing 24K questions over 4.7K paragraphs from Wikipedia, a system must resolve hard
 coreferences before selecting the appropriate span(s) in the paragraphs for answering questions.
 """
 

--- a/datasets/reclor/reclor.py
+++ b/datasets/reclor/reclor.py
@@ -22,10 +22,10 @@ _CITATION = """\
 
 # TODO(reclor):
 _DESCRIPTION = """\
-Logical reasoning is an important ability to examine, analyze, and critically evaluate arguments as they occur in ordinary 
-language as the definition from LSAC. ReClor is a dataset extracted from logical reasoning questions of standardized graduate 
-admission examinations. Empirical results show that the state-of-the-art models struggle on ReClor with poor performance 
-indicating more research is needed to essentially enhance the logical reasoning ability of current models. We hope this 
+Logical reasoning is an important ability to examine, analyze, and critically evaluate arguments as they occur in ordinary
+language as the definition from LSAC. ReClor is a dataset extracted from logical reasoning questions of standardized graduate
+admission examinations. Empirical results show that the state-of-the-art models struggle on ReClor with poor performance
+indicating more research is needed to essentially enhance the logical reasoning ability of current models. We hope this
 dataset could help push Machine Reading Comprehension (MRC) towards more complicated reasonin
 """
 
@@ -39,7 +39,7 @@ class Reclor(nlp.GeneratorBasedBuilder):
     @property
     def manual_download_instructions(self):
         return """\
-  to use ReClor you need to download it manually. Please go to its homepage (http://whyu.me/reclor/) fill the google 
+  to use ReClor you need to download it manually. Please go to its homepage (http://whyu.me/reclor/) fill the google
   form and you will recive a download link and a password to extract it.Please extract all files in one folder and use the path folder in nlp.load_dataset('reclor', data_dir='path/to/folder/folder_name')
   """
 

--- a/datasets/reddit/reddit.py
+++ b/datasets/reddit/reddit.py
@@ -73,7 +73,8 @@ class Reddit(nlp.GeneratorBasedBuilder):
         dl_path = dl_manager.download_and_extract(_URL)
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={"path": os.path.join(dl_path, "corpus-webis-tldr-17.json")},
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"path": os.path.join(dl_path, "corpus-webis-tldr-17.json")},
             )
         ]
 

--- a/datasets/reddit_tifu/reddit_tifu.py
+++ b/datasets/reddit_tifu/reddit_tifu.py
@@ -63,10 +63,10 @@ class RedditTifuConfig(nlp.BuilderConfig):
     def __init__(self, summary_key=None, **kwargs):
         """BuilderConfig for RedditTifu.
 
-    Args:
-      summary_key: key string of summary in downloaded json file.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          summary_key: key string of summary in downloaded json file.
+          **kwargs: keyword arguments forwarded to super.
+        """
         # Version 1.1.0 remove empty document and summary strings.
         super(RedditTifuConfig, self).__init__(version=nlp.Version("1.1.0"), **kwargs)
         self.summary_key = summary_key
@@ -76,8 +76,16 @@ class RedditTifu(nlp.GeneratorBasedBuilder):
     """Reddit TIFU Dataset."""
 
     BUILDER_CONFIGS = [
-        RedditTifuConfig(name="short", summary_key=_TITLE, description="Using title as summary.",),
-        RedditTifuConfig(name="long", summary_key=_TLDR, description="Using TLDR as summary.",),
+        RedditTifuConfig(
+            name="short",
+            summary_key=_TITLE,
+            description="Using title as summary.",
+        ),
+        RedditTifuConfig(
+            name="long",
+            summary_key=_TLDR,
+            description="Using TLDR as summary.",
+        ),
     ]
 
     def _info(self):
@@ -99,7 +107,12 @@ class RedditTifu(nlp.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
         dl_path = dl_manager.download_and_extract(_URL)
-        return [nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"path": dl_path},)]
+        return [
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"path": dl_path},
+            )
+        ]
 
     def _generate_examples(self, path=None):
         """Yields examples."""

--- a/datasets/reuters21578/reuters21578.py
+++ b/datasets/reuters21578/reuters21578.py
@@ -184,6 +184,7 @@ categorization research. It is collected from the Reuters financial newswire ser
 
 _DATA_URL = "https://kdd.ics.uci.edu/databases/reuters21578/reuters21578.tar.gz"
 
+
 class Reuters21578Config(nlp.BuilderConfig):
     """BuilderConfig for reuters-21578."""
 
@@ -193,34 +194,40 @@ class Reuters21578Config(nlp.BuilderConfig):
         Args:
         **kwargs: keyword arguments forwarded to super.
         """
-        super(Reuters21578Config, self).__init__(version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs)
-    
+        super(Reuters21578Config, self).__init__(
+            version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
+        )
+
+
 class Reuters21578(nlp.GeneratorBasedBuilder):
     """Reuters 21578"""
-    
+
     BUILDER_CONFIGS = [
         Reuters21578Config(
             name="ModHayes",
-            description=dedent("""Training Set (20856 docs): CGISPLIT="TRAINING-SET"
+            description=dedent(
+                """Training Set (20856 docs): CGISPLIT="TRAINING-SET"
                                 Test Set (722 docs): CGISPLIT="PUBLISHED-TESTSET"
-                                Unused (0 docs)""")
+                                Unused (0 docs)"""
+            ),
         ),
         Reuters21578Config(
             name="ModLewis",
-            description=dedent("""Training Set (13,625 docs): LEWISSPLIT="TRAIN";  TOPICS="YES" or "NO"
+            description=dedent(
+                """Training Set (13,625 docs): LEWISSPLIT="TRAIN";  TOPICS="YES" or "NO"
                                 Test Set (6,188 docs):  LEWISSPLIT="TEST"; TOPICS="YES" or "NO"
-                                Unused (1,765): LEWISSPLIT="NOT-USED" or TOPICS="BYPASS""")
+                                Unused (1,765): LEWISSPLIT="NOT-USED" or TOPICS="BYPASS"""
+            ),
         ),
         Reuters21578Config(
             name="ModApte",
-            description=dedent("""Training Set (9,603 docs): LEWISSPLIT="TRAIN";  TOPICS="YES"
+            description=dedent(
+                """Training Set (9,603 docs): LEWISSPLIT="TRAIN";  TOPICS="YES"
                                 Test Set (3,299 docs): LEWISSPLIT="TEST"; TOPICS="YES"
-                                Unused (8,676 docs):   LEWISSPLIT="NOT-USED"; TOPICS="YES" or TOPICS="NO" or TOPICS="BYPASS" """)
+                                Unused (8,676 docs):   LEWISSPLIT="NOT-USED"; TOPICS="YES" or TOPICS="NO" or TOPICS="BYPASS" """
+            ),
         ),
-        
-        
     ]
-
 
     def _info(self):
         return nlp.DatasetInfo(
@@ -247,66 +254,58 @@ class Reuters21578(nlp.GeneratorBasedBuilder):
             homepage="https://kdd.ics.uci.edu/databases/reuters21578/reuters21578.html",
             citation=_CITATION,
         )
+
     def _split_generators(self, dl_manager):
         dl_dir = dl_manager.download_and_extract(_DATA_URL)
-        files = [os.path.join(dl_dir, "reut2-"+"%03d"% i+".sgm" ) for i in range(22)]
+        files = [os.path.join(dl_dir, "reut2-" + "%03d" % i + ".sgm") for i in range(22)]
         if self.config.name == "ModHayes":
             return [
                 nlp.SplitGenerator(
-                    name=nlp.Split.TEST, 
+                    name=nlp.Split.TEST,
                     gen_kwargs={
                         "filepath": files,
                         "split": "PUBLISHED-TESTSET",
-                        
-                        
-                        }),
+                    },
+                ),
                 nlp.SplitGenerator(
-                    name=nlp.Split.TRAIN, 
+                    name=nlp.Split.TRAIN,
                     gen_kwargs={
                         "filepath": files,
                         "split": "TRAINING-SET",
-                        
-                        }),
+                    },
+                ),
             ]
         else:
             return [
                 nlp.SplitGenerator(
-                    name=nlp.Split.TEST, 
+                    name=nlp.Split.TEST,
                     gen_kwargs={
                         "filepath": files,
                         "split": "TEST",
-                        
-                        }),
-                nlp.SplitGenerator(
-                    name=nlp.Split.TRAIN, 
-                    gen_kwargs={
-                        "filepath": files,
-                        "split": "TRAIN"
-                    }),
-                nlp.SplitGenerator(
-                    name="unused",
-                    gen_kwargs={
-                        "filepath": files,
-                        "split": "NOT-USED"
-                    })
+                    },
+                ),
+                nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"filepath": files, "split": "TRAIN"}),
+                nlp.SplitGenerator(name="unused", gen_kwargs={"filepath": files, "split": "NOT-USED"}),
             ]
-    
+
     def _generate_examples(self, filepath, split):
         """This function returns the examples in the raw (text) form."""
         for file in filepath:
-            with open(file, encoding="utf-8",  errors='ignore') as f: # only the file reut2-017 has one line non UTF-8 encoded so we can ignore it
+            with open(
+                file, encoding="utf-8", errors="ignore"
+            ) as f:  # only the file reut2-017 has one line non UTF-8 encoded so we can ignore it
                 line = f.readline()
-                lewis_split = ''
-                cgis_split = ''
-                old_id = ''
-                new_id = ''
+                lewis_split = ""
+                cgis_split = ""
+                old_id = ""
+                new_id = ""
                 topics = []
                 places = []
                 people = []
                 orgs = []
                 exchanges = []
-                date = ''
-                title = ''
+                date = ""
+                title = ""
                 while line:
                     if line.startswith("<REUTERS"):
                         line = line.split()
@@ -316,16 +315,32 @@ class Reuters21578(nlp.GeneratorBasedBuilder):
                         new_id = line[5].split("=")[1][:-1]
                         has_topic = line[1].split("=")[1]
                         line = f.readline()
-                        if (self.config.name == "ModHayes" and split not in cgis_split) or (self.config.name == "ModLewis" and ((split not in lewis_split) or 
-                                (split=="TRAIN" and has_topic not in ['"YES"', '"NO"']) or (split=="TEST" and has_topic not in ['"YES"', '"NO"'])  or
-                                (split=="NOT-USED" and has_topic not in ['"YES"', '"NO"', '"BYPASS"']))) or (self.config.name == "ModApte" and (split not in lewis_split or 
-                                (split=="TRAIN" and has_topic != '"YES"') or (split=="TEST" and has_topic != '"YES"') or 
-                                (split=="NOT-USED" and has_topic not in ['"YES"', '"NO"', '"BYPASS"']))): #skip example that are not in the current split
-                                l = line
-                                while l and not l.startswith("<REUTERS"):
-                                    l = f.readline()
-                                if l:
-                                    line = l 
+                        if (
+                            (self.config.name == "ModHayes" and split not in cgis_split)
+                            or (
+                                self.config.name == "ModLewis"
+                                and (
+                                    (split not in lewis_split)
+                                    or (split == "TRAIN" and has_topic not in ['"YES"', '"NO"'])
+                                    or (split == "TEST" and has_topic not in ['"YES"', '"NO"'])
+                                    or (split == "NOT-USED" and has_topic not in ['"YES"', '"NO"', '"BYPASS"'])
+                                )
+                            )
+                            or (
+                                self.config.name == "ModApte"
+                                and (
+                                    split not in lewis_split
+                                    or (split == "TRAIN" and has_topic != '"YES"')
+                                    or (split == "TEST" and has_topic != '"YES"')
+                                    or (split == "NOT-USED" and has_topic not in ['"YES"', '"NO"', '"BYPASS"'])
+                                )
+                            )
+                        ):  # skip example that are not in the current split
+                            l = line
+                            while l and not l.startswith("<REUTERS"):
+                                l = f.readline()
+                            if l:
+                                line = l
                     elif line.startswith("<TOPICS>"):
                         if line.replace("\n", "") != "<TOPICS></TOPICS>":
                             line = line.split("<D>")
@@ -358,33 +373,33 @@ class Reuters21578(nlp.GeneratorBasedBuilder):
                         line = f.readline()
                     elif line.startswith("<DATE>"):
                         date = line.replace("\n", "")
-                        date = line[6:-8]   
+                        date = line[6:-8]
                         line = f.readline()
                     elif line.startswith("<TITLE>"):
                         title = line[7:-9]
                         line = f.readline()
                     elif "<BODY>" in line:
-                        text = line.split('<BODY>')[1]
+                        text = line.split("<BODY>")[1]
                         line = f.readline()
                         while "</BODY>" not in line:
                             text += line
                             line = f.readline()
-                        
+
                         yield new_id, {
-                                "lewis_split": lewis_split,
-                                "cgis_split": cgis_split,
-                                "old_id": old_id,
-                                "new_id": new_id,
-                                "topics": topics,
-                                "places": places,
-                                "people": people,
-                                "orgs": orgs,
-                                "exchanges": exchanges,
-                                "date": date,
-                                "title": title,
-                                "text": text
+                            "lewis_split": lewis_split,
+                            "cgis_split": cgis_split,
+                            "old_id": old_id,
+                            "new_id": new_id,
+                            "topics": topics,
+                            "places": places,
+                            "people": people,
+                            "orgs": orgs,
+                            "exchanges": exchanges,
+                            "date": date,
+                            "title": title,
+                            "text": text,
                         }
                         line = f.readline()
-                        
+
                     else:
                         line = f.readline()

--- a/datasets/reuters21578/reuters21578.py
+++ b/datasets/reuters21578/reuters21578.py
@@ -18,7 +18,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import csv
 import os
 from textwrap import dedent
 
@@ -30,7 +29,7 @@ _CITATION = """\
 author = {Chidanand Apt{\'{e}} and Fred Damerau and Sholom M. Weiss},
 title = {Automated Learning of Decision Rules for Text Categorization},
 journal = {ACM Transactions on Information Systems},
-year = {1994}, 
+year = {1994},
 note = {To appear.}
 }
 
@@ -43,7 +42,7 @@ note = {To appear.}
 }
 
 @inproceedings{HAYES8},
-author = {Philip J. Hayes and Peggy M. Anderson and Irene B. Nirenburg and 
+author = {Philip J. Hayes and Peggy M. Anderson and Irene B. Nirenburg and
 Linda M. Schmandt},
 title = {{TCS}: A Shell for Content-Based Text Categorization},
 booktitle = {IEEE Conference on Artificial Intelligence Applications},
@@ -52,7 +51,7 @@ year = {1990}
 
 @inproceedings{HAYES90b,
 author = {Philip J. Hayes and Steven P. Weinstein},
-title = {{CONSTRUE/TIS:} A System for Content-Based Indexing of a 
+title = {{CONSTRUE/TIS:} A System for Content-Based Indexing of a
 Database of News Stories},
 booktitle = {Second Annual Conference on Innovative Applications of
 Artificial Intelligence},
@@ -147,14 +146,14 @@ month = {apr},
 pages = {81--93}
 }
 
-@article{LEWIS94d, 
-author = {David D. Lewis and Philip J. Hayes}, 
-title = {Guest Editorial}, 
-journal = {ACM Transactions on Information Systems}, 
-year = {1994}, 
-volume  = {12}, 
-number  = {3}, 
-pages = {231}, 
+@article{LEWIS94d,
+author = {David D. Lewis and Philip J. Hayes},
+title = {Guest Editorial},
+journal = {ACM Transactions on Information Systems},
+year = {1994},
+volume  = {12},
+number  = {3},
+pages = {231},
 month = {jul}
 }
 
@@ -336,11 +335,11 @@ class Reuters21578(nlp.GeneratorBasedBuilder):
                                 )
                             )
                         ):  # skip example that are not in the current split
-                            l = line
-                            while l and not l.startswith("<REUTERS"):
-                                l = f.readline()
-                            if l:
-                                line = l
+                            li = line
+                            while li and not li.startswith("<REUTERS"):
+                                li = f.readline()
+                            if li:
+                                line = li
                     elif line.startswith("<TOPICS>"):
                         if line.replace("\n", "") != "<TOPICS></TOPICS>":
                             line = line.split("<D>")

--- a/datasets/rotten_tomatoes/rotten_tomatoes.py
+++ b/datasets/rotten_tomatoes/rotten_tomatoes.py
@@ -70,21 +70,24 @@ class RottenTomatoesMovieReview(nlp.GeneratorBasedBuilder):
         extracted_folder_path = dl_manager.download_and_extract(_DOWNLOAD_URL)
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={"split_key": "train", "data_dir": extracted_folder_path},
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"split_key": "train", "data_dir": extracted_folder_path},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={"split_key": "validation", "data_dir": extracted_folder_path},
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"split_key": "validation", "data_dir": extracted_folder_path},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.TEST, gen_kwargs={"split_key": "test", "data_dir": extracted_folder_path},
+                name=nlp.Split.TEST,
+                gen_kwargs={"split_key": "test", "data_dir": extracted_folder_path},
             ),
         ]
 
     def _get_examples_from_split(self, split_key, data_dir):
-        """ Reads Rotten Tomatoes sentences and splits into 80% train,
-            10% validation, and 10% test, as is the practice set out in Jinfeng
-            Li, ``TEXTBUGGER: Generating Adversarial Text Against Real-world 
-            Applications.''
+        """Reads Rotten Tomatoes sentences and splits into 80% train,
+        10% validation, and 10% test, as is the practice set out in Jinfeng
+        Li, ``TEXTBUGGER: Generating Adversarial Text Against Real-world
+        Applications.''
         """
         data_dir = os.path.join(data_dir, "rt-polaritydata")
 

--- a/datasets/rotten_tomatoes/rotten_tomatoes.py
+++ b/datasets/rotten_tomatoes/rotten_tomatoes.py
@@ -25,10 +25,10 @@ import nlp
 
 _DESCRIPTION = """\
 Movie Review Dataset.
-This is a dataset of containing 5,331 positive and 5,331 negative processed 
-sentences from Rotten Tomatoes movie reviews. This data was first used in Bo 
-Pang and Lillian Lee, ``Seeing stars: Exploiting class relationships for 
-sentiment categorization with respect to rating scales.'', Proceedings of the 
+This is a dataset of containing 5,331 positive and 5,331 negative processed
+sentences from Rotten Tomatoes movie reviews. This data was first used in Bo
+Pang and Lillian Lee, ``Seeing stars: Exploiting class relationships for
+sentiment categorization with respect to rating scales.'', Proceedings of the
 ACL, 2005.
 """
 

--- a/datasets/scan/scan.py
+++ b/datasets/scan/scan.py
@@ -54,11 +54,11 @@ class ScanConfig(nlp.BuilderConfig):
     def __init__(self, name, directory=None, **kwargs):
         """BuilderConfig for SCAN.
 
-    Args:
-      name: Unique name of the split.
-      directory: Which subdirectory to read the split from.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          name: Unique name of the split.
+          directory: Which subdirectory to read the split from.
+          **kwargs: keyword arguments forwarded to super.
+        """
         # Version history:
         super(ScanConfig, self).__init__(name=name, version=nlp.Version("1.0.0"), description=_DESCRIPTION, **kwargs)
         if directory is None:
@@ -92,7 +92,12 @@ class Scan(nlp.GeneratorBasedBuilder):
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({_COMMANDS: nlp.Value("string"), _ACTIONS: nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    _COMMANDS: nlp.Value("string"),
+                    _ACTIONS: nlp.Value("string"),
+                }
+            ),
             supervised_keys=None,
             homepage="https://github.com/brendenlake/SCAN",
             citation=_CITATION,

--- a/datasets/scicite/scicite.py
+++ b/datasets/scicite/scicite.py
@@ -97,13 +97,24 @@ class Scicite(nlp.GeneratorBasedBuilder):
     def _split_generators(self, dl_manager):
         """Returns SplitGenerators."""
         dl_paths = dl_manager.download_and_extract(
-            {"scicite": "https://s3-us-west-2.amazonaws.com/ai2-s2-research/scicite/scicite.tar.gz",}
+            {
+                "scicite": "https://s3-us-west-2.amazonaws.com/ai2-s2-research/scicite/scicite.tar.gz",
+            }
         )
         path = os.path.join(dl_paths["scicite"], "scicite")
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"path": os.path.join(path, "train.jsonl")},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"path": os.path.join(path, "dev.jsonl")},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"path": os.path.join(path, "test.jsonl")},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"path": os.path.join(path, "train.jsonl")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"path": os.path.join(path, "dev.jsonl")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"path": os.path.join(path, "test.jsonl")},
+            ),
         ]
 
     def _generate_examples(self, path=None):

--- a/datasets/scientific_papers/scientific_papers.py
+++ b/datasets/scientific_papers/scientific_papers.py
@@ -65,10 +65,10 @@ class ScientificPapersConfig(nlp.BuilderConfig):
     def __init__(self, filename=None, **kwargs):
         """BuilderConfig for Wikihow.
 
-    Args:
-      filename: filename of different configs for the dataset.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          filename: filename of different configs for the dataset.
+          **kwargs: keyword arguments forwarded to super.
+        """
         # 1.1.0 remove sentence breaker <S> and </S> in summary.
         super(ScientificPapersConfig, self).__init__(version=nlp.Version("1.1.1"), **kwargs)
         self.filename = filename
@@ -86,7 +86,11 @@ class ScientificPapers(nlp.GeneratorBasedBuilder):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
             features=nlp.Features(
-                {_DOCUMENT: nlp.Value("string"), _SUMMARY: nlp.Value("string"), "section_names": nlp.Value("string"),}
+                {
+                    _DOCUMENT: nlp.Value("string"),
+                    _SUMMARY: nlp.Value("string"),
+                    "section_names": nlp.Value("string"),
+                }
             ),
             supervised_keys=None,
             homepage="https://github.com/armancohan/long-summarization",
@@ -98,9 +102,18 @@ class ScientificPapers(nlp.GeneratorBasedBuilder):
         dl_paths = dl_manager.download_and_extract(_URLS)
         path = os.path.join(dl_paths[self.config.name], self.config.name + "-dataset")
         return [
-            nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"path": os.path.join(path, "train.txt")},),
-            nlp.SplitGenerator(name=nlp.Split.VALIDATION, gen_kwargs={"path": os.path.join(path, "val.txt")},),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"path": os.path.join(path, "test.txt")},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TRAIN,
+                gen_kwargs={"path": os.path.join(path, "train.txt")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"path": os.path.join(path, "val.txt")},
+            ),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"path": os.path.join(path, "test.txt")},
+            ),
         ]
 
     def _generate_examples(self, path=None):

--- a/datasets/scitail/scitail.py
+++ b/datasets/scitail/scitail.py
@@ -22,11 +22,11 @@ inproceedings{scitail,
 
 # TODO(sciTail):
 _DESCRIPTION = """\
-The SciTail dataset is an entailment dataset created from multiple-choice science exams and web sentences. Each question 
-and the correct answer choice are converted into an assertive statement to form the hypothesis. We use information 
-retrieval to obtain relevant text from a large text corpus of web sentences, and use these sentences as a premise P. We 
-crowdsource the annotation of such premise-hypothesis pair as supports (entails) or not (neutral), in order to create 
-the SciTail dataset. The dataset contains 27,026 examples with 10,101 examples with entails label and 16,925 examples 
+The SciTail dataset is an entailment dataset created from multiple-choice science exams and web sentences. Each question
+and the correct answer choice are converted into an assertive statement to form the hypothesis. We use information
+retrieval to obtain relevant text from a large text corpus of web sentences, and use these sentences as a premise P. We
+crowdsource the annotation of such premise-hypothesis pair as supports (entails) or not (neutral), in order to create
+the SciTail dataset. The dataset contains 27,026 examples with 10,101 examples with entails label and 16,925 examples
 with neutral label
 """
 

--- a/datasets/search_qa/search_qa.py
+++ b/datasets/search_qa/search_qa.py
@@ -19,13 +19,12 @@
 from __future__ import absolute_import, division, print_function
 
 import json
-import logging
 import os
 
 import nlp
 
 
-_CITATION = """
+_CITATION = r"""
     @article{DBLP:journals/corr/DunnSHGCC17,
     author    = {Matthew Dunn and
                 Levent Sagun and
@@ -49,12 +48,12 @@ _CITATION = """
 """
 # pylint: disable=line-too-long
 _DESCRIPTION = """
-We publicly release a new large-scale dataset, called SearchQA, for machine comprehension, or question-answering. Unlike recently released datasets, such as DeepMind 
-CNN/DailyMail and SQuAD, the proposed SearchQA was constructed to reflect a full pipeline of general question-answering. That is, we start not from an existing article 
-and generate a question-answer pair, but start from an existing question-answer pair, crawled from J! Archive, and augment it with text snippets retrieved by Google. 
+We publicly release a new large-scale dataset, called SearchQA, for machine comprehension, or question-answering. Unlike recently released datasets, such as DeepMind
+CNN/DailyMail and SQuAD, the proposed SearchQA was constructed to reflect a full pipeline of general question-answering. That is, we start not from an existing article
+and generate a question-answer pair, but start from an existing question-answer pair, crawled from J! Archive, and augment it with text snippets retrieved by Google.
 Following this approach, we built SearchQA, which consists of more than 140k question-answer pairs with each pair having 49.6 snippets on average. Each question-answer-context
- tuple of the SearchQA comes with additional meta-data such as the snippet's URL, which we believe will be valuable resources for future research. We conduct human evaluation 
- as well as test two baseline methods, one simple word selection and the other deep learning based, on the SearchQA. We show that there is a meaningful gap between the human 
+ tuple of the SearchQA comes with additional meta-data such as the snippet's URL, which we believe will be valuable resources for future research. We conduct human evaluation
+ as well as test two baseline methods, one simple word selection and the other deep learning based, on the SearchQA. We show that there is a meaningful gap between the human
  and machine performances. This suggests that the proposed dataset could well serve as a benchmark for question-answering.
 """
 
@@ -96,7 +95,6 @@ class SearchQa(nlp.GeneratorBasedBuilder):
                     "value": nlp.Value("string"),
                     "answer": nlp.Value("string"),
                     "round": nlp.Value("string"),
-                    "category": nlp.Value("string"),
                     "show_number": nlp.Value("int32"),
                     "search_results": nlp.features.Sequence(
                         {

--- a/datasets/snli/snli.py
+++ b/datasets/snli/snli.py
@@ -26,11 +26,11 @@ import nlp
 
 _CITATION = """\
 @inproceedings{snli:emnlp2015,
-	Author = {Bowman, Samuel R. and Angeli, Gabor and Potts, Christopher, and Manning, Christopher D.},
-	Booktitle = {Proceedings of the 2015 Conference on Empirical Methods in Natural Language Processing (EMNLP)},
-	Publisher = {Association for Computational Linguistics},
-	Title = {A large annotated corpus for learning natural language inference},
-	Year = {2015}
+    Author = {Bowman, Samuel R. and Angeli, Gabor and Potts, Christopher, and Manning, Christopher D.},
+    Booktitle = {Proceedings of the 2015 Conference on Empirical Methods in Natural Language Processing (EMNLP)},
+    Publisher = {Association for Computational Linguistics},
+    Title = {A large annotated corpus for learning natural language inference},
+    Year = {2015}
 }
 """
 

--- a/datasets/social_bias_frames/social_bias_frames.py
+++ b/datasets/social_bias_frames/social_bias_frames.py
@@ -34,8 +34,8 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-Social Bias Frames is a new way of representing the biases and offensiveness that are implied in language. 
-For example, these frames are meant to distill the implication that "women (candidates) are less qualified" 
+Social Bias Frames is a new way of representing the biases and offensiveness that are implied in language.
+For example, these frames are meant to distill the implication that "women (candidates) are less qualified"
 behind the statement "we shouldn’t lower our standards to hire more women."
 """
 

--- a/datasets/sogou_news/sogou_news.py
+++ b/datasets/sogou_news/sogou_news.py
@@ -40,7 +40,7 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-The Sogou News dataset is a mixture of 2,909,551 news articles from the SogouCA and SogouCS news corpora, in 5 categories. 
+The Sogou News dataset is a mixture of 2,909,551 news articles from the SogouCA and SogouCS news corpora, in 5 categories.
 The number of training samples selected for each class is 90,000 and testing 12,000. Note that the Chinese characters have been converted to Pinyin.
 classification labels of the news are determined by their domain names in the URL. For example, the news with
 URL http://sports.sohu.com is categorized as a sport class.

--- a/datasets/squad/squad.py
+++ b/datasets/squad/squad.py
@@ -53,9 +53,9 @@ class SquadConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for SQUAD.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(SquadConfig, self).__init__(**kwargs)
 
 
@@ -84,7 +84,10 @@ class Squad(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                 }
             ),
@@ -130,5 +133,8 @@ class Squad(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/squad_es/squad_es.py
+++ b/datasets/squad_es/squad_es.py
@@ -37,9 +37,9 @@ class SquadEsConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for SQUADEsV2.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(SquadEsConfig, self).__init__(**kwargs)
 
 
@@ -76,7 +76,10 @@ class SquadEs(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                 }
             ),
@@ -143,5 +146,8 @@ class SquadEs(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/squad_it/squad_it.py
+++ b/datasets/squad_it/squad_it.py
@@ -53,7 +53,10 @@ class SquadIt(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                     # These are the features of your dataset like images, labels ...
                 }
@@ -99,5 +102,8 @@ class SquadIt(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/squad_it/squad_it.py
+++ b/datasets/squad_it/squad_it.py
@@ -11,23 +11,23 @@ import nlp
 # TODO(squad_it): BibTeX citation
 _CITATION = """\
 @InProceedings{10.1007/978-3-030-03840-3_29,
-	author={Croce, Danilo and Zelenanska, Alexandra and Basili, Roberto},
-	editor={Ghidini, Chiara and Magnini, Bernardo and Passerini, Andrea and Traverso, Paolo",
-	title={Neural Learning for Question Answering in Italian},
-	booktitle={AI*IA 2018 -- Advances in Artificial Intelligence},
-	year={2018},
-	publisher={Springer International Publishing},
-	address={Cham},
-	pages={389--402},
-	isbn={978-3-030-03840-3}
+    author={Croce, Danilo and Zelenanska, Alexandra and Basili, Roberto},
+    editor={Ghidini, Chiara and Magnini, Bernardo and Passerini, Andrea and Traverso, Paolo",
+    title={Neural Learning for Question Answering in Italian},
+    booktitle={AI*IA 2018 -- Advances in Artificial Intelligence},
+    year={2018},
+    publisher={Springer International Publishing},
+    address={Cham},
+    pages={389--402},
+    isbn={978-3-030-03840-3}
 }
 """
 
 # TODO(squad_it):
 _DESCRIPTION = """\
-SQuAD-it is derived from the SQuAD dataset and it is obtained through semi-automatic translation of the SQuAD dataset 
+SQuAD-it is derived from the SQuAD dataset and it is obtained through semi-automatic translation of the SQuAD dataset
 into Italian. It represents a large-scale dataset for open question answering processes on factoid questions in Italian.
- The dataset contains more than 60,000 question/answer pairs derived from the original English dataset. The dataset is 
+ The dataset contains more than 60,000 question/answer pairs derived from the original English dataset. The dataset is
  split into training and test sets to support the replicability of the benchmarking of QA systems:
 """
 _URL = "https://github.com/crux82/squad-it/raw/master"

--- a/datasets/squad_v1_pt/squad_v1_pt.py
+++ b/datasets/squad_v1_pt/squad_v1_pt.py
@@ -51,7 +51,10 @@ class SquadV1Pt(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                     # These are the features of your dataset like images, labels ...
                 }
@@ -99,5 +102,8 @@ class SquadV1Pt(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/squad_v2/squad_v2.py
+++ b/datasets/squad_v2/squad_v2.py
@@ -40,9 +40,9 @@ class SquadV2Config(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for SQUADV2.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(SquadV2Config, self).__init__(**kwargs)
 
 
@@ -67,7 +67,10 @@ class SquadV2(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                     # These are the features of your dataset like images, labels ...
                 }
@@ -117,5 +120,8 @@ class SquadV2(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/squad_v2/squad_v2.py
+++ b/datasets/squad_v2/squad_v2.py
@@ -25,7 +25,7 @@ archivePrefix = {arXiv},
 
 _DESCRIPTION = """\
 combines the 100,000 questions in SQuAD1.1 with over 50,000 unanswerable questions written adversarially by crowdworkers
- to look similar to answerable ones. To do well on SQuAD2.0, systems must not only answer questions when possible, but 
+ to look similar to answerable ones. To do well on SQuAD2.0, systems must not only answer questions when possible, but
  also determine when no answer is supported by the paragraph and abstain from answering.
 """
 

--- a/datasets/squadshifts/squadshifts.py
+++ b/datasets/squadshifts/squadshifts.py
@@ -53,9 +53,9 @@ class SquadShiftsConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for SQUAD.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(SquadShiftsConfig, self).__init__(**kwargs)
 
 
@@ -101,7 +101,10 @@ class SquadShifts(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                 }
             ),
@@ -163,5 +166,8 @@ class SquadShifts(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/squadshifts/squadshifts.py
+++ b/datasets/squadshifts/squadshifts.py
@@ -34,9 +34,9 @@ _CITATION = """\
 }
 """
 
-_DESCRIPTION = """\
+_DESCRIPTION = r"""\
 SquadShifts consists of four new test sets for the Stanford Question Answering \
-Dataset (SQuAD) from four different domains: Wikipedia articles, New York \ 
+Dataset (SQuAD) from four different domains: Wikipedia articles, New York \
 Times articles, Reddit comments, and Amazon product reviews. Each dataset \
 was generated using the same data generating pipeline, Amazon Mechanical \
 Turk interface, and data cleaning code as the original SQuAD v1.1 dataset. \

--- a/datasets/style_change_detection/style_change_detection.py
+++ b/datasets/style_change_detection/style_change_detection.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import os
-import textwrap
 
 import nlp
 

--- a/datasets/super_glue/super_glue.py
+++ b/datasets/super_glue/super_glue.py
@@ -287,17 +287,17 @@ class SuperGlueConfig(nlp.BuilderConfig):
     def __init__(self, features, data_url, citation, url, label_classes=("False", "True"), **kwargs):
         """BuilderConfig for SuperGLUE.
 
-    Args:
-      features: `list[string]`, list of the features that will appear in the
-        feature dict. Should not include "label".
-      data_url: `string`, url to download the zip file from.
-      citation: `string`, citation for the data set.
-      url: `string`, url for information about the data set.
-      label_classes: `list[string]`, the list of classes for the label if the
-        label is present as a string. Non-string labels will be cast to either
-        'False' or 'True'.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          features: `list[string]`, list of the features that will appear in the
+            feature dict. Should not include "label".
+          data_url: `string`, url to download the zip file from.
+          citation: `string`, citation for the data set.
+          url: `string`, url for information about the data set.
+          label_classes: `list[string]`, the list of classes for the label if the
+            label is present as a string. Non-string labels will be cast to either
+            'False' or 'True'.
+          **kwargs: keyword arguments forwarded to super.
+        """
         # Version history:
         # 1.0.2: Fixed non-nondeterminism in ReCoRD.
         # 1.0.1: Change from the pre-release trial version of SuperGLUE (v1.9) to
@@ -437,10 +437,19 @@ class SuperGlue(nlp.GeneratorBasedBuilder):
             features["end2"] = nlp.Value("int32")
         if self.config.name == "multirc":
             features["idx"] = dict(
-                {"paragraph": nlp.Value("int32"), "question": nlp.Value("int32"), "answer": nlp.Value("int32"),}
+                {
+                    "paragraph": nlp.Value("int32"),
+                    "question": nlp.Value("int32"),
+                    "answer": nlp.Value("int32"),
+                }
             )
         elif self.config.name == "record":
-            features["idx"] = dict({"passage": nlp.Value("int32"), "query": nlp.Value("int32"),})
+            features["idx"] = dict(
+                {
+                    "passage": nlp.Value("int32"),
+                    "query": nlp.Value("int32"),
+                }
+            )
         else:
             features["idx"] = nlp.Value("int32")
 
@@ -476,15 +485,24 @@ class SuperGlue(nlp.GeneratorBasedBuilder):
         return [
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
-                gen_kwargs={"data_file": os.path.join(dl_dir, "train.jsonl"), "split": nlp.Split.TRAIN,},
+                gen_kwargs={
+                    "data_file": os.path.join(dl_dir, "train.jsonl"),
+                    "split": nlp.Split.TRAIN,
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION,
-                gen_kwargs={"data_file": os.path.join(dl_dir, "val.jsonl"), "split": nlp.Split.VALIDATION,},
+                gen_kwargs={
+                    "data_file": os.path.join(dl_dir, "val.jsonl"),
+                    "split": nlp.Split.VALIDATION,
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.TEST,
-                gen_kwargs={"data_file": os.path.join(dl_dir, "test.jsonl"), "split": nlp.Split.TEST,},
+                gen_kwargs={
+                    "data_file": os.path.join(dl_dir, "test.jsonl"),
+                    "split": nlp.Split.TEST,
+                },
             ),
         ]
 

--- a/datasets/ted_hrlr/ted_hrlr.py
+++ b/datasets/ted_hrlr/ted_hrlr.py
@@ -63,24 +63,24 @@ class TedHrlrConfig(nlp.BuilderConfig):
     def __init__(self, language_pair=(None, None), **kwargs):
         """BuilderConfig for TED talk data comparing high/low resource languages.
 
-    The first language in `language_pair` should either be a 2-letter coded
-    string or two such strings joined by an underscore (e.g., "az" or "az_tr").
-    In cases where it contains two languages, the train data set will contain an
-    (unlabelled) mix of the two languages and the validation and test sets
-    will contain only the first language. This dataset will refer to the
-    source language by the 5-letter string with the underscore. The second
-    language in `language_pair` must be a 2-letter coded string.
+        The first language in `language_pair` should either be a 2-letter coded
+        string or two such strings joined by an underscore (e.g., "az" or "az_tr").
+        In cases where it contains two languages, the train data set will contain an
+        (unlabelled) mix of the two languages and the validation and test sets
+        will contain only the first language. This dataset will refer to the
+        source language by the 5-letter string with the underscore. The second
+        language in `language_pair` must be a 2-letter coded string.
 
-    For example, to get pairings between Russian and English, specify
-    `("ru", "en")` as `language_pair`. To get a mix of Belarusian and Russian in
-    the training set and purely Belarusian in the validation and test sets,
-    specify `("be_ru", "en")`.
+        For example, to get pairings between Russian and English, specify
+        `("ru", "en")` as `language_pair`. To get a mix of Belarusian and Russian in
+        the training set and purely Belarusian in the validation and test sets,
+        specify `("be_ru", "en")`.
 
-    Args:
-      language_pair: pair of languages that will be used for translation. The
-        first will be used as source and second as target in supervised mode.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          language_pair: pair of languages that will be used for translation. The
+            first will be used as source and second as target in supervised mode.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s_to_%s" % (language_pair[0].replace("_", ""), language_pair[1])
 
         description = ("Translation dataset from %s to %s in plain text.") % (language_pair[0], language_pair[1])
@@ -99,7 +99,8 @@ class TedHrlr(nlp.GeneratorBasedBuilder):
 
     BUILDER_CONFIGS = [
         TedHrlrConfig(  # pylint: disable=g-complex-comprehension
-            language_pair=pair, version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"),
+            language_pair=pair,
+            version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"),
         )
         for pair in _VALID_LANGUAGE_PAIRS
     ]

--- a/datasets/text/text.py
+++ b/datasets/text/text.py
@@ -1,6 +1,5 @@
 import logging
 from dataclasses import dataclass
-from typing import List
 
 import pyarrow.csv as pac
 

--- a/datasets/text/text.py
+++ b/datasets/text/text.py
@@ -9,7 +9,12 @@ import nlp
 
 logger = logging.getLogger(__name__)
 
-FEATURES = nlp.Features({"text": nlp.Value("string"),})
+FEATURES = nlp.Features(
+    {
+        "text": nlp.Value("string"),
+    }
+)
+
 
 @dataclass
 class TextConfig(nlp.BuilderConfig):
@@ -27,8 +32,7 @@ class TextConfig(nlp.BuilderConfig):
         if self.read_options is not None:
             read_options = self.read_options
         else:
-            read_options = pac.ReadOptions(
-                column_names=['text'])
+            read_options = pac.ReadOptions(column_names=["text"])
         if self.encoding is not None:
             read_options.encoding = self.encoding
         if self.block_size is not None:
@@ -43,13 +47,13 @@ class TextConfig(nlp.BuilderConfig):
             parse_options = self.parse_options
         else:
             parse_options = pac.ParseOptions(
-                delimiter='\r',
+                delimiter="\r",
                 quote_char=False,
                 double_quote=False,
                 escape_char=False,
                 newlines_in_values=False,
                 ignore_empty_lines=False,
-                )
+            )
         return parse_options
 
     @property
@@ -59,7 +63,7 @@ class TextConfig(nlp.BuilderConfig):
         else:
             convert_options = pac.ConvertOptions(
                 column_types=FEATURES.type,
-                )
+            )
         return convert_options
 
 
@@ -70,10 +74,10 @@ class Text(nlp.ArrowBasedBuilder):
         return nlp.DatasetInfo(features=FEATURES)
 
     def _split_generators(self, dl_manager):
-        """ The `datafiles` kwarg in load_dataset() can be a str, List[str], Dict[str,str], or Dict[str,List[str]].
+        """The `datafiles` kwarg in load_dataset() can be a str, List[str], Dict[str,str], or Dict[str,List[str]].
 
-            If str or List[str], then the dataset returns only the 'train' split.
-            If dict, then keys should be from the `nlp.Split` enum.
+        If str or List[str], then the dataset returns only the 'train' split.
+        If dict, then keys should be from the `nlp.Split` enum.
         """
         if not self.config.data_files:
             raise ValueError(f"At least one data file must be specified, but got data_files={self.config.data_files}")

--- a/datasets/tiny_shakespeare/tiny_shakespeare.py
+++ b/datasets/tiny_shakespeare/tiny_shakespeare.py
@@ -95,9 +95,13 @@ class TinyShakespeare(nlp.GeneratorBasedBuilder):
                 gen_kwargs={"split_key": "train", "split_text": train_text},
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.VALIDATION, gen_kwargs={"split_key": "validation", "split_text": validation_text},
+                name=nlp.Split.VALIDATION,
+                gen_kwargs={"split_key": "validation", "split_text": validation_text},
             ),
-            nlp.SplitGenerator(name=nlp.Split.TEST, gen_kwargs={"split_key": "test", "split_text": test_text},),
+            nlp.SplitGenerator(
+                name=nlp.Split.TEST,
+                gen_kwargs={"split_key": "test", "split_text": test_text},
+            ),
         ]
 
     def _generate_examples(self, split_key, split_text):

--- a/datasets/trec/trec.py
+++ b/datasets/trec/trec.py
@@ -146,12 +146,16 @@ class Trec(nlp.GeneratorBasedBuilder):
             nlp.SplitGenerator(
                 name=nlp.Split.TRAIN,
                 # These kwargs will be passed to _generate_examples
-                gen_kwargs={"filepath": dl_files["train"],},
+                gen_kwargs={
+                    "filepath": dl_files["train"],
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.TEST,
                 # These kwargs will be passed to _generate_examples
-                gen_kwargs={"filepath": dl_files["test"],},
+                gen_kwargs={
+                    "filepath": dl_files["test"],
+                },
             ),
         ]
 

--- a/datasets/trec/trec.py
+++ b/datasets/trec/trec.py
@@ -16,10 +16,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import csv
-import json
-import os
-
 import nlp
 
 

--- a/datasets/trivia_qa/trivia_qa.py
+++ b/datasets/trivia_qa/trivia_qa.py
@@ -84,13 +84,13 @@ class TriviaQaConfig(nlp.BuilderConfig):
     def __init__(self, unfiltered=False, exclude_context=False, **kwargs):
         """BuilderConfig for TriviaQA.
 
-    Args:
-      unfiltered: bool, whether to use the unfiltered version of the dataset,
-        intended for open-domain QA.
-      exclude_context: bool, whether to exclude Wikipedia and search context for
-        reduced size.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          unfiltered: bool, whether to use the unfiltered version of the dataset,
+            intended for open-domain QA.
+          exclude_context: bool, whether to exclude Wikipedia and search context for
+            reduced size.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "unfiltered" if unfiltered else "rc"
         if exclude_context:
             name += ".nocontext"
@@ -107,8 +107,8 @@ class TriviaQaConfig(nlp.BuilderConfig):
 class TriviaQa(nlp.GeneratorBasedBuilder):
     """TriviaQA is a reading comprehension dataset.
 
-  It containss over 650K question-answer-evidence triples.
-  """
+    It containss over 650K question-answer-evidence triples.
+    """
 
     BUILDER_CONFIGS = [
         TriviaQaConfig(unfiltered=False, exclude_context=False),  # rc

--- a/datasets/tydiqa/tydiqa.py
+++ b/datasets/tydiqa/tydiqa.py
@@ -135,7 +135,10 @@ class Tydiqa(nlp.GeneratorBasedBuilder):
                         "context": nlp.Value("string"),
                         "question": nlp.Value("string"),
                         "answers": nlp.features.Sequence(
-                            {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                            {
+                                "text": nlp.Value("string"),
+                                "answer_start": nlp.Value("int32"),
+                            }
                         ),
                     }
                 ),
@@ -256,5 +259,8 @@ class Tydiqa(nlp.GeneratorBasedBuilder):
                                 "context": context,
                                 "question": question,
                                 "id": id_,
-                                "answers": {"answer_start": answer_starts, "text": answers,},
+                                "answers": {
+                                    "answer_start": answer_starts,
+                                    "text": answers,
+                                },
                             }

--- a/datasets/tydiqa/tydiqa.py
+++ b/datasets/tydiqa/tydiqa.py
@@ -21,11 +21,11 @@ journal = {Transactions of the Association for Computational Linguistics}
 
 # TODO(tydiqa):
 _DESCRIPTION = """\
-TyDi QA is a question answering dataset covering 11 typologically diverse languages with 204K question-answer pairs. 
-The languages of TyDi QA are diverse with regard to their typology -- the set of linguistic features that each language 
-expresses -- such that we expect models performing well on this set to generalize across a large number of the languages 
-in the world. It contains language phenomena that would not be found in English-only corpora. To provide a realistic 
-information-seeking task and avoid priming effects, questions are written by people who want to know the answer, but 
+TyDi QA is a question answering dataset covering 11 typologically diverse languages with 204K question-answer pairs.
+The languages of TyDi QA are diverse with regard to their typology -- the set of linguistic features that each language
+expresses -- such that we expect models performing well on this set to generalize across a large number of the languages
+in the world. It contains language phenomena that would not be found in English-only corpora. To provide a realistic
+information-seeking task and avoid priming effects, questions are written by people who want to know the answer, but
 don’t know the answer yet, (unlike SQuAD and its descendents) and the data is collected directly in each language without
 the use of translation (unlike MLQA and XQuAD).
 """
@@ -61,22 +61,22 @@ class Tydiqa(nlp.GeneratorBasedBuilder):
             name="primary_task",
             description=textwrap.dedent(
                 """\
-          Passage selection task (SelectP): Given a list of the passages in the article, return either (a) the index of 
+          Passage selection task (SelectP): Given a list of the passages in the article, return either (a) the index of
           the passage that answers the question or (b) NULL if no such passage exists.
-          Minimal answer span task (MinSpan): Given the full text of an article, return one of (a) the start and end 
-          byte indices of the minimal span that completely answers the question; (b) YES or NO if the question requires 
-          a yes/no answer and we can draw a conclusion from the passage; (c) NULL if it is not possible to produce a 
+          Minimal answer span task (MinSpan): Given the full text of an article, return one of (a) the start and end
+          byte indices of the minimal span that completely answers the question; (b) YES or NO if the question requires
+          a yes/no answer and we can draw a conclusion from the passage; (c) NULL if it is not possible to produce a
           minimal answer for this question."""
             ),
         ),
         TydiqaConfig(
             name="secondary_task",
             description=textwrap.dedent(
-                """\Gold passage task (GoldP): Given a passage that is guaranteed to contain the 
-          answer, predict the single contiguous span of characters that answers the question. This is more similar to 
-          existing reading comprehension datasets (as opposed to the information-seeking task outlined above). 
-          This task is constructed with two goals in mind: (1) more directly comparing with prior work and (2) providing 
-          a simplified way for researchers to use TyDi QA by providing compatibility with existing code for SQuAD 1.1, 
+                """Gold passage task (GoldP): Given a passage that is guaranteed to contain the
+          answer, predict the single contiguous span of characters that answers the question. This is more similar to
+          existing reading comprehension datasets (as opposed to the information-seeking task outlined above).
+          This task is constructed with two goals in mind: (1) more directly comparing with prior work and (2) providing
+          a simplified way for researchers to use TyDi QA by providing compatibility with existing code for SQuAD 1.1,
           XQuAD, and MLQA. Toward these goals, the gold passage task differs from the primary task in several ways:
           only the gold answer passage is provided rather than the entire Wikipedia article;
           unanswerable questions have been discarded, similar to MLQA and XQuAD;
@@ -104,7 +104,7 @@ class Tydiqa(nlp.GeneratorBasedBuilder):
                         "language": nlp.Value("string"),
                         "annotations": nlp.features.Sequence(
                             {
-                                #'annotation_id': nlp.Value('variant'),
+                                # 'annotation_id': nlp.Value('variant'),
                                 "passage_answer_candidate_index": nlp.Value("int32"),
                                 "minimal_answers_start_byte": nlp.Value("int32"),
                                 "minimal_answers_end_byte": nlp.Value("int32"),
@@ -205,7 +205,7 @@ class Tydiqa(nlp.GeneratorBasedBuilder):
                     lang = data["language"]
                     question = data["question_text"]
                     annotations = data["annotations"]
-                    annot_ids = [annotation["annotation_id"] for annotation in annotations]
+                    # annot_ids = [annotation["annotation_id"] for annotation in annotations]
                     yes_no_answers = [annotation["yes_no_answer"] for annotation in annotations]
                     min_answers_end_byte = [
                         annotation["minimal_answer"]["plaintext_end_byte"] for annotation in annotations
@@ -217,7 +217,7 @@ class Tydiqa(nlp.GeneratorBasedBuilder):
                         annotation["passage_answer"]["candidate_index"] for annotation in annotations
                     ]
                     doc = data["document_plaintext"]
-                    example_id = data["example_id"]
+                    # example_id = data["example_id"]
                     url = data["document_url"]
                     yield id_, {
                         "passage_answer_candidates": {
@@ -228,14 +228,14 @@ class Tydiqa(nlp.GeneratorBasedBuilder):
                         "document_title": title,
                         "language": lang,
                         "annotations": {
-                            #'annotation_id': annot_ids,
+                            # 'annotation_id': annot_ids,
                             "passage_answer_candidate_index": passage_cand_answers,
                             "minimal_answers_start_byte": min_answers_start_byte,
                             "minimal_answers_end_byte": min_answers_end_byte,
                             "yes_no_answer": yes_no_answers,
                         },
                         "document_plaintext": doc,
-                        #'example_id': example_id,
+                        # 'example_id': example_id,
                         "document_url": url,
                     }
         elif self.config.name == "secondary_task":

--- a/datasets/ubuntu_dialogs_corpus/ubuntu_dialogs_corpus.py
+++ b/datasets/ubuntu_dialogs_corpus/ubuntu_dialogs_corpus.py
@@ -41,10 +41,10 @@ class UbuntuDialogsCorpusConfig(nlp.BuilderConfig):
     def __init__(self, features, **kwargs):
         """BuilderConfig for UbuntuDialogsCorpus.
 
-    Args:
+        Args:
 
-      **kwargs: keyword arguments forwarded to super.
-    """
+          **kwargs: keyword arguments forwarded to super.
+        """
 
         super(UbuntuDialogsCorpusConfig, self).__init__(version=nlp.Version("2.0.0"), **kwargs)
         self.features = features

--- a/datasets/wiki40b/wiki40b.py
+++ b/datasets/wiki40b/wiki40b.py
@@ -97,10 +97,10 @@ class Wiki40bConfig(nlp.BuilderConfig):
     def __init__(self, language=None, **kwargs):
         """BuilderConfig for Wiki40B.
 
-    Args:
-      language: string, the language code for the Wiki40B dataset to use.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          language: string, the language code for the Wiki40B dataset to use.
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(Wiki40bConfig, self).__init__(
             name=str(language), description="Wiki40B dataset for {0}.".format(language), **kwargs
         )
@@ -114,7 +114,10 @@ class Wiki40b(nlp.BeamBasedBuilder):
     """Wiki40B: A Clean Wikipedia Dataset for Mutlilingual Language Modeling."""
 
     BUILDER_CONFIGS = [
-        Wiki40bConfig(version=_VERSION, language=lang,)  # pylint:disable=g-complex-comprehension
+        Wiki40bConfig(
+            version=_VERSION,
+            language=lang,
+        )  # pylint:disable=g-complex-comprehension
         for lang in WIKIPEDIA_LANGUAGES
     ]
 

--- a/datasets/wiki_dpr/wiki_dpr.py
+++ b/datasets/wiki_dpr/wiki_dpr.py
@@ -47,11 +47,11 @@ class WikiDprConfig(nlp.BuilderConfig):
         **kwargs,
     ):
         """BuilderConfig for WikiSnippets.
-    Args:
-        with_embeddings (`bool`, defaults to `True`): Load the 768-dimensional embeddings from DPR trained on NQ.
-        with_index (`bool`, defaults to `True`): Load the faiss index trained on the embeddings.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+            with_embeddings (`bool`, defaults to `True`): Load the 768-dimensional embeddings from DPR trained on NQ.
+            with_index (`bool`, defaults to `True`): Load the faiss index trained on the embeddings.
+          **kwargs: keyword arguments forwarded to super.
+        """
         self.with_embeddings = with_embeddings
         self.with_index = with_index
         self.wiki_split = wiki_split

--- a/datasets/wiki_qa/wiki_qa.py
+++ b/datasets/wiki_qa/wiki_qa.py
@@ -25,7 +25,7 @@ _DESCRIPTION = """\
 Wiki Question Answering corpus from Microsoft
 """
 
-_DATA_URL = "https://download.microsoft.com/download/E/5/f/E5FCFCEE-7005-4814-853D-DAA7C66507E0/WikiQACorpus.zip"  #'https://www.microsoft.com/en-us/download/confirmation.aspx?id=52419'
+_DATA_URL = "https://download.microsoft.com/download/E/5/f/E5FCFCEE-7005-4814-853D-DAA7C66507E0/WikiQACorpus.zip"  # 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=52419'
 
 
 class WikiQa(nlp.GeneratorBasedBuilder):

--- a/datasets/wiki_snippets/wiki_snippets.py
+++ b/datasets/wiki_snippets/wiki_snippets.py
@@ -127,9 +127,9 @@ class WikiSnippetsConfig(nlp.BuilderConfig):
         self, wikipedia_name="wiki40b", wikipedia_version_name="en", snippets_length=100, snippets_overlap=0, **kwargs
     ):
         """BuilderConfig for WikiSnippets.
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(WikiSnippetsConfig, self).__init__(**kwargs)
         self.wikipedia_name = wikipedia_name
         self.wikipedia_version_name = wikipedia_version_name
@@ -184,7 +184,10 @@ class WikiSnippets(nlp.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager):
 
-        wikipedia = nlp.load_dataset(path=self.config.wikipedia_name, name=self.config.wikipedia_version_name,)
+        wikipedia = nlp.load_dataset(
+            path=self.config.wikipedia_name,
+            name=self.config.wikipedia_version_name,
+        )
 
         return [
             nlp.SplitGenerator(name=nlp.Split.TRAIN, gen_kwargs={"wikipedia": wikipedia}),

--- a/datasets/wiki_split/wiki_split.py
+++ b/datasets/wiki_split/wiki_split.py
@@ -22,8 +22,8 @@ _CITATION = """\
 
 # TODO(wiki_split):
 _DESCRIPTION = """\
-One million English sentences, each split into two sentences that together preserve the original meaning, extracted from Wikipedia 
-Google's WikiSplit dataset was constructed automatically from the publicly available Wikipedia revision history. Although 
+One million English sentences, each split into two sentences that together preserve the original meaning, extracted from Wikipedia
+Google's WikiSplit dataset was constructed automatically from the publicly available Wikipedia revision history. Although
 the dataset contains some inherent noise, it can serve as valuable training data for models that split or merge sentences.
 """
 _URL = "https://github.com/google-research-datasets/wiki-split/raw/master"

--- a/datasets/wikihow/wikihow.py
+++ b/datasets/wikihow/wikihow.py
@@ -73,10 +73,10 @@ class WikihowConfig(nlp.BuilderConfig):
     def __init__(self, filename=None, **kwargs):
         """BuilderConfig for Wikihow.
 
-    Args:
-      filename: filename of different configs for the dataset.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          filename: filename of different configs for the dataset.
+          **kwargs: keyword arguments forwarded to super.
+        """
         # Version 1.1.0 remove empty document and summary strings.
         # Version 1.2.0 add train validation test split, add cleaning & filtering.
         super(WikihowConfig, self).__init__(version=nlp.Version("1.2.0"), **kwargs)
@@ -142,14 +142,25 @@ class Wikihow(nlp.GeneratorBasedBuilder):
             )
         return [
             nlp.SplitGenerator(
-                name=nlp.Split.TRAIN, gen_kwargs={"path": path_to_manual_file, "title_set": titles["train"],},
+                name=nlp.Split.TRAIN,
+                gen_kwargs={
+                    "path": path_to_manual_file,
+                    "title_set": titles["train"],
+                },
             ),
             nlp.SplitGenerator(
                 name=nlp.Split.VALIDATION,
-                gen_kwargs={"path": path_to_manual_file, "title_set": titles["validation"],},
+                gen_kwargs={
+                    "path": path_to_manual_file,
+                    "title_set": titles["validation"],
+                },
             ),
             nlp.SplitGenerator(
-                name=nlp.Split.TEST, gen_kwargs={"path": path_to_manual_file, "title_set": titles["test"],},
+                name=nlp.Split.TEST,
+                gen_kwargs={
+                    "path": path_to_manual_file,
+                    "title_set": titles["test"],
+                },
             ),
         ]
 

--- a/datasets/wikipedia/wikipedia.py
+++ b/datasets/wikipedia/wikipedia.py
@@ -373,12 +373,12 @@ class WikipediaConfig(nlp.BuilderConfig):
     def __init__(self, language=None, date=None, **kwargs):
         """BuilderConfig for Wikipedia.
 
-    Args:
-      language: string, the language code for the Wikipedia dump to use.
-      date: string, date of the Wikipedia dump in YYYYMMDD format. A list of
-        available dates can be found at https://dumps.wikimedia.org/enwiki/.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          language: string, the language code for the Wikipedia dump to use.
+          date: string, date of the Wikipedia dump in YYYYMMDD format. A list of
+            available dates can be found at https://dumps.wikimedia.org/enwiki/.
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(WikipediaConfig, self).__init__(
             name="{0}.{1}".format(date, language),
             description="Wikipedia dataset for {0}, parsed from {1} dump.".format(language, date),
@@ -397,7 +397,11 @@ class Wikipedia(nlp.BeamBasedBuilder):
     # Use mirror (your.org) to avoid download caps.
 
     BUILDER_CONFIGS = [
-        WikipediaConfig(version=_VERSION, language=lang, date="20200501",)  # pylint:disable=g-complex-comprehension
+        WikipediaConfig(
+            version=_VERSION,
+            language=lang,
+            date="20200501",
+        )  # pylint:disable=g-complex-comprehension
         for lang in WIKIPEDIA_LANGUAGES
     ]
 
@@ -426,9 +430,11 @@ class Wikipedia(nlp.BeamBasedBuilder):
         with open(downloaded_files["info"], encoding="utf-8") as f:
             dump_info = json.load(f)
         multistream_dump_info = dump_info["jobs"]["articlesmultistreamdump"]
-        assert multistream_dump_info["status"] == "done", (
-            "Specified dump (%s) multistream status is not 'done': %s"
-            % (_base_url(lang), multistream_dump_info["status"])
+        assert (
+            multistream_dump_info["status"] == "done"
+        ), "Specified dump (%s) multistream status is not 'done': %s" % (
+            _base_url(lang),
+            multistream_dump_info["status"],
         )
 
         for fname, info in multistream_dump_info["files"].items():

--- a/datasets/wikisql/wikisql.py
+++ b/datasets/wikisql/wikisql.py
@@ -143,7 +143,10 @@ class WikiSQL(nlp.GeneratorBasedBuilder):
 
                 # Get human-readable version
                 row["sql"]["human_readable"] = self._convert_to_human_readable(
-                    row["sql"]["sel"], row["sql"]["agg"], row["table"]["header"], row["sql"]["conds"],
+                    row["sql"]["sel"],
+                    row["sql"]["agg"],
+                    row["table"]["header"],
+                    row["sql"]["conds"],
                 )
 
                 # Restructure sql->conds

--- a/datasets/wikitext/wikitext.py
+++ b/datasets/wikitext/wikitext.py
@@ -30,11 +30,16 @@ class WikitextConfig(nlp.BuilderConfig):
     def __init__(self, data_url, **kwargs):
         """BuilderConfig for Wikitext
 
-    Args:
-      data_url: `string`, url to the dataset (word or raw level)
-      **kwargs: keyword arguments forwarded to super.
-    """
-        super(WikitextConfig, self).__init__(version=nlp.Version("1.0.0",), **kwargs)
+        Args:
+          data_url: `string`, url to the dataset (word or raw level)
+          **kwargs: keyword arguments forwarded to super.
+        """
+        super(WikitextConfig, self).__init__(
+            version=nlp.Version(
+                "1.0.0",
+            ),
+            **kwargs,
+        )
         self.data_url = data_url
 
 

--- a/datasets/wikitext/wikitext.py
+++ b/datasets/wikitext/wikitext.py
@@ -17,7 +17,7 @@ _CITATION = """\
 
 # TODO(wikitext):
 _DESCRIPTION = """\
- The WikiText language modeling dataset is a collection of over 100 million tokens extracted from the set of verified 
+ The WikiText language modeling dataset is a collection of over 100 million tokens extracted from the set of verified
  Good and Featured articles on Wikipedia. The dataset is available under the Creative Commons Attribution-ShareAlike License.
 """
 _URL = "https://blog.einstein.ai/the-wikitext-long-term-dependency-language-modeling-dataset/"

--- a/datasets/winogrande/winogrande.py
+++ b/datasets/winogrande/winogrande.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import csv
 import json
 import os
 
@@ -22,9 +21,9 @@ year={2019}
 # TODO(winogrande):
 _DESCRIPTION = """\
 WinoGrande is a new collection of 44k problems, inspired by Winograd Schema Challenge (Levesque, Davis, and Morgenstern
- 2011), but adjusted to improve the scale and robustness against the dataset-specific bias. Formulated as a 
-fill-in-a-blank task with binary options, the goal is to choose the right option for a given sentence which requires 
-commonsense reasoning. 
+ 2011), but adjusted to improve the scale and robustness against the dataset-specific bias. Formulated as a
+fill-in-a-blank task with binary options, the goal is to choose the right option for a given sentence which requires
+commonsense reasoning.
 """
 
 _URL = "https://storage.googleapis.com/ai2-mosaic/public/winogrande/winogrande_1.1.zip"
@@ -94,7 +93,7 @@ class Winogrande(nlp.GeneratorBasedBuilder):
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
                     "filepath": os.path.join(data_dir, "train_{}.jsonl".format(self.config.data_size)),
-                    #'labelpath': os.path.join(data_dir, 'train_{}-labels.lst'.format(self.config.data_size)),
+                    # 'labelpath': os.path.join(data_dir, 'train_{}-labels.lst'.format(self.config.data_size)),
                     "split": "train",
                 },
             ),
@@ -108,7 +107,7 @@ class Winogrande(nlp.GeneratorBasedBuilder):
                 # These kwargs will be passed to _generate_examples
                 gen_kwargs={
                     "filepath": os.path.join(data_dir, "dev.jsonl"),
-                    #'labelpath': os.path.join(data_dir, 'dev-labels.lst'),
+                    # 'labelpath': os.path.join(data_dir, 'dev-labels.lst'),
                     "split": "dev",
                 },
             ),

--- a/datasets/wiqa/wiqa.py
+++ b/datasets/wiqa/wiqa.py
@@ -20,7 +20,7 @@ _CITATION = """\
 
 # TODO(wiqa):
 _DESCRIPTION = """\
-The WIQA dataset V1 has 39705 questions containing a perturbation and a possible effect in the context of a paragraph. 
+The WIQA dataset V1 has 39705 questions containing a perturbation and a possible effect in the context of a paragraph.
 The dataset is split into 29808 train questions, 6894 dev questions and 3003 test questions.
 """
 _URL = "https://public-aristo-processes.s3-us-west-2.amazonaws.com/wiqa_dataset_no_explanation_v2/wiqa-dataset-v2-october-2019.zip"

--- a/datasets/wmt14/wmt_utils.py
+++ b/datasets/wmt14/wmt_utils.py
@@ -65,28 +65,28 @@ class SubDataset(object):
     def __init__(self, name, target, sources, url, path, manual_dl_files=None):
         """Sub-dataset of WMT.
 
-    Args:
-      name: `string`, a unique dataset identifier.
-      target: `string`, the target language code.
-      sources: `set<string>`, the set of source language codes.
-      url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
-        where to download the raw data from. If two strings are provided, the
-        first is used for the source language and the second for the target.
-        Template strings can either contain '{src}' placeholders that will be
-        filled in with the source language code, '{0}' and '{1}' placeholders
-        that will be filled in with the source and target language codes in
-        alphabetical order, or all 3.
-      path: `string` or `(string, string)`, path(s) or path template(s)
-        specifing the path to the raw data relative to the root of the
-        downloaded archive. If two strings are provided, the dataset is assumed
-        to be made up of parallel text files, the first being the source and the
-        second the target. If one string is provided, both languages are assumed
-        to be stored within the same file and the extension is used to determine
-        how to parse it. Template strings should be formatted the same as in
-        `url`.
-      manual_dl_files: `<list>(string)` (optional), the list of files that must
-        be manually downloaded to the data directory.
-    """
+        Args:
+          name: `string`, a unique dataset identifier.
+          target: `string`, the target language code.
+          sources: `set<string>`, the set of source language codes.
+          url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
+            where to download the raw data from. If two strings are provided, the
+            first is used for the source language and the second for the target.
+            Template strings can either contain '{src}' placeholders that will be
+            filled in with the source language code, '{0}' and '{1}' placeholders
+            that will be filled in with the source and target language codes in
+            alphabetical order, or all 3.
+          path: `string` or `(string, string)`, path(s) or path template(s)
+            specifing the path to the raw data relative to the root of the
+            downloaded archive. If two strings are provided, the dataset is assumed
+            to be made up of parallel text files, the first being the source and the
+            second the target. If one string is provided, both languages are assumed
+            to be stored within the same file and the extension is used to determine
+            how to parse it. Template strings should be formatted the same as in
+            `url`.
+          manual_dl_files: `<list>(string)` (optional), the list of files that must
+            be manually downloaded to the data directory.
+        """
         self._paths = (path,) if isinstance(path, six.string_types) else path
         self._urls = (url,) if isinstance(url, six.string_types) else url
         self._manual_dl_files = manual_dl_files if manual_dl_files else []
@@ -633,18 +633,18 @@ class WmtConfig(nlp.BuilderConfig):
     def __init__(self, url=None, citation=None, description=None, language_pair=(None, None), subsets=None, **kwargs):
         """BuilderConfig for WMT.
 
-    Args:
-      url: The reference URL for the dataset.
-      citation: The paper citation for the dataset.
-      description: The description of the dataset.
-      language_pair: pair of languages that will be used for translation. Should
-                 contain 2 letter coded strings. For example: ("en", "de").
-        configuration for the `nlp.features.text.TextEncoder` used for the
-        `nlp.features.text.Translation` features.
-      subsets: Dict[split, list[str]]. List of the subset to use for each of the
-        split. Note that WMT subclasses overwrite this parameter.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          url: The reference URL for the dataset.
+          citation: The paper citation for the dataset.
+          description: The description of the dataset.
+          language_pair: pair of languages that will be used for translation. Should
+                     contain 2 letter coded strings. For example: ("en", "de").
+            configuration for the `nlp.features.text.TextEncoder` used for the
+            `nlp.features.text.Translation` features.
+          subsets: Dict[split, list[str]]. List of the subset to use for each of the
+            split. Note that WMT subclasses overwrite this parameter.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s-%s" % (language_pair[0], language_pair[1])
         if "name" in kwargs:  # Add name suffix for custom configs
             name += "." + kwargs.pop("name")

--- a/datasets/wmt15/wmt_utils.py
+++ b/datasets/wmt15/wmt_utils.py
@@ -65,28 +65,28 @@ class SubDataset(object):
     def __init__(self, name, target, sources, url, path, manual_dl_files=None):
         """Sub-dataset of WMT.
 
-    Args:
-      name: `string`, a unique dataset identifier.
-      target: `string`, the target language code.
-      sources: `set<string>`, the set of source language codes.
-      url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
-        where to download the raw data from. If two strings are provided, the
-        first is used for the source language and the second for the target.
-        Template strings can either contain '{src}' placeholders that will be
-        filled in with the source language code, '{0}' and '{1}' placeholders
-        that will be filled in with the source and target language codes in
-        alphabetical order, or all 3.
-      path: `string` or `(string, string)`, path(s) or path template(s)
-        specifing the path to the raw data relative to the root of the
-        downloaded archive. If two strings are provided, the dataset is assumed
-        to be made up of parallel text files, the first being the source and the
-        second the target. If one string is provided, both languages are assumed
-        to be stored within the same file and the extension is used to determine
-        how to parse it. Template strings should be formatted the same as in
-        `url`.
-      manual_dl_files: `<list>(string)` (optional), the list of files that must
-        be manually downloaded to the data directory.
-    """
+        Args:
+          name: `string`, a unique dataset identifier.
+          target: `string`, the target language code.
+          sources: `set<string>`, the set of source language codes.
+          url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
+            where to download the raw data from. If two strings are provided, the
+            first is used for the source language and the second for the target.
+            Template strings can either contain '{src}' placeholders that will be
+            filled in with the source language code, '{0}' and '{1}' placeholders
+            that will be filled in with the source and target language codes in
+            alphabetical order, or all 3.
+          path: `string` or `(string, string)`, path(s) or path template(s)
+            specifing the path to the raw data relative to the root of the
+            downloaded archive. If two strings are provided, the dataset is assumed
+            to be made up of parallel text files, the first being the source and the
+            second the target. If one string is provided, both languages are assumed
+            to be stored within the same file and the extension is used to determine
+            how to parse it. Template strings should be formatted the same as in
+            `url`.
+          manual_dl_files: `<list>(string)` (optional), the list of files that must
+            be manually downloaded to the data directory.
+        """
         self._paths = (path,) if isinstance(path, six.string_types) else path
         self._urls = (url,) if isinstance(url, six.string_types) else url
         self._manual_dl_files = manual_dl_files if manual_dl_files else []
@@ -633,18 +633,18 @@ class WmtConfig(nlp.BuilderConfig):
     def __init__(self, url=None, citation=None, description=None, language_pair=(None, None), subsets=None, **kwargs):
         """BuilderConfig for WMT.
 
-    Args:
-      url: The reference URL for the dataset.
-      citation: The paper citation for the dataset.
-      description: The description of the dataset.
-      language_pair: pair of languages that will be used for translation. Should
-                 contain 2 letter coded strings. For example: ("en", "de").
-        configuration for the `nlp.features.text.TextEncoder` used for the
-        `nlp.features.text.Translation` features.
-      subsets: Dict[split, list[str]]. List of the subset to use for each of the
-        split. Note that WMT subclasses overwrite this parameter.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          url: The reference URL for the dataset.
+          citation: The paper citation for the dataset.
+          description: The description of the dataset.
+          language_pair: pair of languages that will be used for translation. Should
+                     contain 2 letter coded strings. For example: ("en", "de").
+            configuration for the `nlp.features.text.TextEncoder` used for the
+            `nlp.features.text.Translation` features.
+          subsets: Dict[split, list[str]]. List of the subset to use for each of the
+            split. Note that WMT subclasses overwrite this parameter.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s-%s" % (language_pair[0], language_pair[1])
         if "name" in kwargs:  # Add name suffix for custom configs
             name += "." + kwargs.pop("name")

--- a/datasets/wmt16/wmt_utils.py
+++ b/datasets/wmt16/wmt_utils.py
@@ -65,28 +65,28 @@ class SubDataset(object):
     def __init__(self, name, target, sources, url, path, manual_dl_files=None):
         """Sub-dataset of WMT.
 
-    Args:
-      name: `string`, a unique dataset identifier.
-      target: `string`, the target language code.
-      sources: `set<string>`, the set of source language codes.
-      url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
-        where to download the raw data from. If two strings are provided, the
-        first is used for the source language and the second for the target.
-        Template strings can either contain '{src}' placeholders that will be
-        filled in with the source language code, '{0}' and '{1}' placeholders
-        that will be filled in with the source and target language codes in
-        alphabetical order, or all 3.
-      path: `string` or `(string, string)`, path(s) or path template(s)
-        specifing the path to the raw data relative to the root of the
-        downloaded archive. If two strings are provided, the dataset is assumed
-        to be made up of parallel text files, the first being the source and the
-        second the target. If one string is provided, both languages are assumed
-        to be stored within the same file and the extension is used to determine
-        how to parse it. Template strings should be formatted the same as in
-        `url`.
-      manual_dl_files: `<list>(string)` (optional), the list of files that must
-        be manually downloaded to the data directory.
-    """
+        Args:
+          name: `string`, a unique dataset identifier.
+          target: `string`, the target language code.
+          sources: `set<string>`, the set of source language codes.
+          url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
+            where to download the raw data from. If two strings are provided, the
+            first is used for the source language and the second for the target.
+            Template strings can either contain '{src}' placeholders that will be
+            filled in with the source language code, '{0}' and '{1}' placeholders
+            that will be filled in with the source and target language codes in
+            alphabetical order, or all 3.
+          path: `string` or `(string, string)`, path(s) or path template(s)
+            specifing the path to the raw data relative to the root of the
+            downloaded archive. If two strings are provided, the dataset is assumed
+            to be made up of parallel text files, the first being the source and the
+            second the target. If one string is provided, both languages are assumed
+            to be stored within the same file and the extension is used to determine
+            how to parse it. Template strings should be formatted the same as in
+            `url`.
+          manual_dl_files: `<list>(string)` (optional), the list of files that must
+            be manually downloaded to the data directory.
+        """
         self._paths = (path,) if isinstance(path, six.string_types) else path
         self._urls = (url,) if isinstance(url, six.string_types) else url
         self._manual_dl_files = manual_dl_files if manual_dl_files else []
@@ -633,18 +633,18 @@ class WmtConfig(nlp.BuilderConfig):
     def __init__(self, url=None, citation=None, description=None, language_pair=(None, None), subsets=None, **kwargs):
         """BuilderConfig for WMT.
 
-    Args:
-      url: The reference URL for the dataset.
-      citation: The paper citation for the dataset.
-      description: The description of the dataset.
-      language_pair: pair of languages that will be used for translation. Should
-                 contain 2 letter coded strings. For example: ("en", "de").
-        configuration for the `nlp.features.text.TextEncoder` used for the
-        `nlp.features.text.Translation` features.
-      subsets: Dict[split, list[str]]. List of the subset to use for each of the
-        split. Note that WMT subclasses overwrite this parameter.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          url: The reference URL for the dataset.
+          citation: The paper citation for the dataset.
+          description: The description of the dataset.
+          language_pair: pair of languages that will be used for translation. Should
+                     contain 2 letter coded strings. For example: ("en", "de").
+            configuration for the `nlp.features.text.TextEncoder` used for the
+            `nlp.features.text.Translation` features.
+          subsets: Dict[split, list[str]]. List of the subset to use for each of the
+            split. Note that WMT subclasses overwrite this parameter.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s-%s" % (language_pair[0], language_pair[1])
         if "name" in kwargs:  # Add name suffix for custom configs
             name += "." + kwargs.pop("name")

--- a/datasets/wmt17/wmt_utils.py
+++ b/datasets/wmt17/wmt_utils.py
@@ -65,28 +65,28 @@ class SubDataset(object):
     def __init__(self, name, target, sources, url, path, manual_dl_files=None):
         """Sub-dataset of WMT.
 
-    Args:
-      name: `string`, a unique dataset identifier.
-      target: `string`, the target language code.
-      sources: `set<string>`, the set of source language codes.
-      url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
-        where to download the raw data from. If two strings are provided, the
-        first is used for the source language and the second for the target.
-        Template strings can either contain '{src}' placeholders that will be
-        filled in with the source language code, '{0}' and '{1}' placeholders
-        that will be filled in with the source and target language codes in
-        alphabetical order, or all 3.
-      path: `string` or `(string, string)`, path(s) or path template(s)
-        specifing the path to the raw data relative to the root of the
-        downloaded archive. If two strings are provided, the dataset is assumed
-        to be made up of parallel text files, the first being the source and the
-        second the target. If one string is provided, both languages are assumed
-        to be stored within the same file and the extension is used to determine
-        how to parse it. Template strings should be formatted the same as in
-        `url`.
-      manual_dl_files: `<list>(string)` (optional), the list of files that must
-        be manually downloaded to the data directory.
-    """
+        Args:
+          name: `string`, a unique dataset identifier.
+          target: `string`, the target language code.
+          sources: `set<string>`, the set of source language codes.
+          url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
+            where to download the raw data from. If two strings are provided, the
+            first is used for the source language and the second for the target.
+            Template strings can either contain '{src}' placeholders that will be
+            filled in with the source language code, '{0}' and '{1}' placeholders
+            that will be filled in with the source and target language codes in
+            alphabetical order, or all 3.
+          path: `string` or `(string, string)`, path(s) or path template(s)
+            specifing the path to the raw data relative to the root of the
+            downloaded archive. If two strings are provided, the dataset is assumed
+            to be made up of parallel text files, the first being the source and the
+            second the target. If one string is provided, both languages are assumed
+            to be stored within the same file and the extension is used to determine
+            how to parse it. Template strings should be formatted the same as in
+            `url`.
+          manual_dl_files: `<list>(string)` (optional), the list of files that must
+            be manually downloaded to the data directory.
+        """
         self._paths = (path,) if isinstance(path, six.string_types) else path
         self._urls = (url,) if isinstance(url, six.string_types) else url
         self._manual_dl_files = manual_dl_files if manual_dl_files else []
@@ -633,18 +633,18 @@ class WmtConfig(nlp.BuilderConfig):
     def __init__(self, url=None, citation=None, description=None, language_pair=(None, None), subsets=None, **kwargs):
         """BuilderConfig for WMT.
 
-    Args:
-      url: The reference URL for the dataset.
-      citation: The paper citation for the dataset.
-      description: The description of the dataset.
-      language_pair: pair of languages that will be used for translation. Should
-                 contain 2 letter coded strings. For example: ("en", "de").
-        configuration for the `nlp.features.text.TextEncoder` used for the
-        `nlp.features.text.Translation` features.
-      subsets: Dict[split, list[str]]. List of the subset to use for each of the
-        split. Note that WMT subclasses overwrite this parameter.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          url: The reference URL for the dataset.
+          citation: The paper citation for the dataset.
+          description: The description of the dataset.
+          language_pair: pair of languages that will be used for translation. Should
+                     contain 2 letter coded strings. For example: ("en", "de").
+            configuration for the `nlp.features.text.TextEncoder` used for the
+            `nlp.features.text.Translation` features.
+          subsets: Dict[split, list[str]]. List of the subset to use for each of the
+            split. Note that WMT subclasses overwrite this parameter.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s-%s" % (language_pair[0], language_pair[1])
         if "name" in kwargs:  # Add name suffix for custom configs
             name += "." + kwargs.pop("name")

--- a/datasets/wmt18/wmt_utils.py
+++ b/datasets/wmt18/wmt_utils.py
@@ -65,28 +65,28 @@ class SubDataset(object):
     def __init__(self, name, target, sources, url, path, manual_dl_files=None):
         """Sub-dataset of WMT.
 
-    Args:
-      name: `string`, a unique dataset identifier.
-      target: `string`, the target language code.
-      sources: `set<string>`, the set of source language codes.
-      url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
-        where to download the raw data from. If two strings are provided, the
-        first is used for the source language and the second for the target.
-        Template strings can either contain '{src}' placeholders that will be
-        filled in with the source language code, '{0}' and '{1}' placeholders
-        that will be filled in with the source and target language codes in
-        alphabetical order, or all 3.
-      path: `string` or `(string, string)`, path(s) or path template(s)
-        specifing the path to the raw data relative to the root of the
-        downloaded archive. If two strings are provided, the dataset is assumed
-        to be made up of parallel text files, the first being the source and the
-        second the target. If one string is provided, both languages are assumed
-        to be stored within the same file and the extension is used to determine
-        how to parse it. Template strings should be formatted the same as in
-        `url`.
-      manual_dl_files: `<list>(string)` (optional), the list of files that must
-        be manually downloaded to the data directory.
-    """
+        Args:
+          name: `string`, a unique dataset identifier.
+          target: `string`, the target language code.
+          sources: `set<string>`, the set of source language codes.
+          url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
+            where to download the raw data from. If two strings are provided, the
+            first is used for the source language and the second for the target.
+            Template strings can either contain '{src}' placeholders that will be
+            filled in with the source language code, '{0}' and '{1}' placeholders
+            that will be filled in with the source and target language codes in
+            alphabetical order, or all 3.
+          path: `string` or `(string, string)`, path(s) or path template(s)
+            specifing the path to the raw data relative to the root of the
+            downloaded archive. If two strings are provided, the dataset is assumed
+            to be made up of parallel text files, the first being the source and the
+            second the target. If one string is provided, both languages are assumed
+            to be stored within the same file and the extension is used to determine
+            how to parse it. Template strings should be formatted the same as in
+            `url`.
+          manual_dl_files: `<list>(string)` (optional), the list of files that must
+            be manually downloaded to the data directory.
+        """
         self._paths = (path,) if isinstance(path, six.string_types) else path
         self._urls = (url,) if isinstance(url, six.string_types) else url
         self._manual_dl_files = manual_dl_files if manual_dl_files else []
@@ -633,18 +633,18 @@ class WmtConfig(nlp.BuilderConfig):
     def __init__(self, url=None, citation=None, description=None, language_pair=(None, None), subsets=None, **kwargs):
         """BuilderConfig for WMT.
 
-    Args:
-      url: The reference URL for the dataset.
-      citation: The paper citation for the dataset.
-      description: The description of the dataset.
-      language_pair: pair of languages that will be used for translation. Should
-                 contain 2 letter coded strings. For example: ("en", "de").
-        configuration for the `nlp.features.text.TextEncoder` used for the
-        `nlp.features.text.Translation` features.
-      subsets: Dict[split, list[str]]. List of the subset to use for each of the
-        split. Note that WMT subclasses overwrite this parameter.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          url: The reference URL for the dataset.
+          citation: The paper citation for the dataset.
+          description: The description of the dataset.
+          language_pair: pair of languages that will be used for translation. Should
+                     contain 2 letter coded strings. For example: ("en", "de").
+            configuration for the `nlp.features.text.TextEncoder` used for the
+            `nlp.features.text.Translation` features.
+          subsets: Dict[split, list[str]]. List of the subset to use for each of the
+            split. Note that WMT subclasses overwrite this parameter.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s-%s" % (language_pair[0], language_pair[1])
         if "name" in kwargs:  # Add name suffix for custom configs
             name += "." + kwargs.pop("name")

--- a/datasets/wmt19/wmt_utils.py
+++ b/datasets/wmt19/wmt_utils.py
@@ -65,28 +65,28 @@ class SubDataset(object):
     def __init__(self, name, target, sources, url, path, manual_dl_files=None):
         """Sub-dataset of WMT.
 
-    Args:
-      name: `string`, a unique dataset identifier.
-      target: `string`, the target language code.
-      sources: `set<string>`, the set of source language codes.
-      url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
-        where to download the raw data from. If two strings are provided, the
-        first is used for the source language and the second for the target.
-        Template strings can either contain '{src}' placeholders that will be
-        filled in with the source language code, '{0}' and '{1}' placeholders
-        that will be filled in with the source and target language codes in
-        alphabetical order, or all 3.
-      path: `string` or `(string, string)`, path(s) or path template(s)
-        specifing the path to the raw data relative to the root of the
-        downloaded archive. If two strings are provided, the dataset is assumed
-        to be made up of parallel text files, the first being the source and the
-        second the target. If one string is provided, both languages are assumed
-        to be stored within the same file and the extension is used to determine
-        how to parse it. Template strings should be formatted the same as in
-        `url`.
-      manual_dl_files: `<list>(string)` (optional), the list of files that must
-        be manually downloaded to the data directory.
-    """
+        Args:
+          name: `string`, a unique dataset identifier.
+          target: `string`, the target language code.
+          sources: `set<string>`, the set of source language codes.
+          url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
+            where to download the raw data from. If two strings are provided, the
+            first is used for the source language and the second for the target.
+            Template strings can either contain '{src}' placeholders that will be
+            filled in with the source language code, '{0}' and '{1}' placeholders
+            that will be filled in with the source and target language codes in
+            alphabetical order, or all 3.
+          path: `string` or `(string, string)`, path(s) or path template(s)
+            specifing the path to the raw data relative to the root of the
+            downloaded archive. If two strings are provided, the dataset is assumed
+            to be made up of parallel text files, the first being the source and the
+            second the target. If one string is provided, both languages are assumed
+            to be stored within the same file and the extension is used to determine
+            how to parse it. Template strings should be formatted the same as in
+            `url`.
+          manual_dl_files: `<list>(string)` (optional), the list of files that must
+            be manually downloaded to the data directory.
+        """
         self._paths = (path,) if isinstance(path, six.string_types) else path
         self._urls = (url,) if isinstance(url, six.string_types) else url
         self._manual_dl_files = manual_dl_files if manual_dl_files else []
@@ -633,18 +633,18 @@ class WmtConfig(nlp.BuilderConfig):
     def __init__(self, url=None, citation=None, description=None, language_pair=(None, None), subsets=None, **kwargs):
         """BuilderConfig for WMT.
 
-    Args:
-      url: The reference URL for the dataset.
-      citation: The paper citation for the dataset.
-      description: The description of the dataset.
-      language_pair: pair of languages that will be used for translation. Should
-                 contain 2 letter coded strings. For example: ("en", "de").
-        configuration for the `nlp.features.text.TextEncoder` used for the
-        `nlp.features.text.Translation` features.
-      subsets: Dict[split, list[str]]. List of the subset to use for each of the
-        split. Note that WMT subclasses overwrite this parameter.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          url: The reference URL for the dataset.
+          citation: The paper citation for the dataset.
+          description: The description of the dataset.
+          language_pair: pair of languages that will be used for translation. Should
+                     contain 2 letter coded strings. For example: ("en", "de").
+            configuration for the `nlp.features.text.TextEncoder` used for the
+            `nlp.features.text.Translation` features.
+          subsets: Dict[split, list[str]]. List of the subset to use for each of the
+            split. Note that WMT subclasses overwrite this parameter.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s-%s" % (language_pair[0], language_pair[1])
         if "name" in kwargs:  # Add name suffix for custom configs
             name += "." + kwargs.pop("name")

--- a/datasets/wmt_t2t/wmt_utils.py
+++ b/datasets/wmt_t2t/wmt_utils.py
@@ -65,28 +65,28 @@ class SubDataset(object):
     def __init__(self, name, target, sources, url, path, manual_dl_files=None):
         """Sub-dataset of WMT.
 
-    Args:
-      name: `string`, a unique dataset identifier.
-      target: `string`, the target language code.
-      sources: `set<string>`, the set of source language codes.
-      url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
-        where to download the raw data from. If two strings are provided, the
-        first is used for the source language and the second for the target.
-        Template strings can either contain '{src}' placeholders that will be
-        filled in with the source language code, '{0}' and '{1}' placeholders
-        that will be filled in with the source and target language codes in
-        alphabetical order, or all 3.
-      path: `string` or `(string, string)`, path(s) or path template(s)
-        specifing the path to the raw data relative to the root of the
-        downloaded archive. If two strings are provided, the dataset is assumed
-        to be made up of parallel text files, the first being the source and the
-        second the target. If one string is provided, both languages are assumed
-        to be stored within the same file and the extension is used to determine
-        how to parse it. Template strings should be formatted the same as in
-        `url`.
-      manual_dl_files: `<list>(string)` (optional), the list of files that must
-        be manually downloaded to the data directory.
-    """
+        Args:
+          name: `string`, a unique dataset identifier.
+          target: `string`, the target language code.
+          sources: `set<string>`, the set of source language codes.
+          url: `string` or `(string, string)`, URL(s) or URL template(s) specifying
+            where to download the raw data from. If two strings are provided, the
+            first is used for the source language and the second for the target.
+            Template strings can either contain '{src}' placeholders that will be
+            filled in with the source language code, '{0}' and '{1}' placeholders
+            that will be filled in with the source and target language codes in
+            alphabetical order, or all 3.
+          path: `string` or `(string, string)`, path(s) or path template(s)
+            specifing the path to the raw data relative to the root of the
+            downloaded archive. If two strings are provided, the dataset is assumed
+            to be made up of parallel text files, the first being the source and the
+            second the target. If one string is provided, both languages are assumed
+            to be stored within the same file and the extension is used to determine
+            how to parse it. Template strings should be formatted the same as in
+            `url`.
+          manual_dl_files: `<list>(string)` (optional), the list of files that must
+            be manually downloaded to the data directory.
+        """
         self._paths = (path,) if isinstance(path, six.string_types) else path
         self._urls = (url,) if isinstance(url, six.string_types) else url
         self._manual_dl_files = manual_dl_files if manual_dl_files else []
@@ -633,18 +633,18 @@ class WmtConfig(nlp.BuilderConfig):
     def __init__(self, url=None, citation=None, description=None, language_pair=(None, None), subsets=None, **kwargs):
         """BuilderConfig for WMT.
 
-    Args:
-      url: The reference URL for the dataset.
-      citation: The paper citation for the dataset.
-      description: The description of the dataset.
-      language_pair: pair of languages that will be used for translation. Should
-                 contain 2 letter coded strings. For example: ("en", "de").
-        configuration for the `nlp.features.text.TextEncoder` used for the
-        `nlp.features.text.Translation` features.
-      subsets: Dict[split, list[str]]. List of the subset to use for each of the
-        split. Note that WMT subclasses overwrite this parameter.
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          url: The reference URL for the dataset.
+          citation: The paper citation for the dataset.
+          description: The description of the dataset.
+          language_pair: pair of languages that will be used for translation. Should
+                     contain 2 letter coded strings. For example: ("en", "de").
+            configuration for the `nlp.features.text.TextEncoder` used for the
+            `nlp.features.text.Translation` features.
+          subsets: Dict[split, list[str]]. List of the subset to use for each of the
+            split. Note that WMT subclasses overwrite this parameter.
+          **kwargs: keyword arguments forwarded to super.
+        """
         name = "%s-%s" % (language_pair[0], language_pair[1])
         if "name" in kwargs:  # Add name suffix for custom configs
             name += "." + kwargs.pop("name")

--- a/datasets/wnut_17/wnut_17.py
+++ b/datasets/wnut_17/wnut_17.py
@@ -77,9 +77,9 @@ class WNUT_17Config(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for WNUT 17.
 
-    Args:
-      **kwargs: keyword arguments forwarded to super.
-    """
+        Args:
+          **kwargs: keyword arguments forwarded to super.
+        """
         super(WNUT_17Config, self).__init__(**kwargs)
 
 
@@ -142,7 +142,11 @@ class WNUT_17(nlp.GeneratorBasedBuilder):
                     assert len(current_tokens) == len(current_labels), "💔 between len of tokens & labels"
                     sentence = (
                         sentence_counter,
-                        {"id": str(sentence_counter), "tokens": current_tokens, "labels": current_labels,},
+                        {
+                            "id": str(sentence_counter),
+                            "tokens": current_tokens,
+                            "labels": current_labels,
+                        },
                     )
                     sentence_counter += 1
                     current_tokens = []

--- a/datasets/wnut_17/wnut_17.py
+++ b/datasets/wnut_17/wnut_17.py
@@ -18,11 +18,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import csv
-import glob
 import logging
-import os
-from pathlib import Path
 
 import nlp
 

--- a/datasets/xcopa/xcopa.py
+++ b/datasets/xcopa/xcopa.py
@@ -61,7 +61,13 @@ class Xcopa(nlp.GeneratorBasedBuilder):
 
     # TODO(xcopa): Set up version.
     VERSION = nlp.Version("0.1.0")
-    BUILDER_CONFIGS = [XcopaConfig(name=lang, description="Xcopa language {}".format(lang),) for lang in _LANG]
+    BUILDER_CONFIGS = [
+        XcopaConfig(
+            name=lang,
+            description="Xcopa language {}".format(lang),
+        )
+        for lang in _LANG
+    ]
 
     def _info(self):
         # TODO(xcopa): Specifies the nlp.DatasetInfo object

--- a/datasets/xcopa/xcopa.py
+++ b/datasets/xcopa/xcopa.py
@@ -30,9 +30,9 @@ _CITATION = """\
 # TODO(xcopa):
 _DESCRIPTION = """\
   XCOPA: A Multilingual Dataset for Causal Commonsense Reasoning
-The Cross-lingual Choice of Plausible Alternatives dataset is a benchmark to evaluate the ability of machine learning models to transfer commonsense reasoning across 
-languages. The dataset is the translation and reannotation of the English COPA (Roemmele et al. 2011) and covers 11 languages from 11 families and several areas around 
-the globe. The dataset is challenging as it requires both the command of world knowledge and the ability to generalise to new languages. All the details about the 
+The Cross-lingual Choice of Plausible Alternatives dataset is a benchmark to evaluate the ability of machine learning models to transfer commonsense reasoning across
+languages. The dataset is the translation and reannotation of the English COPA (Roemmele et al. 2011) and covers 11 languages from 11 families and several areas around
+the globe. The dataset is challenging as it requires both the command of world knowledge and the ability to generalise to new languages. All the details about the
 creation of XCOPA and the implementation of the baselines are available in the paper.\n
 """
 

--- a/datasets/xnli/xnli.py
+++ b/datasets/xnli/xnli.py
@@ -73,8 +73,12 @@ class Xnli(nlp.GeneratorBasedBuilder):
             description=_DESCRIPTION,
             features=nlp.Features(
                 {
-                    "premise": nlp.features.Translation(languages=_LANGUAGES,),
-                    "hypothesis": nlp.features.TranslationVariableLanguages(languages=_LANGUAGES,),
+                    "premise": nlp.features.Translation(
+                        languages=_LANGUAGES,
+                    ),
+                    "hypothesis": nlp.features.TranslationVariableLanguages(
+                        languages=_LANGUAGES,
+                    ),
                     "label": nlp.features.ClassLabel(names=["entailment", "neutral", "contradiction"]),
                 }
             ),

--- a/datasets/xquad/xquad.py
+++ b/datasets/xquad/xquad.py
@@ -69,7 +69,10 @@ class Xquad(nlp.GeneratorBasedBuilder):
                     "context": nlp.Value("string"),
                     "question": nlp.Value("string"),
                     "answers": nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
+                        {
+                            "text": nlp.Value("string"),
+                            "answer_start": nlp.Value("int32"),
+                        }
                     ),
                     # These are the features of your dataset like images, labels ...
                 }
@@ -120,5 +123,8 @@ class Xquad(nlp.GeneratorBasedBuilder):
                             "context": context,
                             "question": question,
                             "id": id_,
-                            "answers": {"answer_start": answer_starts, "text": answers,},
+                            "answers": {
+                                "answer_start": answer_starts,
+                                "text": answers,
+                            },
                         }

--- a/datasets/xsum/xsum.py
+++ b/datasets/xsum/xsum.py
@@ -61,7 +61,12 @@ class Xsum(nlp.GeneratorBasedBuilder):
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({_DOCUMENT: nlp.Value("string"), _SUMMARY: nlp.Value("string"),}),
+            features=nlp.Features(
+                {
+                    _DOCUMENT: nlp.Value("string"),
+                    _SUMMARY: nlp.Value("string"),
+                }
+            ),
             supervised_keys=(_DOCUMENT, _SUMMARY),
             homepage="https://github.com/EdinburghNLP/XSum/tree/master/XSum-Dataset",
             citation=_CITATION,

--- a/datasets/xsum/xsum.py
+++ b/datasets/xsum/xsum.py
@@ -18,8 +18,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import json
-import logging
 import os
 
 import nlp

--- a/datasets/yelp_polarity/yelp_polarity.py
+++ b/datasets/yelp_polarity/yelp_polarity.py
@@ -95,10 +95,10 @@ class YelpPolarityReviewsConfig(nlp.BuilderConfig):
     def __init__(self, **kwargs):
         """BuilderConfig for YelpPolarityReviews.
 
-    Args:
+        Args:
 
-        **kwargs: keyword arguments forwarded to super.
-    """
+            **kwargs: keyword arguments forwarded to super.
+        """
         super(YelpPolarityReviewsConfig, self).__init__(
             version=nlp.Version("1.0.0", "New split API (https://tensorflow.org/datasets/splits)"), **kwargs
         )
@@ -107,12 +107,22 @@ class YelpPolarityReviewsConfig(nlp.BuilderConfig):
 class YelpPolarity(nlp.GeneratorBasedBuilder):
     """Yelp Polarity reviews dataset."""
 
-    BUILDER_CONFIGS = [YelpPolarityReviewsConfig(name="plain_text", description="Plain text",)]
+    BUILDER_CONFIGS = [
+        YelpPolarityReviewsConfig(
+            name="plain_text",
+            description="Plain text",
+        )
+    ]
 
     def _info(self):
         return nlp.DatasetInfo(
             description=_DESCRIPTION,
-            features=nlp.Features({"text": nlp.Value("string"), "label": nlp.features.ClassLabel(names=["1", "2"]),}),
+            features=nlp.Features(
+                {
+                    "text": nlp.Value("string"),
+                    "label": nlp.features.ClassLabel(names=["1", "2"]),
+                }
+            ),
             supervised_keys=None,
             homepage="https://course.fast.ai/datasets",
             citation=_CITATION,

--- a/docs/source/share_dataset.rst
+++ b/docs/source/share_dataset.rst
@@ -63,13 +63,6 @@ To add a "canonical" dataset to the library, you need to go through the followin
    it with ``pip uninstall nlp`` before reinstalling it in editable
    mode with the ``-e`` flag.
 
-   Right now, we need an unreleased version of ``isort`` to avoid a
-   `bug <https://github.com/timothycrosley/isort/pull/1000>`__:
-
-.. code-block::
-
-   pip install -U git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort
-
 **5. Create a new folder with your dataset name** inside the `datasets folder <https://github.com/huggingface/nlp/tree/master/datasets>`__ of the repository and add the dataset script you wrote and tested while following the instructions on the :doc:`add_dataset` page. 
 
 **6. Format your code.** Run black and isort so that your newly added files look nice with the following command:

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 """ BERTScore metric. """
 
-import nlp
 import bert_score
+
+import nlp
+
 
 _CITATION = """\
 @inproceedings{bert-score,
@@ -29,7 +31,7 @@ _CITATION = """\
 
 _DESCRIPTION = """\
 BERTScore leverages the pre-trained contextual embeddings from BERT and matches words in candidate and reference sentences by cosine similarity.
-It has been shown to correlate with human judgment on sentence-level and system-level evaluation. 
+It has been shown to correlate with human judgment on sentence-level and system-level evaluation.
 Moreover, BERTScore computes precision, recall, and F1 measure, which can be useful for evaluating different language generation tasks.
 
 See the [README.md] file at https://github.com/Tiiiger/bert_score for more information.
@@ -71,19 +73,20 @@ class BERTScore(nlp.Metric):
             citation=_CITATION,
             homepage="https://github.com/Tiiiger/bert_score",
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Value('string', id='sequence'),
-                'references': nlp.Sequence(nlp.Value('string', id='sequence'), id='references'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Value("string", id="sequence"),
+                    "references": nlp.Sequence(nlp.Value("string", id="sequence"), id="references"),
+                }
+            ),
             codebase_urls=["https://github.com/Tiiiger/bert_score"],
-            reference_urls=["https://github.com/Tiiiger/bert_score",
-                            "https://arxiv.org/abs/1904.09675"]
+            reference_urls=["https://github.com/Tiiiger/bert_score", "https://arxiv.org/abs/1904.09675"],
         )
 
     def _compute(
         self,
         predictions,
-        references, 
+        references,
         lang=None,
         model_type=None,
         num_layers=None,
@@ -103,7 +106,7 @@ class BERTScore(nlp.Metric):
             num_layers = bert_score.utils.model2layers[model_type]
 
         hashcode = bert_score.utils.get_hash(model_type, num_layers, idf, rescale_with_baseline)
-        if not hasattr(self, 'cached_bertscorer') or self.cached_bertscorer.hash != hashcode:
+        if not hasattr(self, "cached_bertscorer") or self.cached_bertscorer.hash != hashcode:
             self.cached_bertscorer = bert_score.BERTScorer(
                 model_type=model_type,
                 num_layers=num_layers,
@@ -117,19 +120,21 @@ class BERTScore(nlp.Metric):
             )
 
         (P, R, F) = self.cached_bertscorer.score(
-            cands=predictions, refs=references, verbose=verbose, batch_size=batch_size,
+            cands=predictions,
+            refs=references,
+            verbose=verbose,
+            batch_size=batch_size,
         )
         output_dict = {
-            'precision': P,
-            'recall': R,
-            'f1': F,
-            'hashcode': hashcode,
+            "precision": P,
+            "recall": R,
+            "f1": F,
+            "hashcode": hashcode,
         }
         return output_dict
 
     def add_batch(self, predictions=None, references=None, **kwargs):
-        """ Add a batch of predictions and references for the metric's stack.
-        """
+        """Add a batch of predictions and references for the metric's stack."""
         # Refefences can be strings or lists of strings
         # Let's change strings to lists of strings with one element
         if references is not None:
@@ -137,8 +142,7 @@ class BERTScore(nlp.Metric):
         super().add_batch(predictions=predictions, references=references, **kwargs)
 
     def add(self, prediction=None, reference=None, **kwargs):
-        """ Add one prediction and reference for the metric's stack.
-        """
+        """Add one prediction and reference for the metric's stack."""
         # Refefences can be strings or lists of strings
         # Let's change strings to lists of strings with one element
         if isinstance(reference, str):

--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -15,7 +15,9 @@
 """ BLEU metric. """
 
 import nlp
+
 from .nmt_bleu import compute_bleu  # From: https://github.com/tensorflow/nmt/blob/master/nmt/scripts/bleu.py
+
 
 _CITATION = """\
 @INPROCEEDINGS{Papineni02bleu:a,
@@ -73,27 +75,38 @@ Returns:
     'reference_length': reference_length
 """
 
+
 class Bleu(nlp.Metric):
     def _info(self):
         return nlp.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Sequence(nlp.Value('string', id='token'), id='sequence'),
-                'references': nlp.Sequence(nlp.Sequence(nlp.Value('string', id='token'), id='sequence'), id='references'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Sequence(nlp.Value("string", id="token"), id="sequence"),
+                    "references": nlp.Sequence(
+                        nlp.Sequence(nlp.Value("string", id="token"), id="sequence"), id="references"
+                    ),
+                }
+            ),
             codebase_urls=["https://github.com/tensorflow/nmt/blob/master/nmt/scripts/bleu.py"],
-            reference_urls=["https://en.wikipedia.org/wiki/BLEU",
-                            "https://towardsdatascience.com/evaluating-text-output-in-nlp-bleu-at-your-own-risk-e8609665a213"]
+            reference_urls=[
+                "https://en.wikipedia.org/wiki/BLEU",
+                "https://towardsdatascience.com/evaluating-text-output-in-nlp-bleu-at-your-own-risk-e8609665a213",
+            ],
         )
 
     def _compute(self, predictions, references, max_order=4, smooth=False):
-        score = compute_bleu(reference_corpus=references, translation_corpus=predictions, max_order=max_order, smooth=smooth)
+        score = compute_bleu(
+            reference_corpus=references, translation_corpus=predictions, max_order=max_order, smooth=smooth
+        )
         (bleu, precisions, bp, ratio, translation_length, reference_length) = score
-        return {'bleu': bleu,
-                'precisions': precisions,
-                'brevity_penalty': bp,
-                'length_ratio': ratio,
-                'translation_length': translation_length,
-                'reference_length': reference_length}
+        return {
+            "bleu": bleu,
+            "precisions": precisions,
+            "brevity_penalty": bp,
+            "length_ratio": ratio,
+            "translation_length": translation_length,
+            "reference_length": reference_length,
+        }

--- a/metrics/gleu/gleu.py
+++ b/metrics/gleu/gleu.py
@@ -15,11 +15,14 @@
 """ GLEU metric. """
 
 import random
-import nlp
-import scipy.stats
+
 import numpy as np
+import scipy.stats
+
+import nlp
 
 from .gec_gleu import GLEU  # From: https://github.com/cnap/gec-ranking/blob/master/scripts/gleu.py
+
 
 _CITATION = """\
 @InProceedings{napoles-EtAl:2015:ACL-IJCNLP,
@@ -69,13 +72,13 @@ Returns:
     'reference_length': reference_length
 """
 
-def get_gleu_stats(scores) :
+
+def get_gleu_stats(scores):
     mean = np.mean(scores)
     std = np.std(scores)
-    ci = scipy.stats.norm.interval(0.95,loc=mean,scale=std)
-    return {'mean': mean,
-            'std': std,
-            'ci': ci}
+    ci = scipy.stats.norm.interval(0.95, loc=mean, scale=std)
+    return {"mean": mean, "std": std, "ci": ci}
+
 
 class Gleu(nlp.Metric):
     def __init__(self, **kwargs):
@@ -86,12 +89,16 @@ class Gleu(nlp.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Sequence(nlp.Value('string', id='token'), id='sequence'),
-                'references': nlp.Sequence(nlp.Sequence(nlp.Value('string', id='token'), id='sequence'), id='references'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Sequence(nlp.Value("string", id="token"), id="sequence"),
+                    "references": nlp.Sequence(
+                        nlp.Sequence(nlp.Value("string", id="token"), id="sequence"), id="references"
+                    ),
+                }
+            ),
             codebase_urls=["https://github.com/cnap/gec-ranking"],
-            reference_urls=["https://github.com/cnap/gec-ranking"]
+            reference_urls=["https://github.com/cnap/gec-ranking"],
         )
 
     def _compute(self, predictions, references, source, num_iterations=500, debug=False):
@@ -104,54 +111,46 @@ class Gleu(nlp.Metric):
         # first generate a random list of indices, using a different seed
         # for each iteration
         indices = []
-        for j in range(num_iterations) :
-            random.seed(j*101)
-            indices.append([random.randint(0,len(references)-1)
-                            for i in range(len(predictions))])
+        for j in range(num_iterations):
+            random.seed(j * 101)
+            indices.append([random.randint(0, len(references) - 1) for i in range(len(predictions))])
 
-        if debug :
-            print('===== Sentence-level scores =====')
-            print('SID Mean Stdev 95%CI GLEU')
+        if debug:
+            print("===== Sentence-level scores =====")
+            print("SID Mean Stdev 95%CI GLEU")
 
-        iter_stats = [ [0 for i in range(2*4+2)]
-                        for j in range(num_iterations) ]
+        iter_stats = [[0 for i in range(2 * 4 + 2)] for j in range(num_iterations)]
 
-        for i,h in enumerate(predictions) :
+        for i, h in enumerate(predictions):
 
             gleu_calculator.load_hypothesis_sentence(h)
             # we are going to store the score of this sentence for each ref
             # so we don't have to recalculate them 500 times
 
-            stats_by_ref = [ None for r in range(len(references)) ]
+            stats_by_ref = [None for r in range(len(references))]
 
-            for j in range(num_iterations) :
+            for j in range(num_iterations):
                 ref = indices[j][i]
                 this_stats = stats_by_ref[ref]
 
-                if this_stats is None :
-                    this_stats = [ s for s in gleu_calculator.gleu_stats(
-                        i,r_ind=ref) ]
+                if this_stats is None:
+                    this_stats = [s for s in gleu_calculator.gleu_stats(i, r_ind=ref)]
                     stats_by_ref[ref] = this_stats
 
-                iter_stats[j] = [ sum(scores)
-                                    for scores in zip(iter_stats[j], this_stats)]
+                iter_stats[j] = [sum(scores) for scores in zip(iter_stats[j], this_stats)]
 
-            if debug :
+            if debug:
                 # sentence-level GLEU is the mean GLEU of the hypothesis
                 # compared to each reference
-                for r in range(len(references)) :
-                    if stats_by_ref[r] is None :
-                        stats_by_ref[r] = [s for s in gleu_calculator.gleu_stats(
-                            i,r_ind=r) ]
+                for r in range(len(references)):
+                    if stats_by_ref[r] is None:
+                        stats_by_ref[r] = [s for s in gleu_calculator.gleu_stats(i, r_ind=r)]
 
                 print(i)
-                print(' '.join(get_gleu_stats([gleu_calculator.gleu(stats,smooth=True)
-                                                for stats in stats_by_ref])))
+                print(" ".join(get_gleu_stats([gleu_calculator.gleu(stats, smooth=True) for stats in stats_by_ref])))
 
-        if debug :
-            print('\n==== Overall score =====')
-            print('Mean Stdev 95%CI GLEU')
-            print(' '.join(get_gleu_stats([gleu_calculator.gleu(stats)
-                                            for stats in iter_stats ])))
-        return get_gleu_stats([gleu_calculator.gleu(stats)
-                                    for stats in iter_stats ])[0]
+        if debug:
+            print("\n==== Overall score =====")
+            print("Mean Stdev 95%CI GLEU")
+            print(" ".join(get_gleu_stats([gleu_calculator.gleu(stats) for stats in iter_stats])))
+        return get_gleu_stats([gleu_calculator.gleu(stats) for stats in iter_stats])[0]

--- a/metrics/glue/glue.py
+++ b/metrics/glue/glue.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 """ GLUE benchmark metric. """
 
-import nlp
 from scipy.stats import pearsonr, spearmanr
-from sklearn.metrics import matthews_corrcoef, f1_score
+from sklearn.metrics import f1_score, matthews_corrcoef
+
+import nlp
+
 
 _CITATION = """\
 @inproceedings{wang2019glue,
@@ -48,8 +50,10 @@ Returns: depending on the GLUE subset, one or several of:
     "matthews_correlation": Matthew Correlation
 """
 
+
 def simple_accuracy(preds, labels):
     return (preds == labels).mean()
+
 
 def acc_and_f1(preds, labels):
     acc = simple_accuracy(preds, labels)
@@ -58,6 +62,7 @@ def acc_and_f1(preds, labels):
         "accuracy": acc,
         "f1": f1,
     }
+
 
 def pearson_and_spearman(preds, labels):
     pearson_corr = pearsonr(preds, labels)[0]
@@ -70,22 +75,38 @@ def pearson_and_spearman(preds, labels):
 
 class Glue(nlp.Metric):
     def _info(self):
-        if self.config_name not in ["sst2", "mnli", "mnli_mismatched", "mnli_matched",
-                "cola", "stsb", "mrpc", "qqp", "qnli", "rte", "wnli", "hans"]:
-            raise KeyError('You should supply a configuration name selected in '
-                           '["sst2", "mnli", "mnli_mismatched", "mnli_matched", '
-                           '"cola", "stsb", "mrpc", "qqp", "qnli", "rte", "wnli", "hans"]')
+        if self.config_name not in [
+            "sst2",
+            "mnli",
+            "mnli_mismatched",
+            "mnli_matched",
+            "cola",
+            "stsb",
+            "mrpc",
+            "qqp",
+            "qnli",
+            "rte",
+            "wnli",
+            "hans",
+        ]:
+            raise KeyError(
+                "You should supply a configuration name selected in "
+                '["sst2", "mnli", "mnli_mismatched", "mnli_matched", '
+                '"cola", "stsb", "mrpc", "qqp", "qnli", "rte", "wnli", "hans"]'
+            )
         return nlp.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Value('int64' if self.config_name != 'stsb' else 'float32'),
-                'references': nlp.Value('int64' if self.config_name != 'stsb' else 'float32'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Value("int64" if self.config_name != "stsb" else "float32"),
+                    "references": nlp.Value("int64" if self.config_name != "stsb" else "float32"),
+                }
+            ),
             codebase_urls=[],
             reference_urls=[],
-            format='numpy'
+            format="numpy",
         )
 
     def _compute(self, predictions, references):
@@ -98,6 +119,8 @@ class Glue(nlp.Metric):
         elif self.config_name in ["sst2", "mnli", "mnli_mismatched", "mnli_matched", "qnli", "rte", "wnli", "hans"]:
             return {"accuracy": simple_accuracy(predictions, references)}
         else:
-            raise KeyError('You should supply a configuration name selected in '
-                           '["sst2", "mnli", "mnli_mismatched", "mnli_matched", '
-                           '"cola", "stsb", "mrpc", "qqp", "qnli", "rte", "wnli", "hans"]')
+            raise KeyError(
+                "You should supply a configuration name selected in "
+                '["sst2", "mnli", "mnli_mismatched", "mnli_matched", '
+                '"cola", "stsb", "mrpc", "qqp", "qnli", "rte", "wnli", "hans"]'
+            )

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 """ METEOR metric. """
 
+import numpy as np
+from nltk.translate import meteor_score
+
 import nlp
 
-import numpy as np
-
-from nltk.translate import meteor_score
 
 _CITATION = """\
 @inproceedings{banarjee2005,
@@ -45,12 +45,12 @@ between the two strings have been found, METEOR computes a score for
 this matching using a combination of unigram-precision, unigram-recall, and
 a measure of fragmentation that is designed to directly capture how
 well-ordered the matched words in the machine translation are in relation
-to the reference.  
+to the reference.
 
 METEOR gets an R correlation value of 0.347 with human evaluation on the Arabic
 data and 0.331 on the Chinese data. This is shown to be an improvement on
 using simply unigram-precision, unigram-recall and their harmonic F1
-combination. 
+combination.
 """
 
 _KWARGS_DESCRIPTION = """
@@ -74,18 +74,20 @@ class Meteor(nlp.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Value('string', id='sequence'),
-                'references': nlp.Value('string', id='sequence')
-            }),
-            codebase_urls=[
-                "https://github.com/nltk/nltk/blob/develop/nltk/translate/meteor_score.py"],
-            reference_urls=["https://www.nltk.org/api/nltk.translate.html#module-nltk.translate.meteor_score",
-                            "https://en.wikipedia.org/wiki/METEOR"]
+            features=nlp.Features(
+                {"predictions": nlp.Value("string", id="sequence"), "references": nlp.Value("string", id="sequence")}
+            ),
+            codebase_urls=["https://github.com/nltk/nltk/blob/develop/nltk/translate/meteor_score.py"],
+            reference_urls=[
+                "https://www.nltk.org/api/nltk.translate.html#module-nltk.translate.meteor_score",
+                "https://en.wikipedia.org/wiki/METEOR",
+            ],
         )
 
     def _compute(self, predictions, references, alpha=0.9, beta=3, gamma=0.5):
-        scores = [meteor_score.single_meteor_score(ref, pred, alpha=alpha, beta=beta, gamma=gamma)
-                  for ref, pred in zip(references, predictions)]
+        scores = [
+            meteor_score.single_meteor_score(ref, pred, alpha=alpha, beta=beta, gamma=gamma)
+            for ref, pred in zip(references, predictions)
+        ]
 
         return {"meteor": np.mean(scores)}

--- a/metrics/rouge/rouge.py
+++ b/metrics/rouge/rouge.py
@@ -14,16 +14,15 @@
 # limitations under the License.
 """ ROUGE metric from Google Research github repo. """
 
-import nlp
-
 # The dependencies in https://github.com/google-research/google-research/blob/master/rouge/requirements.txt
 import absl  # Here to have a nice missing dependency error message early on
 import nltk  # Here to have a nice missing dependency error message early on
 import numpy  # Here to have a nice missing dependency error message early on
 import six  # Here to have a nice missing dependency error message early on
+from rouge_score import rouge_scorer, scoring
 
-from rouge_score import rouge_scorer
-from rouge_score import scoring
+import nlp
+
 
 _CITATION = """\
 @inproceedings{lin-2004-rouge,
@@ -62,24 +61,29 @@ Returns:
     rougeLsum: rouge_l precision
 """
 
+
 class Rouge(nlp.Metric):
     def _info(self):
         return nlp.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Value('string', id='sequence'),
-                'references': nlp.Value('string', id='sequence'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Value("string", id="sequence"),
+                    "references": nlp.Value("string", id="sequence"),
+                }
+            ),
             codebase_urls=["https://github.com/google-research/google-research/tree/master/rouge"],
-            reference_urls=["https://en.wikipedia.org/wiki/ROUGE_(metric)",
-                            "https://github.com/google-research/google-research/tree/master/rouge"]
+            reference_urls=[
+                "https://en.wikipedia.org/wiki/ROUGE_(metric)",
+                "https://github.com/google-research/google-research/tree/master/rouge",
+            ],
         )
 
     def _compute(self, predictions, references, rouge_types=None, use_agregator=True, use_stemmer=False):
         if rouge_types is None:
-            rouge_types = ['rouge1', 'rougeL']
+            rouge_types = ["rouge1", "rougeL"]
 
         scorer = rouge_scorer.RougeScorer(rouge_types=rouge_types, use_stemmer=use_stemmer)
         if use_agregator:

--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 """ SACREBLEU metric. """
 
-import nlp
 import sacrebleu as scb
+
+import nlp
+
 
 _CITATION = """\
 @inproceedings{post-2018-call,
@@ -61,6 +63,7 @@ Returns:
     'ref_len': reference length,
 """
 
+
 class Sacrebleu(nlp.Metric):
     def _info(self):
         return nlp.MetricInfo(
@@ -68,29 +71,35 @@ class Sacrebleu(nlp.Metric):
             citation=_CITATION,
             homepage="https://github.com/mjpost/sacreBLEU",
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Value('string', id='sequence'),
-                'references': nlp.Sequence(nlp.Value('string', id='sequence'), id='references'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Value("string", id="sequence"),
+                    "references": nlp.Sequence(nlp.Value("string", id="sequence"), id="references"),
+                }
+            ),
             codebase_urls=["https://github.com/mjpost/sacreBLEU"],
-            reference_urls=["https://github.com/mjpost/sacreBLEU",
-                            "https://en.wikipedia.org/wiki/BLEU",
-                            "https://towardsdatascience.com/evaluating-text-output-in-nlp-bleu-at-your-own-risk-e8609665a213"]
+            reference_urls=[
+                "https://github.com/mjpost/sacreBLEU",
+                "https://en.wikipedia.org/wiki/BLEU",
+                "https://towardsdatascience.com/evaluating-text-output-in-nlp-bleu-at-your-own-risk-e8609665a213",
+            ],
         )
 
-    def _compute(self, predictions, references, smooth_method='exp',
-                smooth_value=None,
-                force=False,
-                lowercase=False,
-                tokenize=scb.DEFAULT_TOKENIZER,
-                use_effective_order=False):
+    def _compute(
+        self,
+        predictions,
+        references,
+        smooth_method="exp",
+        smooth_value=None,
+        force=False,
+        lowercase=False,
+        tokenize=scb.DEFAULT_TOKENIZER,
+        use_effective_order=False,
+    ):
         references_per_prediction = len(references[0])
         if any(len(refs) != references_per_prediction for refs in references):
-            raise ValueError('Sacrebleu requires the same number of references for each prediction')
-        transformed_references = [
-            [refs[i] for refs in references]
-            for i in range(references_per_prediction)
-        ]
+            raise ValueError("Sacrebleu requires the same number of references for each prediction")
+        transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
         output = scb.corpus_bleu(
             sys_stream=predictions,
             ref_streams=transformed_references,
@@ -99,14 +108,15 @@ class Sacrebleu(nlp.Metric):
             force=force,
             lowercase=lowercase,
             tokenize=tokenize,
-            use_effective_order=use_effective_order)
+            use_effective_order=use_effective_order,
+        )
         output_dict = {
-            'score': output.score,
-            'counts': output.counts,
-            'totals': output.totals,
-            'precisions': output.precisions,
-            'bp': output.bp,
-            'sys_len': output.sys_len,
-            'ref_len': output.ref_len,
+            "score": output.score,
+            "counts": output.counts,
+            "totals": output.totals,
+            "precisions": output.precisions,
+            "bp": output.bp,
+            "sys_len": output.sys_len,
+            "ref_len": output.ref_len,
         }
         return output_dict

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -16,8 +16,10 @@
 
 from collections import defaultdict
 
+from seqeval.metrics import accuracy_score, f1_score, precision_score, recall_score
+
 import nlp
-from seqeval.metrics import accuracy_score, precision_score, recall_score, f1_score
+
 
 _CITATION = """\
 """
@@ -59,6 +61,7 @@ Returns:
         'f1': F1 score, also known as balanced F-score or F-measure,
 """
 
+
 def end_of_chunk(prev_tag, tag, prev_type, type_):
     """Checks if a chunk ended between the previous and current word.
     Args:
@@ -74,7 +77,7 @@ def end_of_chunk(prev_tag, tag, prev_type, type_):
     if (prev_tag in ["B", "I"] and tag in ["B", "S", "O"]) or prev_tag in ["E", "S"]:
         chunk_end = True
 
-    if prev_tag not in ['O', '.'] and prev_type != type_:
+    if prev_tag not in ["O", "."] and prev_type != type_:
         chunk_end = True
 
     return chunk_end
@@ -95,10 +98,11 @@ def start_of_chunk(prev_tag, tag, prev_type, type_):
     if (prev_tag in ["E", "S", "O"] and tag in ["E", "I"]) or tag in ["B", "S"]:
         chunk_start = True
 
-    if tag not in ['O', '.'] and prev_type != type_:
+    if tag not in ["O", "."] and prev_type != type_:
         chunk_start = True
 
     return chunk_start
+
 
 def get_entities(seq, suffix=False):
     """Gets entities from sequence.
@@ -108,28 +112,29 @@ def get_entities(seq, suffix=False):
         list: list of (chunk_type, chunk_start, chunk_end).
     """
     if any(isinstance(s, list) for s in seq):
-        seq = [item for sublist in seq for item in sublist + ['O']]
+        seq = [item for sublist in seq for item in sublist + ["O"]]
 
-    prev_tag = 'O'
-    prev_type = ''
+    prev_tag = "O"
+    prev_type = ""
     begin_offset = 0
     chunks = []
-    for i, chunk in enumerate(seq + ['O']):
+    for i, chunk in enumerate(seq + ["O"]):
         if suffix:
             tag = chunk[-1]
-            type_ = chunk[:-1].rsplit('-', maxsplit=1)[0] or '_'
+            type_ = chunk[:-1].rsplit("-", maxsplit=1)[0] or "_"
         else:
             tag = chunk[0]
-            type_ = chunk[1:].split('-', maxsplit=1)[-1] or '_'
+            type_ = chunk[1:].split("-", maxsplit=1)[-1] or "_"
 
         if end_of_chunk(prev_tag, tag, prev_type, type_):
-            chunks.append((prev_type, begin_offset, i-1))
+            chunks.append((prev_type, begin_offset, i - 1))
         if start_of_chunk(prev_tag, tag, prev_type, type_):
             begin_offset = i
         prev_tag = tag
         prev_type = type_
 
     return chunks
+
 
 class Seqeval(nlp.Metric):
     def _info(self):
@@ -138,12 +143,14 @@ class Seqeval(nlp.Metric):
             citation=_CITATION,
             homepage="https://github.com/chakki-works/seqeval",
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Sequence(nlp.Value('string', id='label'), id='sequence'),
-                'references': nlp.Sequence(nlp.Value('string', id='label'), id='sequence'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Sequence(nlp.Value("string", id="label"), id="sequence"),
+                    "references": nlp.Sequence(nlp.Value("string", id="label"), id="sequence"),
+                }
+            ),
             codebase_urls=["https://github.com/chakki-works/seqeval"],
-            reference_urls=["https://github.com/chakki-works/seqeval"]
+            reference_urls=["https://github.com/chakki-works/seqeval"],
         )
 
     def _compute(self, predictions, references, suffix=False):

--- a/metrics/squad/evaluate.py
+++ b/metrics/squad/evaluate.py
@@ -1,24 +1,26 @@
 """ Official evaluation script for v1.1 of the SQuAD dataset. """
 from __future__ import print_function
-from collections import Counter
-import string
-import re
+
 import argparse
 import json
+import re
+import string
 import sys
+from collections import Counter
 
 
 def normalize_answer(s):
     """Lower text and remove punctuation, articles and extra whitespace."""
+
     def remove_articles(text):
-        return re.sub(r'\b(a|an|the)\b', ' ', text)
+        return re.sub(r"\b(a|an|the)\b", " ", text)
 
     def white_space_fix(text):
-        return ' '.join(text.split())
+        return " ".join(text.split())
 
     def remove_punc(text):
         exclude = set(string.punctuation)
-        return ''.join(ch for ch in text if ch not in exclude)
+        return "".join(ch for ch in text if ch not in exclude)
 
     def lower(text):
         return text.lower()
@@ -40,7 +42,7 @@ def f1_score(prediction, ground_truth):
 
 
 def exact_match_score(prediction, ground_truth):
-    return (normalize_answer(prediction) == normalize_answer(ground_truth))
+    return normalize_answer(prediction) == normalize_answer(ground_truth)
 
 
 def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
@@ -54,41 +56,38 @@ def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
 def evaluate(dataset, predictions):
     f1 = exact_match = total = 0
     for article in dataset:
-        for paragraph in article['paragraphs']:
-            for qa in paragraph['qas']:
+        for paragraph in article["paragraphs"]:
+            for qa in paragraph["qas"]:
                 total += 1
-                if qa['id'] not in predictions:
-                    message = 'Unanswered question ' + qa['id'] + \
-                              ' will receive score 0.'
+                if qa["id"] not in predictions:
+                    message = "Unanswered question " + qa["id"] + " will receive score 0."
                     print(message, file=sys.stderr)
                     continue
-                ground_truths = list(map(lambda x: x['text'], qa['answers']))
-                prediction = predictions[qa['id']]
-                exact_match += metric_max_over_ground_truths(
-                    exact_match_score, prediction, ground_truths)
-                f1 += metric_max_over_ground_truths(
-                    f1_score, prediction, ground_truths)
+                ground_truths = list(map(lambda x: x["text"], qa["answers"]))
+                prediction = predictions[qa["id"]]
+                exact_match += metric_max_over_ground_truths(exact_match_score, prediction, ground_truths)
+                f1 += metric_max_over_ground_truths(f1_score, prediction, ground_truths)
 
     exact_match = 100.0 * exact_match / total
     f1 = 100.0 * f1 / total
 
-    return {'exact_match': exact_match, 'f1': f1}
+    return {"exact_match": exact_match, "f1": f1}
 
 
-if __name__ == '__main__':
-    expected_version = '1.1'
-    parser = argparse.ArgumentParser(
-        description='Evaluation for SQuAD ' + expected_version)
-    parser.add_argument('dataset_file', help='Dataset file')
-    parser.add_argument('prediction_file', help='Prediction File')
+if __name__ == "__main__":
+    expected_version = "1.1"
+    parser = argparse.ArgumentParser(description="Evaluation for SQuAD " + expected_version)
+    parser.add_argument("dataset_file", help="Dataset file")
+    parser.add_argument("prediction_file", help="Prediction File")
     args = parser.parse_args()
     with open(args.dataset_file) as dataset_file:
         dataset_json = json.load(dataset_file)
-        if (dataset_json['version'] != expected_version):
-            print('Evaluation expects v-' + expected_version +
-                  ', but got dataset with v-' + dataset_json['version'],
-                  file=sys.stderr)
-        dataset = dataset_json['data']
+        if dataset_json["version"] != expected_version:
+            print(
+                "Evaluation expects v-" + expected_version + ", but got dataset with v-" + dataset_json["version"],
+                file=sys.stderr,
+            )
+        dataset = dataset_json["data"]
     with open(args.prediction_file) as prediction_file:
         predictions = json.load(prediction_file)
     print(json.dumps(evaluate(dataset, predictions)))

--- a/metrics/squad/squad.py
+++ b/metrics/squad/squad.py
@@ -15,7 +15,9 @@
 """ SQuAD metric. """
 
 import nlp
+
 from .evaluate import evaluate
+
 
 _CITATION = """\
 @inproceedings{Rajpurkar2016SQuAD10,
@@ -48,32 +50,47 @@ Returns:
     'f1': The F-score of predicted tokens versus the gold answer
 """
 
+
 class Squad(nlp.Metric):
     def _info(self):
         return nlp.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': {
-                    "id": nlp.Value("string"),
-                    "prediction_text": nlp.Value("string")
-                },
-                'references': {
-                    'id': nlp.Value('string'),
-                    'answers': nlp.features.Sequence(
-                        {"text": nlp.Value("string"), "answer_start": nlp.Value("int32"),}
-                    )
-                },
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": {"id": nlp.Value("string"), "prediction_text": nlp.Value("string")},
+                    "references": {
+                        "id": nlp.Value("string"),
+                        "answers": nlp.features.Sequence(
+                            {
+                                "text": nlp.Value("string"),
+                                "answer_start": nlp.Value("int32"),
+                            }
+                        ),
+                    },
+                }
+            ),
             codebase_urls=["https://rajpurkar.github.io/SQuAD-explorer/"],
-            reference_urls=["https://rajpurkar.github.io/SQuAD-explorer/"]
+            reference_urls=["https://rajpurkar.github.io/SQuAD-explorer/"],
         )
 
     def _compute(self, predictions, references):
         pred_dict = {prediction["id"]: prediction["prediction_text"] for prediction in predictions}
-        dataset = [{'paragraphs': [{'qas': [
-            {"answers": [{"text": answer_text} for answer_text in ref["answers"]["text"]], "id": ref["id"]} for ref in references
-        ]}]}]
+        dataset = [
+            {
+                "paragraphs": [
+                    {
+                        "qas": [
+                            {
+                                "answers": [{"text": answer_text} for answer_text in ref["answers"]["text"]],
+                                "id": ref["id"],
+                            }
+                            for ref in references
+                        ]
+                    }
+                ]
+            }
+        ]
         score = evaluate(dataset=dataset, predictions=pred_dict)
         return score

--- a/metrics/squad_v2/evaluate.py
+++ b/metrics/squad_v2/evaluate.py
@@ -8,11 +8,13 @@ that a question is unanswerable.
 import argparse
 import collections
 import json
-import numpy as np
 import os
 import re
 import string
 import sys
+
+import numpy as np
+
 
 OPTS = None
 

--- a/metrics/squad_v2/squad_v2.py
+++ b/metrics/squad_v2/squad_v2.py
@@ -15,7 +15,9 @@
 """ SQuAD v2 metric. """
 
 import nlp
-from .evaluate import make_qid_to_has_ans, get_raw_scores, apply_no_ans_threshold, make_eval_dict, merge_eval
+
+from .evaluate import apply_no_ans_threshold, get_raw_scores, make_eval_dict, make_qid_to_has_ans, merge_eval
+
 
 _CITATION = """\
 @inproceedings{Rajpurkar2016SQuAD10,

--- a/metrics/xnli/xnli.py
+++ b/metrics/xnli/xnli.py
@@ -16,6 +16,7 @@
 
 import nlp
 
+
 _CITATION = """\
 @InProceedings{conneau2018xnli,
   author = "Conneau, Alexis
@@ -51,8 +52,10 @@ Returns:
     'accuracy': accuracy
 """
 
+
 def simple_accuracy(preds, labels):
     return (preds == labels).mean()
+
 
 class Xnli(nlp.Metric):
     def _info(self):
@@ -60,13 +63,15 @@ class Xnli(nlp.Metric):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=nlp.Features({
-                'predictions': nlp.Value('int64' if self.config_name != 'sts-b' else 'float32'),
-                'references': nlp.Value('int64' if self.config_name != 'sts-b' else 'float32'),
-            }),
+            features=nlp.Features(
+                {
+                    "predictions": nlp.Value("int64" if self.config_name != "sts-b" else "float32"),
+                    "references": nlp.Value("int64" if self.config_name != "sts-b" else "float32"),
+                }
+            ),
             codebase_urls=[],
             reference_urls=[],
-            format='numpy'
+            format="numpy",
         )
 
     def _compute(self, predictions, references):

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,5 +46,7 @@ use_parentheses = True
 ignore = E203, E501, W503
 max-line-length = 119
 exclude =
-    src/nlp/datasets,
+    src/nlp/datasets
     src/nlp/metrics
+per-file-ignores =
+    metrics/*:F401

--- a/setup.py
+++ b/setup.py
@@ -105,8 +105,7 @@ TESTS_REQUIRE = [
 
 QUALITY_REQUIRE = [
     "black",
-    # "isort",
-    "isort @ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort",
+    "isort",
     "flake8==3.7.9",
 ]
 

--- a/src/nlp/arrow_writer.py
+++ b/src/nlp/arrow_writer.py
@@ -370,6 +370,7 @@ class BeamWriter(object):
                 that the filter keeps only the metrics for the considered split, under the namespace `split_name`.
         """
         import apache_beam as beam
+
         from .utils import beam_utils
 
         # Convert to arrow

--- a/src/nlp/builder.py
+++ b/src/nlp/builder.py
@@ -958,6 +958,7 @@ class BeamBasedBuilder(DatasetBuilder):
     def _download_and_prepare(self, dl_manager, verify_infos):
         # Create the Beam pipeline and forward it to _prepare_split
         import apache_beam as beam
+
         import nlp.utils.beam_utils as beam_utils
 
         beam_runner = self._beam_runner

--- a/src/nlp/search.py
+++ b/src/nlp/search.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
 try:
     import elasticsearch as es
-    from elasticsearch import Elasticsearch
     import elasticsearch.helpers
+    from elasticsearch import Elasticsearch
 
     _has_elasticsearch = True
 except ImportError:

--- a/src/nlp/utils/logging.py
+++ b/src/nlp/utils/logging.py
@@ -16,9 +16,6 @@
 
 import logging
 import threading
-from typing import Optional
-
-
 from logging import CRITICAL  # NOQA
 from logging import DEBUG  # NOQA
 from logging import ERROR  # NOQA
@@ -27,6 +24,7 @@ from logging import INFO  # NOQA
 from logging import NOTSET  # NOQA
 from logging import WARN  # NOQA
 from logging import WARNING  # NOQA
+from typing import Optional
 
 
 _lock = threading.Lock()


### PR DESCRIPTION
Move the repo to isort 5.0.0.

Also start testing style/quality on datasets and metrics.

Specific rule: we allow F401 (unused imports) in metrics to be able to add imports to detect early on missing dependencies.
Maybe we could add this in datasets but while cleaning this I've seen many example of really unused imports in dataset so maybe it's better to have it as a line-by-line nova instead of a general rule like in metrics.