### PR TITLE
Set scripts version to master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,15 @@ To create the package for pypi.
 4. Build both the sources and the wheel. Do not change anything in setup.py between
    creating the wheel and the source distribution (obviously).
 
+   First pin the SCRIPTS_VERSION to VERSION in __init__.py (but don't commit this change)
+
    For the wheel, run: "python setup.py bdist_wheel" in the top level directory.
    (this will build a wheel for the python version you use to build it).
 
    For the sources, run: "python setup.py sdist"
    You should now have a /dist directory with both .whl and .tar.gz source versions.
+
+   Then change the SCRIPTS_VERSION back to to "master" in __init__.py (but don't commit this change)
 
 5. Check that everything looks correct by uploading the package to the pypi test server:
 

--- a/src/nlp/__init__.py
+++ b/src/nlp/__init__.py
@@ -55,3 +55,5 @@ if int(pyarrow.__version__.split(".")[1]) < 16 and int(pyarrow.__version__.split
         "To use `nlp`, the module `pyarrow>=0.16.0` is required, and the current version of `pyarrow` doesn't match this condition.\n"
         "If you are running this in a Google Colab, you should probably just restart the runtime to use the right version of `pyarrow`."
     )
+
+SCRIPTS_VERIONS = "master"

--- a/src/nlp/utils/file_utils.py
+++ b/src/nlp/utils/file_utils.py
@@ -201,9 +201,9 @@ def head_hf_s3(identifier: str, filename: str, use_cdn=False, dataset=True) -> r
 
 
 def hf_github_url(path: str, name: str, dataset=True, version: Optional[str] = None) -> str:
-    from .. import __version__
+    from .. import SCRIPTS_VERIONS
 
-    version = version or os.getenv("HF_SCRIPTS_VERSION", __version__)
+    version = version or os.getenv("HF_SCRIPTS_VERSION", SCRIPTS_VERIONS)
     if dataset:
         return REPO_DATASETS_URL.format(version=version, path=path, name=name)
     else:


### PR DESCRIPTION
By default the scripts version is master, so that if the library is installed with 
```
pip install git+http://github.com/huggingface/nlp.git
```
or
```
git clone http://github.com/huggingface/nlp.git
pip install -e ./nlp
```

will use the latest scripts, and not the ones from the previous version.